### PR TITLE
Treat SQLite comments as lexical whitespace

### DIFF
--- a/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
@@ -454,4 +454,24 @@ final class SqliteCteShadowingTest extends TestCase
         self::assertSame('Test', $rows[0]['name']);
         self::assertNull($rows[0]['bio']);
     }
+
+    public function testCommentsRemainLexicalWhitespaceAcrossSqliteMutations(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $rawPdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, status INTEGER)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+        $ztdPdo->exec('INSERT INTO items VALUES (1, 1)');
+        $ztdPdo->exec('INSERT INTO/* table */items VALUES (2, 1)');
+        $ztdPdo->exec('UPDATE/* table */items SET status = 0 WHERE id = 1');
+        $ztdPdo->exec('DELETE FROM/* table */items WHERE id = 2');
+
+        $status = $ztdPdo->query('SELECT status FROM/* table */items WHERE id = 1');
+        self::assertNotFalse($status);
+        self::assertSame(0, $status->fetchColumn());
+
+        $ids = $ztdPdo->query("-- SELECT * FROM other_table WHERE DELETE UPDATE INSERT\nSELECT id FROM items ORDER BY id");
+        self::assertNotFalse($ids);
+        self::assertSame([1], $ids->fetchAll(\PDO::FETCH_COLUMN));
+    }
 }

