### PR TITLE
fix(postgres): guard optional regex captures

### DIFF
--- a/packages/ztd-query-postgres/composer.json
+++ b/packages/ztd-query-postgres/composer.json
@@ -15,7 +15,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5 || ^11 || ^12 || ^13",
         "brianium/paratest": "^6.11 || ^7",
-        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
+        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32 || ^0.34.1",
         "giorgiosironi/eris": "^1.0",
         "k-kinzal/phpstan-custom-rules": "@dev",
         "phpbench/phpbench": "^1.4"

--- a/packages/ztd-query-postgres/composer.json
+++ b/packages/ztd-query-postgres/composer.json
@@ -13,7 +13,7 @@
         "nikic/php-fuzzer": "^0.0.11",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^10.5 || ^11 || ^12 || ^13",
+        "phpunit/phpunit": "^10.5 || ^11 || ^12 || >=13.0 <13.3",
         "brianium/paratest": "^6.11 || ^7",
         "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32 || ^0.34.1",
         "giorgiosironi/eris": "^1.0",

--- a/packages/ztd-query-postgres/fuzz/FullPipelineFuzzTest.php
+++ b/packages/ztd-query-postgres/fuzz/FullPipelineFuzzTest.php
@@ -410,7 +410,8 @@ final class FullPipelineFuzzTest extends TestCase
             return null;
         }
 
-        return $m[3] !== '' ? $m[3] : ($m[4] ?? null);
+        $quotedTable = $m[3] ?? '';
+        return $quotedTable !== '' ? $quotedTable : ($m[4] ?? null);
     }
 
     private function quoteIdentifier(string $name): string

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -229,7 +229,8 @@ final class PgSqlMutationResolver
             if (preg_match('/\bAS\s+"?([a-zA-Z_]\w*)"?\s*$/i', $item, $aliasMatch) === 1) {
                 $columns[] = $aliasMatch[1];
             } elseif (preg_match('/^(?:(?:"[^"]+"|\w+)\.)?("([^"]+)"|([a-zA-Z_]\w*))\s*$/', $item, $colMatch) === 1) {
-                $columns[] = $colMatch[2] !== '' ? $colMatch[2] : $colMatch[3];
+                $quotedColumn = $colMatch[2] ?? '';
+                $columns[] = $quotedColumn !== '' ? $quotedColumn : ($colMatch[3] ?? '');
             } else {
                 $replaced = preg_replace('/[^a-zA-Z0-9_]/', '_', $item);
                 $columns[] = is_string($replaced) ? $replaced : 'col';

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -1301,6 +1301,10 @@ final class PgSqlMutationResolverTest extends TestCase
         $mutation = $resolver->resolve($sql, 'CREATE_TABLE', QueryKind::DDL_SIMULATED);
 
         self::assertInstanceOf(CreateTableAsSelectMutation::class, $mutation);
+        $mutation->apply($shadowStore, []);
+        $definition = $registry->get('archive');
+        self::assertNotNull($definition);
+        self::assertSame(['Id', 'Name'], $definition->columns);
     }
 
     public function testResolveCreateTableAsSelectWithTableQualifiedColumn(): void


### PR DESCRIPTION
This pull request makes small but important improvements to how table and column names are extracted from SQL statements in the codebase. The changes enhance the clarity and safety of handling optional matches from regular expressions.

Improvements to SQL parsing logic:

* In `extractTableName` (`FullPipelineFuzzTest.php`), the logic for extracting a quoted table name now uses a temporary variable for clarity and ensures a safe fallback when the match is not present.
* In `extractSelectColumnNames` (`PgSqlMutationResolver.php`), similar logic is applied to extracting quoted column names, improving readability and handling of optional matches.