### PR TITLE
Bound SQLite finite fuzz grammar depth

### DIFF
--- a/packages/ztd-query-sqlite/fuzz/ClassifyFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/ClassifyFuzzTest.php
@@ -45,7 +45,7 @@ final class ClassifyFuzzTest extends TestCase
     public function testClassifyNeverThrowsAndIsDeterministic(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->sql();
+            $sql = $this->provider->sql(maxDepth: 8);
             try {
                 $result1 = $this->guard->classify($sql);
                 $result2 = $this->guard->classify($sql);
@@ -60,7 +60,7 @@ final class ClassifyFuzzTest extends TestCase
     public function testClassifySelectReturnsReadOrNull(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->selectStatement();
+            $sql = $this->provider->selectStatement(maxDepth: 8);
             try {
                 $result = $this->guard->classify($sql);
                 if ($result !== null) {
@@ -80,7 +80,7 @@ final class ClassifyFuzzTest extends TestCase
     public function testClassifyInsertReturnsWriteSimulatedOrNull(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->insertStatement();
+            $sql = $this->provider->insertStatement(maxDepth: 8);
             try {
                 $result = $this->guard->classify($sql);
                 if ($result !== null) {
@@ -100,7 +100,7 @@ final class ClassifyFuzzTest extends TestCase
     public function testClassifyUpdateReturnsWriteSimulatedOrNull(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->updateStatement();
+            $sql = $this->provider->updateStatement(maxDepth: 8);
             try {
                 $result = $this->guard->classify($sql);
                 if ($result !== null) {
@@ -120,7 +120,7 @@ final class ClassifyFuzzTest extends TestCase
     public function testClassifyDeleteReturnsWriteSimulatedOrNull(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->deleteStatement();
+            $sql = $this->provider->deleteStatement(maxDepth: 8);
             try {
                 $result = $this->guard->classify($sql);
                 if ($result !== null) {
@@ -140,7 +140,7 @@ final class ClassifyFuzzTest extends TestCase
     public function testClassifyCreateTableReturnsDdlSimulatedOrNull(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->createTableStatement();
+            $sql = $this->provider->createTableStatement(maxDepth: 5);
             try {
                 $result = $this->guard->classify($sql);
                 if ($result !== null) {
@@ -160,7 +160,7 @@ final class ClassifyFuzzTest extends TestCase
     public function testClassifyDropTableReturnsDdlSimulatedOrNull(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->dropTableStatement();
+            $sql = $this->provider->dropTableStatement(maxDepth: 3);
             try {
                 $result = $this->guard->classify($sql);
                 if ($result !== null) {
@@ -180,7 +180,7 @@ final class ClassifyFuzzTest extends TestCase
     public function testClassifyAlterTableReturnsDdlSimulatedOrNull(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->alterTableStatement();
+            $sql = $this->provider->alterTableStatement(maxDepth: 5);
             try {
                 $result = $this->guard->classify($sql);
                 if ($result !== null) {

--- a/packages/ztd-query-sqlite/fuzz/FullPipelineFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/FullPipelineFuzzTest.php
@@ -120,7 +120,7 @@ final class FullPipelineFuzzTest extends TestCase
     public function testCreateTableThenSelectDoesNotCrash(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $createSql = $this->provider->createTableStatement();
+            $createSql = $this->provider->createTableStatement(maxDepth: 5);
             $definition = $this->schemaParser->parse($createSql);
             if ($definition === null || $definition->columns === []) {
                 continue;
@@ -157,7 +157,7 @@ final class FullPipelineFuzzTest extends TestCase
     public function testCreateTableThenInsertDoesNotCrash(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $createSql = $this->provider->createTableStatement();
+            $createSql = $this->provider->createTableStatement(maxDepth: 5);
             $definition = $this->schemaParser->parse($createSql);
             if ($definition === null || $definition->columns === []) {
                 continue;
@@ -208,7 +208,7 @@ final class FullPipelineFuzzTest extends TestCase
     public function testCreateTableThenUpdateDoesNotCrash(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $createSql = $this->provider->createTableStatement();
+            $createSql = $this->provider->createTableStatement(maxDepth: 5);
             $definition = $this->schemaParser->parse($createSql);
             if ($definition === null || $definition->columns === []) {
                 continue;
@@ -258,7 +258,7 @@ final class FullPipelineFuzzTest extends TestCase
     public function testCreateTableThenDeleteDoesNotCrash(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $createSql = $this->provider->createTableStatement();
+            $createSql = $this->provider->createTableStatement(maxDepth: 5);
             $definition = $this->schemaParser->parse($createSql);
             if ($definition === null || $definition->columns === []) {
                 continue;
@@ -300,7 +300,7 @@ final class FullPipelineFuzzTest extends TestCase
     public function testCreateTableRewriteRegistersThenDmlSucceeds(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $createSql = $this->provider->createTableStatement();
+            $createSql = $this->provider->createTableStatement(maxDepth: 5);
             $definition = $this->schemaParser->parse($createSql);
             if ($definition === null || $definition->columns === []) {
                 continue;
@@ -339,7 +339,7 @@ final class FullPipelineFuzzTest extends TestCase
     public function testShadowStoreIntegrityAfterMultipleOperations(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $createSql = $this->provider->createTableStatement();
+            $createSql = $this->provider->createTableStatement(maxDepth: 5);
             $definition = $this->schemaParser->parse($createSql);
             if ($definition === null || $definition->columns === []) {
                 continue;

--- a/packages/ztd-query-sqlite/fuzz/RewriteFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/RewriteFuzzTest.php
@@ -85,7 +85,7 @@ final class RewriteFuzzTest extends TestCase
     public function testRewriteSelectReturnsReadKind(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->selectStatement();
+            $sql = $this->provider->selectStatement(maxDepth: 8);
             try {
                 $plan = $this->rewriter->rewrite($sql);
                 self::assertNotEmpty($plan->sql());
@@ -102,7 +102,7 @@ final class RewriteFuzzTest extends TestCase
     public function testRewriteInsertReturnsWriteSimulatedKind(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->insertStatement();
+            $sql = $this->provider->insertStatement(maxDepth: 8);
             try {
                 $plan = $this->rewriter->rewrite($sql);
                 self::assertNotEmpty($plan->sql());
@@ -119,7 +119,7 @@ final class RewriteFuzzTest extends TestCase
     public function testRewriteUpdateReturnsWriteSimulatedKind(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->updateStatement();
+            $sql = $this->provider->updateStatement(maxDepth: 8);
             try {
                 $plan = $this->rewriter->rewrite($sql);
                 self::assertNotEmpty($plan->sql());
@@ -136,7 +136,7 @@ final class RewriteFuzzTest extends TestCase
     public function testRewriteDeleteReturnsWriteSimulatedKind(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->deleteStatement();
+            $sql = $this->provider->deleteStatement(maxDepth: 8);
             try {
                 $plan = $this->rewriter->rewrite($sql);
                 self::assertNotEmpty($plan->sql());
@@ -153,7 +153,7 @@ final class RewriteFuzzTest extends TestCase
     public function testRewriteCreateTableReturnsDdlSimulatedKind(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->createTableStatement();
+            $sql = $this->provider->createTableStatement(maxDepth: 5);
             try {
                 $plan = $this->rewriter->rewrite($sql);
                 self::assertNotEmpty($plan->sql());
@@ -169,7 +169,7 @@ final class RewriteFuzzTest extends TestCase
     public function testRewriteDropTableReturnsDdlSimulatedKind(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->dropTableStatement();
+            $sql = $this->provider->dropTableStatement(maxDepth: 3);
             try {
                 $plan = $this->rewriter->rewrite($sql);
                 self::assertNotEmpty($plan->sql());
@@ -189,7 +189,7 @@ final class RewriteFuzzTest extends TestCase
     public function testRewriteExceptionTypesAndPlanConsistency(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->sql();
+            $sql = $this->provider->sql(maxDepth: 8);
             try {
                 $plan = $this->rewriter->rewrite($sql);
                 self::assertNotEmpty($plan->sql(), "Rewritten SQL is empty on iteration $i");
@@ -213,7 +213,7 @@ final class RewriteFuzzTest extends TestCase
     public function testClassifyRewriteAgreement(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->sql();
+            $sql = $this->provider->sql(maxDepth: 8);
             try {
                 $classifyResult = $this->guard->classify($sql);
             } catch (\Throwable) {

--- a/packages/ztd-query-sqlite/fuzz/SchemaParserFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/SchemaParserFuzzTest.php
@@ -45,7 +45,7 @@ final class SchemaParserFuzzTest extends TestCase
     public function testParseDoesNotCrashOnRandomCreateTable(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->createTableStatement();
+            $sql = $this->provider->createTableStatement(maxDepth: 5);
             try {
                 $result = $this->parser->parse($sql);
                 if ($result !== null) {
@@ -61,7 +61,7 @@ final class SchemaParserFuzzTest extends TestCase
     public function testParseStructuralInvariantsOnRandomCreateTable(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->createTableStatement();
+            $sql = $this->provider->createTableStatement(maxDepth: 5);
             try {
                 $result = $this->parser->parse($sql);
                 if ($result === null) {
@@ -121,7 +121,7 @@ final class SchemaParserFuzzTest extends TestCase
     public function testParseReturnsNullOnNonCreateTableSql(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->selectStatement();
+            $sql = $this->provider->selectStatement(maxDepth: 8);
             try {
                 $result = $this->parser->parse($sql);
                 self::assertNull($result, "parse() should return null for SELECT on iteration $i with SQL: $sql");

--- a/packages/ztd-query-sqlite/fuzz/TransformerFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/TransformerFuzzTest.php
@@ -44,7 +44,7 @@ final class TransformerFuzzTest extends TestCase
     public function testTransformDoesNotCrashOnRandomSelectWithEmptyTables(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->selectStatement();
+            $sql = $this->provider->selectStatement(maxDepth: 8);
             try {
                 $result = $this->transformer->transform($sql, []);
                 self::assertNotEmpty($result, "transform() returned empty string on iteration $i");
@@ -75,7 +75,7 @@ final class TransformerFuzzTest extends TestCase
         ];
 
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->selectStatement();
+            $sql = $this->provider->selectStatement(maxDepth: 8);
             try {
                 $result = $this->transformer->transform($sql, $tables);
                 self::assertNotEmpty($result, "transform() returned empty string on iteration $i");
@@ -105,7 +105,7 @@ final class TransformerFuzzTest extends TestCase
         ];
 
         for ($i = 0; $i < self::ITERATIONS; $i++) {
-            $sql = $this->provider->selectStatement();
+            $sql = $this->provider->selectStatement(maxDepth: 8);
             try {
                 $result = $this->transformer->transform($sql, $tables);
                 self::assertNotEmpty($result, "transform() returned empty string on iteration $i");


### PR DESCRIPTION
## Summary

- bound finite SQLite SQLFaker generation to the same depth limits as the continuous fuzz targets
- use depth 8 for ordinary statements, 5 for schema statements, and 3 for DROP TABLE
- keep this infrastructure change separate from the package defects it exposes

## Validation

- `php -l` passes for all five changed fuzz test files
- `git diff --check` passes
- the complete finite fuzz suite now terminates in about two seconds instead of consuming unbounded CPU
- the run exposes a separate SQLite parser defect for commented `WITH` DML; that defect is fixed in the next stacked PR with deterministic regression coverage

## Stack

Depends on #187.