### PR TITLE
Classify finite fuzz suites correctly in PHPUnit

### DIFF
--- a/packages/ztd-query-postgres/fuzz/ClassifyFuzzTest.php
+++ b/packages/ztd-query-postgres/fuzz/ClassifyFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\PostgreSqlProvider;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
@@ -19,6 +21,8 @@ use ZtdQuery\Rewrite\QueryKind;
  * - INV-L1-02: classify() is deterministic (same input -> same output)
  * - Kind correctness: SELECT->READ, INSERT/UPDATE/DELETE->WRITE_SIMULATED, DDL->DDL_SIMULATED
  */
+#[CoversNothing]
+#[Large]
 final class ClassifyFuzzTest extends TestCase
 {
     private const ITERATIONS = 100;

--- a/packages/ztd-query-postgres/fuzz/FullPipelineFuzzTest.php
+++ b/packages/ztd-query-postgres/fuzz/FullPipelineFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\PostgreSqlProvider;
 use ZtdQuery\Exception\UnknownSchemaException;
@@ -40,6 +42,8 @@ use ZtdQuery\Shadow\ShadowStore;
  * - INV-L2-02/03: Plan consistency (mutation presence matches kind)
  * - DDL -> DML pipeline continuity (CREATE TABLE enables subsequent DML)
  */
+#[CoversNothing]
+#[Large]
 final class FullPipelineFuzzTest extends TestCase
 {
     private const ITERATIONS = 50;

--- a/packages/ztd-query-postgres/fuzz/RewriteFuzzTest.php
+++ b/packages/ztd-query-postgres/fuzz/RewriteFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\PostgreSqlProvider;
 use ZtdQuery\Exception\UnknownSchemaException;
@@ -37,6 +39,8 @@ use ZtdQuery\Shadow\ShadowStore;
  * - INV-L2-05: classify() and rewrite() must agree on QueryKind
  * - Kind correctness per SQL type: SELECT->READ, INSERT/UPDATE/DELETE->WRITE_SIMULATED, DDL->DDL_SIMULATED
  */
+#[CoversNothing]
+#[Large]
 final class RewriteFuzzTest extends TestCase
 {
     private const ITERATIONS = 100;

--- a/packages/ztd-query-postgres/fuzz/SchemaParserFuzzTest.php
+++ b/packages/ztd-query-postgres/fuzz/SchemaParserFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\PostgreSqlProvider;
 use ZtdQuery\Platform\Postgres\PgSqlSchemaParser;
@@ -23,6 +25,8 @@ use ZtdQuery\Schema\TableDefinition;
  * - P-SP-6: Non-null result always has non-empty columns
  * - P-SP-7: parse() returns null for non-CREATE TABLE statements
  */
+#[CoversNothing]
+#[Large]
 final class SchemaParserFuzzTest extends TestCase
 {
     private const ITERATIONS = 100;

--- a/packages/ztd-query-postgres/fuzz/TransformerFuzzTest.php
+++ b/packages/ztd-query-postgres/fuzz/TransformerFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\PostgreSqlProvider;
 use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
@@ -22,6 +24,8 @@ use ZtdQuery\Schema\ColumnTypeFamily;
  * - P-TF-3: With empty table context, SQL is returned unchanged (identity transform)
  * - P-TF-4: Empty-row shadow tables still inject CTE with WHERE FALSE
  */
+#[CoversNothing]
+#[Large]
 final class TransformerFuzzTest extends TestCase
 {
     private const ITERATIONS = 100;

--- a/packages/ztd-query-sqlite/fuzz/ClassifyFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/ClassifyFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\SqliteProvider;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
@@ -19,6 +21,8 @@ use ZtdQuery\Rewrite\QueryKind;
  * - INV-L1-02: classify() is deterministic (same input -> same output)
  * - Kind correctness: SELECT->READ, INSERT/UPDATE/DELETE->WRITE_SIMULATED, DDL->DDL_SIMULATED
  */
+#[CoversNothing]
+#[Large]
 final class ClassifyFuzzTest extends TestCase
 {
     private const ITERATIONS = 100;

--- a/packages/ztd-query-sqlite/fuzz/FullPipelineFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/FullPipelineFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\SqliteProvider;
 use ZtdQuery\Exception\UnknownSchemaException;
@@ -40,6 +42,8 @@ use ZtdQuery\Shadow\ShadowStore;
  * - INV-L2-02: WRITE_SIMULATED/DDL_SIMULATED plans must have non-null mutation
  * - INV-L2-03: READ plans must have null mutation
  */
+#[CoversNothing]
+#[Large]
 final class FullPipelineFuzzTest extends TestCase
 {
     private const ITERATIONS = 50;

--- a/packages/ztd-query-sqlite/fuzz/RewriteFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/RewriteFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\SqliteProvider;
 use ZtdQuery\Exception\UnknownSchemaException;
@@ -37,6 +39,8 @@ use ZtdQuery\Shadow\ShadowStore;
  * - INV-L2-05: classify() and rewrite() must agree on QueryKind
  * - Kind correctness per SQL type: SELECT->READ, INSERT/UPDATE/DELETE->WRITE_SIMULATED, DDL->DDL_SIMULATED
  */
+#[CoversNothing]
+#[Large]
 final class RewriteFuzzTest extends TestCase
 {
     private const ITERATIONS = 100;

--- a/packages/ztd-query-sqlite/fuzz/SchemaParserFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/SchemaParserFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\SqliteProvider;
 use ZtdQuery\Platform\Sqlite\SqliteSchemaParser;
@@ -23,6 +25,8 @@ use ZtdQuery\Schema\TableDefinition;
  * - P-SP-6: Non-null result always has non-empty columns
  * - P-SP-7: parse() returns null for non-CREATE TABLE statements
  */
+#[CoversNothing]
+#[Large]
 final class SchemaParserFuzzTest extends TestCase
 {
     private const ITERATIONS = 100;

--- a/packages/ztd-query-sqlite/fuzz/TransformerFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/TransformerFuzzTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Fuzz;
 
 use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\SqliteProvider;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
@@ -22,6 +24,8 @@ use ZtdQuery\Schema\ColumnTypeFamily;
  * - P-TF-3: With empty table context, SQL is returned unchanged (identity transform)
  * - P-TF-4: Empty-row shadow tables still inject CTE with WHERE FALSE
  */
+#[CoversNothing]
+#[Large]
 final class TransformerFuzzTest extends TestCase
 {
     private const ITERATIONS = 100;


### PR DESCRIPTION
## Summary

- mark all PostgreSQL and SQLite finite Fuzz classes with `#[CoversNothing]`
- mark them as `#[Large]` so PHPUnit applies the configured 60-second budget instead of the 1-second small-test budget
- keep the read-only strict `phpunit.xml.dist` files unchanged

## Root cause

The finite Fuzz classes had neither coverage intent nor size metadata. Under the repositories' strict PHPUnit configuration, every class was treated as a one-second small test and was also required to name production coverage targets. The suite therefore failed as Risky before it could reliably exercise its invariants.

The class metadata makes the existing configuration apply as designed; it does not suppress PHPUnit issues globally.

## Stack

- Depends on #186 (and transitively #185, #184, and #183)
- Contains only PHPUnit size/coverage metadata; SQLite workload depth is handled by the next stacked PR

## Validation

- PostgreSQL finite fuzz: 28/28 tests, 3597 assertions, no Risky tests
- PHP syntax check for all 10 changed Fuzz classes
- SQLite no longer fails immediately on one-second/coverage metadata; it exposes a separate depth/performance issue that the next PR addresses