### PR TITLE
Publish fuzz crash artifacts and issues

### DIFF
--- a/.github/workflows/sql-faker-fuzz.yml
+++ b/.github/workflows/sql-faker-fuzz.yml
@@ -11,6 +11,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
@@ -60,23 +61,29 @@ jobs:
           path: packages/sql-faker/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-sql-faker-${{ matrix.target.corpus }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/sql-faker/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-sql-faker-${{ matrix.target.name }}
-          path: |
-            packages/sql-faker/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/sql-faker/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/sql-faker/crash-*
 
   notify:
-    name: Notify on failure
+    name: Notify on crash
     runs-on: ubuntu-latest
     needs: [syntax]
-    if: failure()
     steps:
       - uses: actions/github-script@v8
         with:
           script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            if (!data.artifacts.some(({ name }) => name.startsWith('fuzz-crashes-'))) {
+              console.log('No fuzz crash artifacts found');
+              return;
+            }
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/sql-fixture-fuzz.yml
+++ b/.github/workflows/sql-fixture-fuzz.yml
@@ -11,6 +11,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
@@ -59,23 +60,29 @@ jobs:
           path: packages/sql-fixture/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-sql-fixture-${{ matrix.target.corpus }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/sql-fixture/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-sql-fixture-${{ matrix.target.name }}
-          path: |
-            packages/sql-fixture/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/sql-fixture/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/sql-fixture/crash-*
 
   notify:
-    name: Notify on failure
+    name: Notify on crash
     runs-on: ubuntu-latest
     needs: [fuzz]
-    if: failure()
     steps:
       - uses: actions/github-script@v8
         with:
           script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            if (!data.artifacts.some(({ name }) => name.startsWith('fuzz-crashes-'))) {
+              console.log('No fuzz crash artifacts found');
+              return;
+            }
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ztd-query-mysql-fuzz.yml
+++ b/.github/workflows/ztd-query-mysql-fuzz.yml
@@ -11,6 +11,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
@@ -60,23 +61,29 @@ jobs:
           path: packages/ztd-query-mysql/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-ztd-query-mysql-${{ matrix.target.corpus }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-mysql/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-ztd-query-mysql-robustness-${{ matrix.target.name }}
-          path: |
-            packages/ztd-query-mysql/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/ztd-query-mysql/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/ztd-query-mysql/crash-*
 
   notify:
-    name: Notify on failure
+    name: Notify on crash
     runs-on: ubuntu-latest
     needs: [robustness]
-    if: failure()
     steps:
       - uses: actions/github-script@v8
         with:
           script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            if (!data.artifacts.some(({ name }) => name.startsWith('fuzz-crashes-'))) {
+              console.log('No fuzz crash artifacts found');
+              return;
+            }
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ztd-query-mysqli-adapter-fuzz.yml
+++ b/.github/workflows/ztd-query-mysqli-adapter-fuzz.yml
@@ -15,6 +15,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
@@ -63,13 +64,11 @@ jobs:
           path: packages/ztd-query-mysqli-adapter/fuzz/corpus/robustness-execute
           key: fuzz-robustness-execute-mysqli-${{ matrix.mysql }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-mysqli-adapter/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-robustness-execute-mysqli-${{ matrix.mysql }}
-          path: |
-            packages/ztd-query-mysqli-adapter/fuzz/corpus/robustness-execute/crash-*
-            packages/ztd-query-mysqli-adapter/fuzz/corpus/robustness-execute/timeout-*
+          path: packages/ztd-query-mysqli-adapter/crash-*
 
   correctness:
     name: Correctness / ${{ matrix.target.name }}-mysqli (MySQL ${{ matrix.mysql }})
@@ -120,25 +119,31 @@ jobs:
           path: packages/ztd-query-mysqli-adapter/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-${{ matrix.target.corpus }}-mysqli-${{ matrix.mysql }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-mysqli-adapter/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-${{ matrix.target.name }}-mysqli-${{ matrix.mysql }}
-          path: |
-            packages/ztd-query-mysqli-adapter/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/ztd-query-mysqli-adapter/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/ztd-query-mysqli-adapter/crash-*
 
   notify:
-    name: Notify on failure
+    name: Notify on crash
     runs-on: ubuntu-latest
     needs:
       - robustness-execute
       - correctness
-    if: failure()
     steps:
       - uses: actions/github-script@v8
         with:
           script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            if (!data.artifacts.some(({ name }) => name.startsWith('fuzz-crashes-'))) {
+              console.log('No fuzz crash artifacts found');
+              return;
+            }
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ztd-query-pdo-adapter-fuzz.yml
+++ b/.github/workflows/ztd-query-pdo-adapter-fuzz.yml
@@ -15,6 +15,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
@@ -63,13 +64,11 @@ jobs:
           path: packages/ztd-query-pdo-adapter/fuzz/corpus/robustness-execute
           key: fuzz-robustness-execute-pdo-${{ matrix.mysql }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-pdo-adapter/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-robustness-execute-pdo-${{ matrix.mysql }}
-          path: |
-            packages/ztd-query-pdo-adapter/fuzz/corpus/robustness-execute/crash-*
-            packages/ztd-query-pdo-adapter/fuzz/corpus/robustness-execute/timeout-*
+          path: packages/ztd-query-pdo-adapter/crash-*
 
   correctness-mysql:
     name: Correctness / ${{ matrix.target.name }}-pdo (MySQL ${{ matrix.mysql }})
@@ -120,13 +119,11 @@ jobs:
           path: packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-${{ matrix.target.corpus }}-pdo-${{ matrix.mysql }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-pdo-adapter/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-${{ matrix.target.name }}-pdo-${{ matrix.mysql }}
-          path: |
-            packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/ztd-query-pdo-adapter/crash-*
 
   correctness-sqlite:
     name: Correctness / ${{ matrix.target.name }}-pdo-sqlite
@@ -164,6 +161,7 @@ jobs:
 
       - name: fuzzer
         run: |
+          mkdir -p fuzz/corpus/${{ matrix.target.corpus }}
           vendor/bin/php-fuzzer fuzz fuzz/${{ matrix.target.script }} \
             fuzz/corpus/${{ matrix.target.corpus }}/ \
             --max-runs=${{ inputs.max_runs || '10000' }}
@@ -174,13 +172,11 @@ jobs:
           path: packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-${{ matrix.target.corpus }}-pdo-sqlite-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-pdo-adapter/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-${{ matrix.target.name }}-pdo-sqlite
-          path: |
-            packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/ztd-query-pdo-adapter/crash-*
 
   correctness-pg:
     name: Correctness / ${{ matrix.target.name }}-pdo-pg
@@ -218,6 +214,7 @@ jobs:
 
       - name: fuzzer
         run: |
+          mkdir -p fuzz/corpus/${{ matrix.target.corpus }}
           vendor/bin/php-fuzzer fuzz fuzz/${{ matrix.target.script }} \
             fuzz/corpus/${{ matrix.target.corpus }}/ \
             --max-runs=${{ inputs.max_runs || '10000' }}
@@ -228,27 +225,33 @@ jobs:
           path: packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-${{ matrix.target.corpus }}-pdo-pg-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-pdo-adapter/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-${{ matrix.target.name }}-pdo-pg
-          path: |
-            packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/ztd-query-pdo-adapter/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/ztd-query-pdo-adapter/crash-*
 
   notify:
-    name: Notify on failure
+    name: Notify on crash
     runs-on: ubuntu-latest
     needs:
       - robustness-execute
       - correctness-mysql
       - correctness-sqlite
       - correctness-pg
-    if: failure()
     steps:
       - uses: actions/github-script@v8
         with:
           script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            if (!data.artifacts.some(({ name }) => name.startsWith('fuzz-crashes-'))) {
+              console.log('No fuzz crash artifacts found');
+              return;
+            }
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ztd-query-postgres-fuzz.yml
+++ b/.github/workflows/ztd-query-postgres-fuzz.yml
@@ -11,6 +11,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
@@ -60,23 +61,29 @@ jobs:
           path: packages/ztd-query-postgres/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-ztd-query-postgres-${{ matrix.target.corpus }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-postgres/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-ztd-query-postgres-robustness-${{ matrix.target.name }}
-          path: |
-            packages/ztd-query-postgres/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/ztd-query-postgres/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/ztd-query-postgres/crash-*
 
   notify:
-    name: Notify on failure
+    name: Notify on crash
     runs-on: ubuntu-latest
     needs: [robustness]
-    if: failure()
     steps:
       - uses: actions/github-script@v8
         with:
           script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            if (!data.artifacts.some(({ name }) => name.startsWith('fuzz-crashes-'))) {
+              console.log('No fuzz crash artifacts found');
+              return;
+            }
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ztd-query-sqlite-fuzz.yml
+++ b/.github/workflows/ztd-query-sqlite-fuzz.yml
@@ -11,6 +11,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
@@ -60,23 +61,29 @@ jobs:
           path: packages/ztd-query-sqlite/fuzz/corpus/${{ matrix.target.corpus }}
           key: fuzz-ztd-query-sqlite-${{ matrix.target.corpus }}-${{ github.run_id }}
 
-      - if: failure()
+      - if: ${{ always() && hashFiles('packages/ztd-query-sqlite/crash-*') != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes-ztd-query-sqlite-robustness-${{ matrix.target.name }}
-          path: |
-            packages/ztd-query-sqlite/fuzz/corpus/${{ matrix.target.corpus }}/crash-*
-            packages/ztd-query-sqlite/fuzz/corpus/${{ matrix.target.corpus }}/timeout-*
+          path: packages/ztd-query-sqlite/crash-*
 
   notify:
-    name: Notify on failure
+    name: Notify on crash
     runs-on: ubuntu-latest
     needs: [robustness]
-    if: failure()
     steps:
       - uses: actions/github-script@v8
         with:
           script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            if (!data.artifacts.some(({ name }) => name.startsWith('fuzz-crashes-'))) {
+              console.log('No fuzz crash artifacts found');
+              return;
+            }
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

- keep every package on the official `php-fuzzer fuzz` entrypoint
- upload package-root `crash-*` findings as workflow artifacts
- create a Fuzz Issue only when the current run contains a crash artifact
- keep a recorded finding from changing the Fuzz job result
- create the eight PostgreSQL/SQLite PDO correctness corpus directories at workflow runtime, without tracking seed or `.gitkeep` files

## Root cause

`php-fuzzer` records target findings as `crash-*` files in the package working directory and may complete normally after doing so. The workflows looked for `crash-*` and `timeout-*` under the corpus and only uploaded them after a failed step. Their notification jobs also ran only after failure. A normally recorded finding therefore produced neither an artifact nor an Issue.

This PR does not replace the fuzzer entrypoint, parse fuzzer output, or reinterpret its exit code. GitHub Actions uploads a generated `crash-*` file, then the existing notification Action checks the current run artifacts and opens the Issue.

The correctness corpus is still persisted through `actions/cache`. On a cache miss, the workflow creates the empty corpus directory required by `php-fuzzer`; no placeholder input is kept in the repository.

## Validation

- actionlint v1.7.12 on all seven Fuzz workflows
- YAML parsing for the modified PDO Fuzz workflow
- `git diff --check`
- `git range-diff` confirms all fourteen descendant PR patches are unchanged

Closes #1