### PR TITLE
Guarantee bounded SQLite grammar derivation

### DIFF
--- a/packages/sql-faker/src/Grammar/TerminationAnalyzer.php
+++ b/packages/sql-faker/src/Grammar/TerminationAnalyzer.php
@@ -17,6 +17,9 @@ final class TerminationAnalyzer
     /** @var array<string, int> Non-terminal name => minimum tokens to terminate */
     private array $lengths;
 
+    /** @var array<string, int> Non-terminal name => minimum derivation steps to terminate */
+    private array $steps;
+
     /** @var Closure(string): bool */
     private Closure $terminalSupported;
 
@@ -29,6 +32,7 @@ final class TerminationAnalyzer
             ? Closure::fromCallable($terminalSupported)
             : static fn (string $terminal): bool => true;
         $this->lengths = $this->computeMinTerminationLengths($grammar);
+        $this->steps = $this->computeMinTerminationSteps($grammar);
     }
 
     /**
@@ -45,6 +49,14 @@ final class TerminationAnalyzer
     public function estimateProductionLength(Production $production): int
     {
         return $this->sumProductionLength($production->symbols, $this->lengths);
+    }
+
+    /**
+     * Estimate the minimum number of non-terminal expansions required to terminate a production.
+     */
+    public function estimateProductionSteps(Production $production): int
+    {
+        return $this->sumProductionSteps($production->symbols, $this->steps);
     }
 
     public function isProductionViable(Production $production): bool
@@ -91,6 +103,37 @@ final class TerminationAnalyzer
     }
 
     /**
+     * @return array<string, int>
+     */
+    private function computeMinTerminationSteps(Grammar $grammar): array
+    {
+        $steps = array_fill_keys(array_keys($grammar->ruleMap), PHP_INT_MAX);
+
+        $changed = true;
+        while ($changed) {
+            $changed = false;
+
+            foreach ($grammar->ruleMap as $name => $rule) {
+                $best = $steps[$name];
+
+                foreach ($rule->alternatives as $alternative) {
+                    $remaining = $this->sumProductionSteps($alternative->symbols, $steps);
+                    if ($remaining !== PHP_INT_MAX && $remaining < PHP_INT_MAX - 1) {
+                        $best = min($best, $remaining + 1);
+                    }
+                }
+
+                if ($best !== $steps[$name]) {
+                    $steps[$name] = $best;
+                    $changed = true;
+                }
+            }
+        }
+
+        return $steps;
+    }
+
+    /**
      * Sum the minimum token count for a list of symbols given current length estimates.
      * Returns PHP_INT_MAX if any non-terminal has no known finite length.
      *
@@ -120,6 +163,36 @@ final class TerminationAnalyzer
                 $total += $symLen;
             }
         }
+        return $total;
+    }
+
+    /**
+     * @param list<Symbol> $symbols
+     * @param array<string, int> $steps
+     */
+    private function sumProductionSteps(array $symbols, array $steps): int
+    {
+        $total = 0;
+        foreach ($symbols as $symbol) {
+            if ($symbol instanceof Terminal) {
+                if (!(($this->terminalSupported)($symbol->value))) {
+                    return PHP_INT_MAX;
+                }
+                continue;
+            }
+
+            if (!$symbol instanceof NonTerminal) {
+                continue;
+            }
+
+            $symbolSteps = $steps[$symbol->value]
+                ?? (($this->terminalSupported)($symbol->value) ? 1 : PHP_INT_MAX);
+            if ($symbolSteps === PHP_INT_MAX || $total > PHP_INT_MAX - $symbolSteps) {
+                return PHP_INT_MAX;
+            }
+            $total += $symbolSteps;
+        }
+
         return $total;
     }
 }

--- a/packages/sql-faker/src/Sqlite/SqlGenerator.php
+++ b/packages/sql-faker/src/Sqlite/SqlGenerator.php
@@ -136,12 +136,31 @@ final class SqlGenerator
                 throw new LogicException("Grammar rule has no lexically realizable alternative: {$nonTerminal->value}");
             }
 
