### PR TITLE
fix(sql-fixture): validate generated set values

### DIFF
--- a/packages/sql-fixture/composer.json
+++ b/packages/sql-fixture/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "brianium/paratest": "^6.11 || ^7",
         "friendsofphp/php-cs-fixer": "^3.92",
-        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
+        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32 || ^0.34.1",
         "k-kinzal/phpstan-custom-rules": "@dev",
         "k-kinzal/sql-faker": "@dev",
         "k-kinzal/testcontainers-php": "^0.5.1",

--- a/packages/sql-fixture/src/Platform/MySql/MySqlTypeMapper.php
+++ b/packages/sql-fixture/src/Platform/MySql/MySqlTypeMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SqlFixture\Platform\MySql;
 
 use Faker\Generator;
+use LogicException;
 use SqlFixture\Schema\ColumnDefinition;
 use SqlFixture\TypeMapper\TypeMapperInterface;
 
@@ -196,7 +197,13 @@ final class MySqlTypeMapper implements TypeMapperInterface
             return null;
         }
         $count = $faker->numberBetween(1, count($values));
-        $selected = $faker->randomElements($values, $count);
+        $selected = [];
+        foreach ($faker->randomElements($values, $count) as $value) {
+            if (!is_string($value)) {
+                throw new LogicException('Faker returned a non-string SET value.');
+            }
+            $selected[] = $value;
+        }
         return implode(',', $selected);
     }
 


### PR DESCRIPTION
This pull request introduces improved error handling in the `MySqlTypeMapper` for generating SET values with Faker. The main change ensures that only string values are processed, and any unexpected non-string values from Faker will now trigger a clear exception.

**Error handling improvements:**

* In `MySqlTypeMapper.php`, the `generateSet` method now checks that all values returned by Faker's `randomElements` are strings, throwing a `LogicException` if a non-string value is encountered. This prevents invalid data from being used and makes debugging easier.
* Added the `LogicException` import to support the new error handling.