### PR TITLE
Respect comments at PostgreSQL operator boundaries

### DIFF
--- a/packages/sql-faker/src/PostgreSql/LexicalGrammar.php
+++ b/packages/sql-faker/src/PostgreSql/LexicalGrammar.php
@@ -476,6 +476,9 @@ final class LexicalGrammar implements LexicalGrammarContract
         if (str_contains(self::OPERATOR_CHARACTERS, $char)) {
             $end = $offset;
             while (isset($sql[$end]) && str_contains(self::OPERATOR_CHARACTERS, $sql[$end])) {
+                if ($end > $offset && in_array(substr($sql, $end, 2), ['/*', '--'], true)) {
+                    break;
+                }
                 $end++;
             }
             $lexeme = substr($sql, $offset, $end - $offset);

--- a/packages/sql-faker/tests/Unit/PostgreSql/LexicalGrammarTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/LexicalGrammarTest.php
@@ -57,6 +57,17 @@ SQL;
         );
     }
 
+    public function testTokenizesCommentsAdjacentToOperators(): void
+    {
+        $lexical = new LexicalGrammar(Factory::create(), 'pg-17.2');
+        $sql = "SELECT a=/* outer /* inner */ outer */b, c/-- line\nd, e///* block */f";
+
+        self::assertSame(
+            ['SELECT', 'IDENT', '=', 'IDENT', ',', 'IDENT', '/', 'IDENT', ',', 'IDENT', 'Op', 'IDENT'],
+            $lexical->tokenize($sql),
+        );
+    }
+
     public function testRealizesLookaheadTokenWithRequiredFollower(): void
     {
         $lexical = new LexicalGrammar(Factory::create(), 'pg-17.2');

--- a/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
@@ -100,6 +100,15 @@ final class SqlGeneratorTest extends TestCase
         self::assertNotEmpty($generator->generate('stmt'));
     }
 
+    public function testFixedSeedWithOperatorAdjacentToCommentGeneratesSql(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(72);
+        $provider = new PostgreSqlProvider($faker, 'pg-17.2');
+
+        self::assertNotEmpty($provider->sql(maxDepth: 50));
+    }
+
     public function testGenerateResetsBetweenCalls(): void
     {
         $grammar = new Grammar('stmt', [


### PR DESCRIPTION
## Summary

- stop PostgreSQL operator scanning at adjacent `/*` and `--` comment openers
- preserve the operator prefix while allowing nested block-comment trivia to be consumed by the trivia scanner
- add direct boundary cases for `=/*...*/`, `/--...`, and `///*...*/`
- pin the Fuzz-discovered failure as SQL Faker seed 72

## Root cause

The tokenizer greedily consumed every PostgreSQL operator character before checking trivia. Because `/`, `*`, and `-` are also operator characters, an operator immediately followed by a comment swallowed the comment opener. The remainder of a nested comment was then tokenized as SQL keywords and operators, causing SQL Faker's lexical round-trip to fail after all retries.

The fix follows lexical boundaries in the scanner and does not use statement-level regular expressions.

## Stack

- Depends on #206 (and transitively #205, #184, and #183)
- Contains only the operator/comment-boundary root problem

## Validation

- fixed seed 72 reproduces before the fix and generates SQL after it
- PostgreSQL lexical/generator tests: 58 tests, 69 assertions
- full SQL Faker suite: 1015 tests, 1806 assertions
- PHP-CS-Fixer and PHPStan: clean
- PostgreSQL finite fuzz: 0 lexical errors; remaining failures are only the separately tracked Risky-test configuration