+            $remainingForm = new Production(array_slice($form, $index + 1));
+            $remainingSteps = $this->terminationAnalyzer->estimateProductionSteps($remainingForm);
+            $remainingBudget = self::DERIVATION_LIMIT - $this->derivationSteps;
+            if ($remainingSteps > $remainingBudget) {
+                throw new LogicException('Exceeded derivation limit while generating SQL.');
+            }
+            $productionBudget = $remainingBudget - $remainingSteps;
+            $alternatives = array_values(array_filter(
+                $alternatives,
+                fn (Production $alternative): bool => $this->terminationAnalyzer
+                    ->estimateProductionSteps($alternative) <= $productionBudget,
+            ));
+            if ($alternatives === []) {
+                throw new LogicException('Exceeded derivation limit while generating SQL.');
+            }
+
             if ($this->derivationSteps >= $this->targetDepth) {
                 $selectedIndex = 0;
+                $bestSteps = PHP_INT_MAX;
                 $bestLength = PHP_INT_MAX;
                 foreach ($alternatives as $i => $alt) {
+                    $steps = $this->terminationAnalyzer->estimateProductionSteps($alt);
                     $length = $this->terminationAnalyzer->estimateProductionLength($alt);
-                    if ($length < $bestLength) {
+                    if ($steps < $bestSteps || ($steps === $bestSteps && $length < $bestLength)) {
+                        $bestSteps = $steps;
                         $bestLength = $length;
                         $selectedIndex = $i;
                     }

--- a/packages/sql-faker/tests/Unit/Grammar/TerminationAnalyzerTest.php
+++ b/packages/sql-faker/tests/Unit/Grammar/TerminationAnalyzerTest.php
@@ -135,6 +135,21 @@ final class TerminationAnalyzerTest extends TestCase
         self::assertSame(0, $analyzer->estimateProductionLength($production));
     }
 
+    public function testEstimateProductionStepsBreaksARecursiveLengthTie(): void
+    {
+        $recursive = new Production([new NonTerminal('value')]);
+        $terminal = new Production([new Terminal('VALUE')]);
+        $grammar = new Grammar('value', [
+            'value' => new ProductionRule('value', [$recursive, $terminal]),
+        ]);
+        $analyzer = new TerminationAnalyzer($grammar);
+
+        self::assertSame(1, $analyzer->estimateProductionLength($recursive));
+        self::assertSame(1, $analyzer->estimateProductionLength($terminal));
+        self::assertSame(1, $analyzer->estimateProductionSteps($recursive));
+        self::assertSame(0, $analyzer->estimateProductionSteps($terminal));
+    }
+
     public function testTreatsUnknownSupportedNonTerminalAsOneToken(): void
     {
         $analyzer = new TerminationAnalyzer(new Grammar('start', []));
@@ -142,6 +157,20 @@ final class TerminationAnalyzerTest extends TestCase
 
         self::assertSame(1, $analyzer->getMinLength('lexer_token'));
         self::assertSame(1, $analyzer->estimateProductionLength($production));
+        self::assertSame(1, $analyzer->estimateProductionSteps($production));
+    }
+
+    public function testEstimateProductionStepsRejectsUnsupportedTerminal(): void
+    {
+        $analyzer = new TerminationAnalyzer(
+            new Grammar('start', []),
+            static fn (string $terminal): bool => $terminal !== 'UNSUPPORTED',
+        );
+
+        self::assertSame(
+            PHP_INT_MAX,
+            $analyzer->estimateProductionSteps(new Production([new Terminal('UNSUPPORTED')])),
+        );
     }
 
     public function testEstimateProductionLengthMixed(): void

--- a/packages/sql-faker/tests/Unit/Sqlite/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/SqlGeneratorTest.php
@@ -188,6 +188,62 @@ final class SqlGeneratorTest extends TestCase
         self::assertSame('FIRST', $result);
     }
 
+    public function testGenerateSelectsTerminatingAlternativeOnRecursiveLengthTie(): void
+    {
+        $grammar = new Grammar('value', [
+            'value' => new ProductionRule('value', [
+                new Production([new NonTerminal('value')]),
+                new Production([new Terminal('VALUE')]),
+            ]),
+        ]);
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+
+        self::assertSame('VALUE', $generator->generate('value', 1));
+    }
+
+    public function testFixedSeedRejectsAProductionThatCannotFitTheDerivationBudget(): void
+    {
+        $grammar = new Grammar('value', [
+            'value' => new ProductionRule('value', [
+                new Production(array_fill(0, 5001, new NonTerminal('value'))),
+                new Production([new Terminal('VALUE')]),
+            ]),
+        ]);
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+
+        self::assertSame('VALUE', $generator->generate('value'));
+    }
+
+    public function testDerivationBudgetIncludesEveryRemainingNonTerminal(): void
+    {
+        $remaining = array_fill(0, 4998, new NonTerminal('leaf'));
+        $grammar = new Grammar('start', [
+            'start' => new ProductionRule('start', [
+                new Production([new NonTerminal('choice'), ...$remaining]),
+            ]),
+            'choice' => new ProductionRule('choice', [
+                new Production([new NonTerminal('extra')]),
+                new Production([new Terminal('EXPECTED')]),
+            ]),
+            'extra' => new ProductionRule('extra', [
+                new Production([new Terminal('UNEXPECTED')]),
+            ]),
+            'leaf' => new ProductionRule('leaf', [
+                new Production([new Terminal('x')]),
+            ]),
+        ]);
+        $faker = Factory::create();
+        $provider = new SqliteProvider($faker);
+        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $faker->seed(3);
+
+        self::assertStringStartsWith('EXPECTED ', $generator->generate('start'));
+    }
+
     #[DataProvider('providerRandomAlternativeSeeds')]
     public function testGenerateSelectsRandomAlternativeBeforeTargetDepth(int $seed1, int $seed2): void
     {


### PR DESCRIPTION
## Summary

- compute minimum remaining non-terminal expansion steps in addition to minimum output-token length
- exclude SQLite productions whose minimum continuation cannot fit the remaining 5000-step budget
- resolve equal-token-length recursion in favor of the production with fewer derivation steps
- pin both properties with deterministic grammar tests and Faker seed 12345

## Root cause

The generator switched to the production with the shortest eventual token stream after its target depth. Token length is not a termination measure: a recursive production and a terminal production can have the same minimum token length, and random early productions can create more than 5000 mandatory non-terminal expansions before termination mode begins.

The new fixed-point analysis computes a well-founded expansion distance. Every selected production is checked against the remaining global derivation budget, so accepted choices retain a finite path within the limit. This is an algorithmic guarantee rather than a larger retry/step limit.

## Stack

- Depends on #185 (and transitively #184 and #183)
- Contains only the SQLite derivation-limit root problem

## Validation

- before: SQLite finite fuzz reported 16 `Exceeded derivation limit` errors in one run
- after: the same finite fuzz shape reported 0 derivation errors; only the separately tracked PHPUnit Risky configuration remains
- termination/SQLite generator tests: 81 tests, 176 assertions
- full SQL Faker suite: 1018 tests, 1812 assertions
- PHP-CS-Fixer and PHPStan: clean