--- a/packages/ztd-query-sqlite/src/SqliteLexicalMasker.php
+++ b/packages/ztd-query-sqlite/src/SqliteLexicalMasker.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+final class SqliteLexicalMasker
+{
+    public static function maskComments(string $sql): string
+    {
+        $result = '';
+        $length = strlen($sql);
+        $i = 0;
+
+        while ($i < $length) {
+            $char = $sql[$i];
+
+            if ($char === '\'' || $char === '"' || $char === '`') {
+                $tail = substr($sql, $i);
+                $quotedLength = self::quotedLength($tail, $char);
+                $result .= substr($tail, 0, $quotedLength);
+                $i += $quotedLength;
+                continue;
+            }
+
+            if ($char === '[') {
+                $tail = substr($sql, $i);
+                $quotedLength = self::bracketQuotedLength($tail);
+                $result .= substr($tail, 0, $quotedLength);
+                $i += $quotedLength;
+                continue;
+            }
+
+            $pair = substr($sql, $i, 2);
+            if ($pair === '--' || $char === '#') {
+                $commentLength = strcspn($sql, "\r\n", $i);
+                $result .= ' ';
+                $i += $commentLength;
+                continue;
+            }
+
+            if ($pair === '/*') {
+                $end = strpos($sql, '*/', $i + 2);
+                $result .= ' ';
+                $i = $end === false ? $length : $end + 2;
+                continue;
+            }
+
+            $result .= $char;
+            $i++;
+        }
+
+        return $result;
+    }
+
+    private static function quotedLength(string $sql, string $quote): int
+    {
+        $length = strlen($sql);
+        $i = 1;
+
+        while (true) {
+            $end = strpos($sql, $quote, $i);
+            if ($end === false) {
+                return $length;
+            }
+            $quoteCount = strspn($sql, $quote, $end);
+            $i = $end + $quoteCount;
+            if ($quoteCount % 2 === 0) {
+                continue;
+            }
+
+            return $i;
+        }
+    }
+
+    private static function bracketQuotedLength(string $sql): int
+    {
+        $end = strpos($sql, ']');
+        if ($end === false) {
+            return strlen($sql);
+        }
+
+        return $end;
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -206,6 +206,7 @@ final class SqliteParser
      */
     public function extractSelectTables(string $sql): array
     {
+        $sql = $this->stripComments($sql);
         $tables = [];
 
         if (preg_match('/\bFROM\s+(.+?)(?:\s+WHERE\b|\s+GROUP\s+BY\b|\s+HAVING\b|\s+ORDER\s+BY\b|\s+LIMIT\b|\s+UNION\b|$)/is', $sql, $matches) === 1) {
@@ -241,6 +242,7 @@ final class SqliteParser
      */
     public function extractInsertColumns(string $sql): array
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bINTO\s+(?:"(?:[^"]|"")*"|[^\s(]+)\s*\(([^)]+)\)\s*(?:VALUES|SELECT)/i', $sql, $matches) === 1) {
             return $this->parseColumnList($matches[1]);
         }
@@ -255,6 +257,7 @@ final class SqliteParser
      */
     public function extractInsertValues(string $sql): array
     {
+        $sql = $this->stripComments($sql);
         $upper = strtoupper($sql);
         $valuesPos = strpos($upper, 'VALUES');
         if ($valuesPos === false) {
@@ -273,6 +276,7 @@ final class SqliteParser
      */
     public function extractUpdateAssignments(string $sql): array
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bSET\s+(.+?)(?:\s+WHERE\b|\s+ORDER\s+BY\b|\s+LIMIT\b|$)/is', $sql, $matches) !== 1) {
             return [];
         }
@@ -285,6 +289,7 @@ final class SqliteParser
      */
     public function extractWhereClause(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bWHERE\s+(.+?)(?:\s+ORDER\s+BY\b|\s+LIMIT\b|\s+GROUP\s+BY\b|\s+HAVING\b|$)/is', $sql, $matches) === 1) {
             return trim($matches[1]);
         }
@@ -297,6 +302,7 @@ final class SqliteParser
      */
     public function extractOrderByClause(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bORDER\s+BY\s+(.+?)(?:\s+LIMIT\b|$)/is', $sql, $matches) === 1) {
             return trim($matches[1]);
         }
@@ -309,6 +315,7 @@ final class SqliteParser
      */
     public function extractLimitClause(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bLIMIT\s+(.+?)$/is', $sql, $matches) === 1) {
             return trim($matches[1]);
         }
@@ -321,6 +328,7 @@ final class SqliteParser
      */
     public function hasOnConflict(string $sql): bool
     {
+        $sql = $this->stripComments($sql);
         return preg_match('/\bON\s+CONFLICT\b/i', $sql) === 1;
     }
 
@@ -353,6 +361,7 @@ final class SqliteParser
      */
     public function extractOnConflictUpdates(string $sql): array
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bON\s+CONFLICT\s*(?:\([^)]*\))?\s*DO\s+UPDATE\s+SET\s+(.+?)$/is', $sql, $matches) !== 1) {
             return [];
         }
@@ -365,7 +374,7 @@ final class SqliteParser
      */
     public function hasInsertSelect(string $sql): bool
     {
-        $upper = strtoupper($sql);
+        $sql = $this->stripComments($sql);
         return preg_match('/\bINTO\s+(?:"(?:[^"]|"")*"|[^\s(]+)\s*(?:\([^)]*\)\s*)?SELECT\b/i', $sql) === 1;
     }
 
@@ -374,6 +383,7 @@ final class SqliteParser
      */
     public function extractInsertSelect(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bINTO\s+(?:"(?:[^"]|"")*"|[^\s(]+)\s*(?:\([^)]*\)\s*)?(SELECT\b.+)$/is', $sql, $matches) === 1) {
             return trim($matches[1]);
         }
