### PR TITLE
Normalize PostgreSQL parser lookahead terminals

### DIFF
--- a/packages/sql-faker/src/PostgreSql/LexicalGrammar.php
+++ b/packages/sql-faker/src/PostgreSql/LexicalGrammar.php
@@ -210,6 +210,30 @@ final class LexicalGrammar implements LexicalGrammarContract
     }
 
     /**
+     * Applies the lookahead filter used by PostgreSQL's parser frontend.
+     *
+     * @param list<string> $terminals
+     * @return list<string>
+     */
+    public function normalizeLookahead(array $terminals): array
+    {
+        foreach ($terminals as $index => $terminal) {
+            foreach ($this->lookahead as $base => $rule) {
+                if ($terminal !== $base && $terminal !== $rule['token']) {
+                    continue;
+                }
+
+                $terminals[$index] = in_array($terminals[$index + 1] ?? null, $rule['followed_by'], true)
+                    ? $rule['token']
+                    : $base;
+                break;
+            }
+        }
+
+        return $terminals;
+    }
+
+    /**
      * @return array{string|null, list<string>}
      */
     private function realizeTerminal(string $terminal): array

--- a/packages/sql-faker/src/PostgreSql/SqlGenerator.php
+++ b/packages/sql-faker/src/PostgreSql/SqlGenerator.php
@@ -125,7 +125,7 @@ final class SqlGenerator
             }
         }
 
-        return $terminals;
+        return $this->lexicalGrammar->normalizeLookahead($terminals);
     }
 
     /**

--- a/packages/sql-faker/tests/Unit/PostgreSql/LexicalGrammarTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/LexicalGrammarTest.php
@@ -45,6 +45,18 @@ SQL;
         self::assertSame(['WITH', 'RETURNS'], $lexical->tokenize('WITH RETURNS'));
     }
 
+    public function testNormalizesDerivedLookaheadTokensFromTheirFollowers(): void
+    {
+        $lexical = new LexicalGrammar(Factory::create(), 'pg-17.2');
+
+        self::assertSame(
+            ['WITH', 'IDENT', 'WITH_LA', 'TIME', 'FORMAT', 'IDENT', 'FORMAT_LA', 'JSON'],
+            $lexical->normalizeLookahead([
+                'WITH_LA', 'IDENT', 'WITH', 'TIME', 'FORMAT_LA', 'IDENT', 'FORMAT', 'JSON',
+            ]),
+        );
+    }
+
     public function testRealizesLookaheadTokenWithRequiredFollower(): void
     {
         $lexical = new LexicalGrammar(Factory::create(), 'pg-17.2');

--- a/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
@@ -80,6 +80,26 @@ final class SqlGeneratorTest extends TestCase
         self::assertSame('DEFAULT_RULE_USED', $result);
     }
 
+    public function testGenerateNormalizesParserLookaheadTerminals(): void
+    {
+        $grammar = new Grammar('stmt', [
+            'stmt' => new ProductionRule('stmt', [
+                new Production([
+                    new Terminal('WITH_LA'),
+                    new Terminal('IDENT'),
+                    new Terminal('WITH'),
+                    new Terminal('TIME'),
+                ]),
+            ]),
+        ]);
+        $faker = Factory::create();
+        $provider = new PostgreSqlProvider($faker, 'pg-17.2');
+        $generator = new SqlGenerator($grammar, $faker, $provider, 'pg-17.2');
+        $faker->seed(12345);
+
+        self::assertNotEmpty($generator->generate('stmt'));
+    }
+
     public function testGenerateResetsBetweenCalls(): void
     {
         $grammar = new Grammar('stmt', [


### PR DESCRIPTION
## Summary

- normalize PostgreSQL parser lookahead pseudo-terminals from the actual following token
- convert both directions (`WITH_LA` to `WITH`, and `WITH` to `WITH_LA`) from the versioned lexical profile
- add direct algorithm tests and a fixed-version generator regression

## Root cause

PostgreSQL's parser frontend rewrites a small set of tokens such as `WITH` only for specific followers (`TIME`, `ORDINALITY`, and similar cases). The grammar can derive either the base or pseudo-terminal form, but SQL Faker compared that derivation literally with the scanner output. A valid CTE such as `WITH identifier AS (...)` could therefore exhaust all lexical retries because the derivation contained `WITH_LA` while the scanner correctly returned `WITH`.

The normalization is profile-driven rather than statement-regex based.

## Stack

- Depends on #183
- Empty-output Fuzz detection is handled by the next stacked PR, #205.
- The SQL generation algorithm fix follows in #206; operator/comment boundaries remain isolated in #185.

## Validation

- PostgreSQL lexical and generator tests: 56 tests, 67 assertions
- full SQL Faker suite: 1013 tests, 1804 assertions
- PHP-CS-Fixer and PHPStan: clean
- PostgreSQL finite fuzz: lexical exceptions caused by lookahead mismatch no longer occur