### PR TITLE
Tokenize SQLite WITH statement classification

### DIFF
--- a/packages/ztd-query-sqlite/fuzz/Robustness/Invariant/ClassifyNeverThrowsChecker.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Invariant/ClassifyNeverThrowsChecker.php
@@ -19,7 +19,7 @@ final class ClassifyNeverThrowsChecker implements InvariantChecker
     public function check(string $sql): ?InvariantViolation
     {
         try {
-            $this->guard->classify($sql);
+            $classification = $this->guard->classify($sql);
             return null;
         } catch (Throwable $e) {
             return new InvariantViolation(

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -7,7 +7,7 @@ namespace ZtdQuery\Platform\Sqlite;
 /**
  * Lightweight SQL parser for SQLite.
  *
- * Uses regex-based parsing focused on the SQL subset needed by ZTD:
+ * Uses lexical statement classification and focused extraction for the SQL subset needed by ZTD:
  * SELECT, INSERT, UPDATE, DELETE, CREATE TABLE, DROP TABLE, ALTER TABLE ADD COLUMN.
  *
  * Returns structured representations of parsed statements.
@@ -22,48 +22,51 @@ final class SqliteParser
      */
     public function classifyStatement(string $sql): ?string
     {
-        $trimmed = $this->stripComments($sql);
-        $trimmed = ltrim($trimmed);
-
-        if ($trimmed === '') {
+        $keywords = $this->scanTopLevelKeywords($sql);
+        if ($keywords === []) {
             return null;
         }
 
-        $upper = strtoupper($trimmed);
+        $first = $keywords[0]['keyword'];
+        $result = null;
+        if ($first === 'WITH') {
+            foreach ($keywords as $token) {
+                if (!$token['afterGroup']) {
+                    continue;
+                }
 
-        if (str_starts_with($upper, 'WITH')) {
-            return $this->classifyWithStatement($trimmed);
+                $result = match ($token['keyword']) {
+                    'SELECT' => 'SELECT',
+                    'INSERT', 'REPLACE' => 'INSERT',
+                    'UPDATE' => 'UPDATE',
+                    'DELETE' => 'DELETE',
+                    default => null,
+                };
+
+                if ($result !== null) {
+                    break;
+                }
+            }
+        } else {
+            $second = $keywords[1]['keyword'] ?? null;
+            $third = $keywords[2]['keyword'] ?? null;
+            $result = match ($first) {
+                'SELECT' => 'SELECT',
+                'INSERT', 'REPLACE' => 'INSERT',
+                'UPDATE' => 'UPDATE',
+                'DELETE' => 'DELETE',
+                'CREATE' => match ($second) {
+                    'TABLE' => 'CREATE_TABLE',
+                    'TEMPORARY' => $third === 'TABLE' ? 'CREATE_TABLE' : null,
+                    default => null,
+                },
+                'DROP' => $second === 'TABLE' ? 'DROP_TABLE' : null,
+                'ALTER' => $second === 'TABLE' ? 'ALTER_TABLE' : null,
+                default => null,
+            };
         }
 
-        if (str_starts_with($upper, 'SELECT')) {
-            return 'SELECT';
-        }
-
-        if (str_starts_with($upper, 'INSERT') || str_starts_with($upper, 'REPLACE')) {
-            return 'INSERT';
-        }
-
-        if (str_starts_with($upper, 'UPDATE')) {
-            return 'UPDATE';
-        }
-
-        if (str_starts_with($upper, 'DELETE')) {
-            return 'DELETE';
-        }
-
-        if (preg_match('/^CREATE\s+(TEMPORARY\s+)?TABLE\b/i', $trimmed) === 1) {
-            return 'CREATE_TABLE';
-        }
-
-        if (preg_match('/^DROP\s+TABLE\b/i', $trimmed) === 1) {
-            return 'DROP_TABLE';
-        }
-
-        if (preg_match('/^ALTER\s+TABLE\b/i', $trimmed) === 1) {
-            return 'ALTER_TABLE';
-        }
-
-        return null;
+        return $result;
     }
 
     /**
@@ -416,78 +419,90 @@ final class SqliteParser
         return $trimmed;
     }
 
-    private function classifyWithStatement(string $sql): ?string
+    /**
+     * @return array<int, array{keyword: string, afterGroup: bool}>
+     */
+    private function scanTopLevelKeywords(string $sql): array
     {
-        $upper = strtoupper($sql);
-        $len = strlen($upper);
+        $keywords = [];
+        $len = strlen($sql);
         $depth = 0;
-        $seenCteBody = false;
-        $quote = '';
+        $completedGroup = false;
 
         for ($i = 0; $i < $len; $i++) {
-            $char = $upper[$i];
+            $char = $sql[$i];
+            $pair = substr($sql, $i, 2);
 
-            if ($quote !== '') {
-                if ($char === $quote) {
-                    if ($i + 1 < $len && $upper[$i + 1] === $quote) {
-                        $i++;
-                    } else {
-                        $quote = '';
+            if ($pair === '--' || $char === '#') {
+                $commentLength = strcspn($sql, "\r\n", $i);
+                $i += $commentLength;
+                continue;
+            }
+
+            if ($pair === '/*') {
+                $end = strpos($sql, '*/', $i + 2);
+                if ($end === false) {
+                    break;
+                }
+                $i = $end + 1;
+                continue;
+            }
+
+            if ($char === '\'' || $char === '"' || $char === '`') {
+                $quote = $char;
+                while (true) {
+                    $end = strpos($sql, $quote, $i + 1);
+                    if ($end === false) {
+                        $i = $len;
+                        break;
                     }
+                    $i = $end;
+                    if (str_starts_with(substr($sql, $i), $quote . $quote)) {
+                        $i++;
+                        continue;
+                    }
+                    break;
                 }
                 continue;
             }
 
-            if ($char === '\'' || $char === '"') {
-                $quote = $char;
+            if ($char === '[') {
+                $end = strpos($sql, ']', $i);
+                $i = $end === false ? $len : $end;
                 continue;
             }
 
             if ($char === '(') {
                 $depth++;
-                $seenCteBody = true;
                 continue;
             }
 
             if ($char === ')') {
                 if ($depth > 0) {
                     $depth--;
+                    if ($depth === 0) {
+                        $completedGroup = true;
+                    }
                 }
                 continue;
             }
 
-            if (!$seenCteBody || $depth !== 0 || !ctype_alpha($char)) {
+            $tokenLength = strspn($sql, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$', $i);
+            if ($tokenLength === 0) {
                 continue;
             }
 
-            $prev = $i > 0 ? $upper[$i - 1] : '';
-            if (ctype_alpha($prev)) {
-                continue;
+            $token = substr($sql, $i, $tokenLength);
+            $i += $tokenLength - 1;
+            if ($depth === 0 && strspn($token, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz') > 0) {
+                $keywords[] = [
+                    'keyword' => strtoupper($token),
+                    'afterGroup' => $completedGroup,
+                ];
             }
-
-            $j = $i;
-            while ($j < $len && ctype_alpha($upper[$j])) {
-                $j++;
-            }
-
-            $keyword = substr($upper, $i, $j - $i);
-
-            $result = match ($keyword) {
-                'SELECT' => 'SELECT',
-                'INSERT', 'REPLACE' => 'INSERT',
-                'UPDATE' => 'UPDATE',
-                'DELETE' => 'DELETE',
-                default => null,
-            };
-
-            if ($result !== null) {
-                return $result;
-            }
-
-            $i = $j - 1;
         }
 
-        return null;
+        return $keywords;
     }
 
     private function extractInsertTable(string $sql): ?string

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 
@@ -393,6 +394,68 @@ SELECT * FROM users'));
     {
         $parser = new SqliteParser();
         self::assertSame('SELECT', $parser->classifyStatement("WITH cte AS (SELECT '()') SELECT * FROM cte"));
+    }
+
+    public function testClassifyWithReplaceTreatsBlockCommentsAsLexicalSeparators(): void
+    {
+        $parser = new SqliteParser();
+        $sql = '/* lead */WITH/* separator */[select] ([select])/* separator */AS/* separator */(VALUES ("select"))/* separator */REPLACE/* separator */INTO/* separator */`select` DEFAULT/* separator */VALUES';
+        self::assertSame('INSERT', $parser->classifyStatement($sql));
+    }
+
+    public function testClassifyWithUpdateTreatsLineCommentsAsLexicalSeparators(): void
+    {
+        $parser = new SqliteParser();
+        $sql = "WITH-- separator\n\"select\" (`select`) AS (VALUES (name))-- separator\nUPDATE/* separator */name SET name = `select`";
+        self::assertSame('UPDATE', $parser->classifyStatement($sql));
+    }
+
+    public function testClassifyWithDeleteIgnoresQuotedKeywordCteNames(): void
+    {
+        $parser = new SqliteParser();
+        $sql = "WITH name AS (VALUES (name)),-- separator\n[select] AS (VALUES (`select`))-- separator\nDELETE FROM [select]";
+        self::assertSame('DELETE', $parser->classifyStatement($sql));
+    }
+
+    #[DataProvider('providerLexicalClassificationBoundaries')]
+    public function testClassifyStatementUsesLexicalBoundaries(string $sql, ?string $expected): void
+    {
+        $parser = new SqliteParser();
+        self::assertSame($expected, $parser->classifyStatement($sql));
+    }
+
+    /**
+     * @return \Generator<string, array{string, ?string}>
+     */
+    public static function providerLexicalClassificationBoundaries(): \Generator
+    {
+        yield 'with requires completed group' => ['WITH SELECT', null];
+        yield 'line comment with newline' => ["-- SELECT\nUPDATE name SET value = 1", 'UPDATE'];
+        yield 'line comment with carriage return' => ["-- SELECT\rDELETE FROM name", 'DELETE'];
+        yield 'hash comment' => ["# SELECT\nINSERT INTO name DEFAULT VALUES", 'INSERT'];
+        yield 'line comment at end' => ['-- SELECT', null];
+        yield 'minimal block comment' => ['/**/SELECT 1', 'SELECT'];
+        yield 'overlapping block delimiter is unterminated' => ['/*/SELECT 1', null];
+        yield 'block comment closing boundary' => ['/**/*SELECT 1', 'SELECT'];
+        yield 'unterminated block comment' => ['/* SELECT */ UPDATE /* SELECT', 'UPDATE'];
+        yield 'double quoted keyword' => ['"SELECT" UPDATE name SET value = 1', 'UPDATE'];
+        yield 'backtick quoted keyword' => ['`SELECT` DELETE FROM name', 'DELETE'];
+        yield 'empty single quoted string' => ["''SELECT 1", 'SELECT'];
+        yield 'empty double quoted identifier' => ['""SELECT 1', 'SELECT'];
+        yield 'doubled single quote' => ["'value''SELECT' UPDATE name SET value = 1", 'UPDATE'];
+        yield 'doubled double quote' => ['"value""SELECT" DELETE FROM name', 'DELETE'];
+        yield 'doubled backtick' => ['`value``SELECT` INSERT INTO name DEFAULT VALUES', 'INSERT'];
+        yield 'unterminated single quote' => ["'SELECT UPDATE", null];
+        yield 'unterminated double quote' => ['"SELECT UPDATE', null];
+        yield 'empty bracket identifier' => ['[]SELECT 1', 'SELECT'];
+        yield 'bracket quoted keyword' => ['[SELECT] UPDATE name SET value = 1', 'UPDATE'];
+        yield 'unterminated bracket identifier' => ['[SELECT UPDATE', null];
+        yield 'underscore identifier' => ['_SELECT UPDATE name SET value = 1', 'UPDATE'];
+        yield 'dollar identifier' => ['$SELECT DELETE FROM name', 'DELETE'];
+        yield 'numeric identifier' => ['1SELECT INSERT INTO name DEFAULT VALUES', 'INSERT'];
+        yield 'parenthesized keyword' => ['(SELECT) UPDATE name SET value = 1', 'UPDATE'];
+        yield 'nested parenthesized keyword' => ['((SELECT)) DELETE FROM name', 'DELETE'];
+        yield 'temporary non-table create' => ['CREATE TEMPORARY INDEX name', null];
     }
 
     public function testSplitStatementsIgnoresSemicolonInDoubleQuote(): void


### PR DESCRIPTION
## Summary

- replace SQLite statement-kind prefix/regex checks with a top-level lexical scan
- ignore block comments, line comments, strings, quoted identifiers, and nested CTE bodies while locating the outer statement
- preserve exact keyword boundaries instead of deleting comments and concatenating tokens
- add fixed regression tests for the SQLFaker-generated WITH + REPLACE/UPDATE/DELETE failure shapes

## Validation

- `composer test`: 1,078 tests, 1,924 assertions
- `composer test:fuzz`: 28 tests, 3,769 assertions
- `composer lint`: PHP-CS-Fixer and PHPStan pass
- targeted WITH classification suite: 33 tests pass

## Stack

Depends on #188. The failing SQLFaker cases exposed by #188 pass in this PR.