@@ -386,11 +396,7 @@ final class SqliteParser
      */
     public function stripComments(string $sql): string
     {
-        $result = (string) preg_replace('/\/\*.*?\*\//s', '', $sql);
-        $result = (string) preg_replace('/--[^\n]*/', '', $result);
-        $result = (string) preg_replace('/#[^\n]*/', '', $result);
-
-        return trim($result);
+        return trim(SqliteLexicalMasker::maskComments($sql));
     }
 
     /**
@@ -507,6 +513,7 @@ final class SqliteParser
 
     private function extractInsertTable(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bINTO\s+("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s(]+)/i', $sql, $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
@@ -520,6 +527,7 @@ final class SqliteParser
 
     private function extractUpdateTable(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/^UPDATE\s+(?:OR\s+(?:ROLLBACK|ABORT|REPLACE|FAIL|IGNORE)\s+)?("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s,]+)/i', trim($sql), $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
@@ -529,6 +537,7 @@ final class SqliteParser
 
     private function extractDeleteTable(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/\bFROM\s+("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s,]+)/i', $sql, $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
@@ -538,6 +547,7 @@ final class SqliteParser
 
     private function extractCreateTableName(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/^CREATE\s+(?:TEMPORARY\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s(]+)/i', trim($sql), $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
@@ -547,6 +557,7 @@ final class SqliteParser
 
     private function extractDropTableName(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/^DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s;]+)/i', trim($sql), $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
@@ -556,6 +567,7 @@ final class SqliteParser
 
     private function extractAlterTableName(string $sql): ?string
     {
+        $sql = $this->stripComments($sql);
         if (preg_match('/^ALTER\s+TABLE\s+("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s]+)/i', trim($sql), $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteLexicalMaskerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteLexicalMaskerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
+
+#[CoversClass(SqliteLexicalMasker::class)]
+final class SqliteLexicalMaskerTest extends TestCase
+{
+    #[DataProvider('providerComments')]
+    public function testMasksCommentsAsSingleLexicalSeparators(string $sql, string $expected): void
+    {
+        self::assertSame($expected, SqliteLexicalMasker::maskComments($sql));
+    }
+
+    #[DataProvider('providerQuotedForms')]
+    public function testPreservesCommentMarkersInsideQuotedForms(string $quoted, bool $terminated): void
+    {
+        $sql = 'SELECT ' . $quoted . '/* outside */1';
+        $expected = $terminated ? 'SELECT ' . $quoted . ' 1' : $sql;
+
+        self::assertSame($expected, SqliteLexicalMasker::maskComments($sql));
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerComments(): \Generator
+    {
+        yield 'empty query' => ['', ''];
+        yield 'line comment' => ['SELECT-- comment', 'SELECT '];
+        yield 'line comment with newline' => ["SELECT-- comment\n1", "SELECT \n1"];
+        yield 'line comment with carriage return' => ["SELECT-- comment\r1", "SELECT \r1"];
+        yield 'empty line comment' => ["--\nSELECT", " \nSELECT"];
+        yield 'separated minus signs' => ['SELECT- -1', 'SELECT- -1'];
+        yield 'hash comment' => ['SELECT# comment', 'SELECT '];
+        yield 'empty hash comment' => ["#\nSELECT", " \nSELECT"];
+        yield 'block comment' => ['SELECT/* comment */1', 'SELECT 1'];
+        yield 'minimal block comment' => ['SELECT/**/1', 'SELECT 1'];
+        yield 'adjacent block comments' => ['SELECT/**//**/1', 'SELECT  1'];
+        yield 'unterminated block comment' => ['SELECT/* comment', 'SELECT '];
+        yield 'separated slash and asterisk' => ['SELECT/ *1', 'SELECT/ *1'];
+        yield 'comment-like closing marker' => ['SELECT*/1', 'SELECT*/1'];
+        yield 'comment closing boundary' => ['SELECT/**/*1', 'SELECT *1'];
+        yield 'overlapping unterminated block marker' => ['SELECT/*/1', 'SELECT '];
+    }
+
+    /**
+     * @return \Generator<string, array{string, bool}>
+     */
+    public static function providerQuotedForms(): \Generator
+    {
+        yield 'single quoted line marker' => ["'-- comment'", true];
+        yield 'single quoted block marker' => ["'/* comment */'", true];
+        yield 'empty single quote' => ["''", true];
+        yield 'doubled single quote' => ["'value''/* comment */'", true];
+        yield 'triple single quote closing run' => ["'value'''", true];
+        yield 'unterminated single quote' => ["'/* comment", false];
+        yield 'double quoted line marker' => ['"-- comment"', true];
+        yield 'double quoted block marker' => ['"/* comment */"', true];
+        yield 'empty double quote' => ['""', true];
+        yield 'doubled double quote' => ['"value""/* comment */"', true];
+        yield 'unterminated double quote' => ['"/* comment', false];
+        yield 'backtick quoted hash marker' => ['`# comment`', true];
+        yield 'empty backtick quote' => ['``', true];
+        yield 'doubled backtick' => ['`value``/* comment */`', true];
+        yield 'unterminated backtick' => ['`/* comment', false];
+        yield 'bracket quoted line marker' => ['[-- comment]', true];
+        yield 'bracket quoted block marker' => ['[/* comment */]', true];
+        yield 'empty bracket quote' => ['[]', true];
+        yield 'unterminated bracket' => ['[/* comment', false];
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteMutationResolver;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteSchemaParser;
 use ZtdQuery\Rewrite\QueryKind;
@@ -25,6 +26,7 @@ use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(SqliteMutationResolver::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SqliteSchemaParser::class)]
 final class SqliteMutationResolverTest extends TestCase

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -6,10 +6,13 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 
 #[CoversClass(SqliteParser::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 final class SqliteParserTest extends TestCase
 {
     public function testClassifySelect(): void
@@ -343,7 +346,57 @@ SELECT * FROM users'));
     public function testStripBlockComment(): void
     {
         $parser = new SqliteParser();
-        self::assertSame('SELECT 1  FROM t', $parser->stripComments('SELECT 1 /* comment */ FROM t'));
+        self::assertSame('SELECT 1   FROM t', $parser->stripComments('SELECT 1 /* comment */ FROM t'));
+    }
+
+    public function testStripBlockCommentPreservesLexicalBoundaryWithoutSurroundingSpaces(): void
+    {
+        $parser = new SqliteParser();
+        self::assertSame('SELECT FROM', $parser->stripComments('SELECT/* comment */FROM'));
+    }
+
+    public function testStripCommentsTrimsOuterWhitespace(): void
+    {
+        $parser = new SqliteParser();
+        self::assertSame('SELECT', $parser->stripComments(" \n/* comment */ SELECT \t"));
+    }
+
+    public function testStripCommentsPreservesQuotedCommentMarkers(): void
+    {
+        $parser = new SqliteParser();
+        $sql = "SELECT '/* value */', \"-- identifier\", `# identifier`, [/* identifier */] FROM users";
+        self::assertSame($sql, $parser->stripComments($sql));
+    }
+
+    public function testExtractSelectTableAfterBlockComment(): void
+    {
+        $parser = new SqliteParser();
+        self::assertSame(['my_table'], $parser->extractSelectTables('SELECT * FROM /* table */ my_table'));
+    }
+
+    public function testExtractSelectTableIgnoresKeywordsInsideLineComment(): void
+    {
+        $parser = new SqliteParser();
+        $sql = "-- SELECT * FROM other_table WHERE DELETE UPDATE INSERT\nSELECT * FROM items ORDER BY id";
+        self::assertSame(['items'], $parser->extractSelectTables($sql));
+    }
+
+    public function testExtractUpdateTargetAcrossBlockComment(): void
+    {
+        $parser = new SqliteParser();
+        self::assertSame('my_table', $parser->extractTargetTable('UPDATE/* table */my_table SET value = 1'));
+    }
+
+    public function testExtractDeleteTargetAcrossBlockComment(): void
+    {
+        $parser = new SqliteParser();
+        self::assertSame('my_table', $parser->extractTargetTable('DELETE FROM/* table */my_table WHERE id = 1'));
+    }
+
+    public function testExtractInsertTargetAcrossBlockComment(): void
+    {
+        $parser = new SqliteParser();
+        self::assertSame('my_table', $parser->extractTargetTable('INSERT INTO/* table */my_table VALUES (1)'));
     }
 
     public function testStripHashComment(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteQueryGuardTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteQueryGuardTest.php
@@ -7,11 +7,13 @@ namespace Tests\Unit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\QueryClassifierContractTest;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
 use ZtdQuery\Rewrite\QueryKind;
 
 #[CoversClass(SqliteQueryGuard::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 final class SqliteQueryGuardTest extends QueryClassifierContractTest
 {

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -11,6 +11,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
 use ZtdQuery\Platform\Sqlite\SqliteMutationResolver;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
 use ZtdQuery\Platform\Sqlite\SqliteRewriter;
@@ -35,6 +36,7 @@ use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(SqliteRewriter::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SqliteQueryGuard::class)]
 #[UsesClass(SqliteSchemaParser::class)]
@@ -1472,6 +1474,75 @@ final class SqliteRewriterTest extends RewriterContractTest
 
         $plan = $rewriter->rewrite('/* comment */ DELETE FROM users');
         self::assertSame('SELECT 1 WHERE 0', $plan->sql());
+    }
+
+    public function testSelectRewritesTableAfterBlockComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1]]);
+        $rewriter = $this->createRewriter($store, $registry);
+
+        $plan = $rewriter->rewrite('SELECT * FROM/* table */users');
+
+        self::assertSame(QueryKind::READ, $plan->kind());
+        self::assertStringContainsString('"users" AS', $plan->sql());
+    }
+
+    public function testSelectIgnoresSqlKeywordsInsideLeadingLineComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1]]);
+        $rewriter = $this->createRewriter($store, $registry);
+        $sql = "-- SELECT * FROM other_table WHERE DELETE UPDATE INSERT\nSELECT * FROM users";
+
+        $plan = $rewriter->rewrite($sql);
+
+        self::assertSame(QueryKind::READ, $plan->kind());
+        self::assertStringContainsString('"users" AS', $plan->sql());
+        self::assertStringNotContainsString('"other_table" AS', $plan->sql());
+    }
+
+    public function testInsertResolvesTargetAfterBlockComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite('INSERT INTO/* table */users (id) VALUES (1)');
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertInstanceOf(InsertMutation::class, $plan->mutation());
+        self::assertSame('users', $plan->mutation()->tableName());
+    }
+
+    public function testUpdateResolvesTargetAfterBlockComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite('UPDATE/* table */users SET id = 2 WHERE id = 1');
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertInstanceOf(UpdateMutation::class, $plan->mutation());
+        self::assertSame('users', $plan->mutation()->tableName());
+    }
+
+    public function testDeleteResolvesTargetAfterBlockComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite('DELETE FROM/* table */users WHERE id = 1');
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertInstanceOf(DeleteMutation::class, $plan->mutation());
+        self::assertSame('users', $plan->mutation()->tableName());
     }
 
     public function testUpdateEnsuresShadowStoreEntry(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
@@ -8,11 +8,13 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\SchemaParserContractTest;
 use ZtdQuery\Platform\SchemaParser;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteSchemaParser;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(SqliteSchemaParser::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 final class SqliteSchemaParserTest extends SchemaParserContractTest
 {

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -11,6 +11,7 @@ use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
 use ZtdQuery\Platform\Sqlite\SqliteMutationResolver;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
 use ZtdQuery\Platform\Sqlite\SqliteRewriter;
@@ -29,6 +30,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[CoversClass(SqliteSessionFactory::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteMutationResolver::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SqliteQueryGuard::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\Sqlite\Transformer\SelectTransformer;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(DeleteTransformer::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\Transformer\InsertTransformer;
 use ZtdQuery\Platform\Sqlite\Transformer\SelectTransformer;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(InsertTransformer::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\Sqlite\Transformer\InsertTransformer;
@@ -18,6 +19,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(SqliteTransformer::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(InsertTransformer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Sqlite\Transformer\UpdateTransformer;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(UpdateTransformer::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]


### PR DESCRIPTION
## Summary

- replace regex comment deletion with a quote-aware lexical scanner
- preserve comment markers inside strings and quoted identifiers
- keep token boundaries when comments appear without surrounding spaces
- normalize comments before every SQLite table, column, value, predicate, ordering, limit, conflict, and INSERT...SELECT extraction path
- add parser, rewriter, and PDO end-to-end regressions for the SQLite failures reported in #69 and #82

## Validation

- SQLite unit suite: 1,092 tests, 1,945 assertions
- SQLite finite fuzz: 28 tests, 4,069 assertions
- SQLite and PDO adapter lint/PHPStan pass
- PDO end-to-end regression verifies commented SELECT, INSERT, UPDATE, DELETE, and line comments containing misleading SQL keywords

## Issues

Addresses the SQLite portion of #69 and #82. The PostgreSQL portion remains isolated in the next stacked PR.

## Stack

Depends on #190.