### PR TITLE
Treat PostgreSQL comments as lexical whitespace

### DIFF
--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
@@ -372,4 +372,30 @@ final class PostgreSqlCteShadowingTest extends TestCase
         }
     }
 
+    public function testCommentsRemainLexicalWhitespaceAcrossPostgreSqlMutations(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'comment_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec(sprintf('CREATE TABLE %s (id INTEGER PRIMARY KEY, status INTEGER)', $table));
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+            $ztdPdo->exec(sprintf('INSERT INTO %s VALUES (1, 1)', $table));
+            $ztdPdo->exec(sprintf('INSERT INTO/* table */%s VALUES (2, 1)', $table));
+            $ztdPdo->exec(sprintf("-- deactivate item\nUPDATE/* table */%s SET status = 0 WHERE id = 1", $table));
+            $ztdPdo->exec(sprintf('DELETE FROM/* table */%s WHERE id = 2', $table));
+
+            $status = $ztdPdo->query(sprintf('SELECT status FROM/* table */%s WHERE id = 1', $table));
+            self::assertNotFalse($status);
+            self::assertSame(0, $status->fetchColumn());
+
+            $ids = $ztdPdo->query(sprintf("-- SELECT * FROM other_table WHERE DELETE UPDATE INSERT\nSELECT id FROM %s ORDER BY id", $table));
+            self::assertNotFalse($ids);
+            self::assertSame([1], $ids->fetchAll(\PDO::FETCH_COLUMN));
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
 }

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -23,7 +23,7 @@ final class PgSqlParser
      */
     public function classifyStatement(string $sql): ?string
     {
-        $trimmed = $this->stripLeadingComments($sql);
+        $trimmed = $this->maskComments($sql);
 
         if (preg_match('/^\s*WITH\b/i', $trimmed) === 1) {
             return $this->classifyWithStatement($trimmed);
@@ -169,6 +169,7 @@ final class PgSqlParser
      */
     public function extractInsertTable(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/INSERT\s+INTO\s+(?:ONLY\s+)?("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)(?:\s+AS\s+"?(\w+)"?)?/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
         }
@@ -183,6 +184,7 @@ final class PgSqlParser
      */
     public function extractInsertColumns(string $sql): array
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/INSERT\s+INTO\s+(?:ONLY\s+)?(?:"[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)\s*\(([^)]+)\)\s*(?:VALUES|SELECT|DEFAULT)/i', $sql, $m) === 1) {
             return $this->parseColumnList($m[1]);
         }
@@ -197,6 +199,7 @@ final class PgSqlParser
      */
     public function extractInsertValues(string $sql): array
     {
+        $sql = $this->maskComments($sql);
         $rows = [];
         if (preg_match('/\bVALUES\s*(\(.+)/is', $sql, $m) !== 1) {
             return [];
@@ -231,6 +234,7 @@ final class PgSqlParser
      */
     public function hasOnConflict(string $sql): bool
     {
+        $sql = $this->maskComments($sql);
         return preg_match('/\bON\s+CONFLICT\b/i', $sql) === 1;
     }
 
@@ -241,6 +245,7 @@ final class PgSqlParser
      */
     public function extractOnConflictUpdateColumns(string $sql): array
     {
+        $sql = $this->maskComments($sql);
         $columns = [];
         /** @var array<string, string> $values */
         $values = [];
@@ -272,6 +277,7 @@ final class PgSqlParser
      */
     public function hasInsertSelect(string $sql): bool
     {
+        $sql = $this->maskComments($sql);
         $stripped = $this->stripStringLiterals($sql);
         if (preg_match('/\bVALUES\b/i', $stripped) === 1) {
             return false;
@@ -285,6 +291,7 @@ final class PgSqlParser
      */
     public function extractInsertSelectSql(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         $stripped = $this->stripStringLiterals($sql);
         if (preg_match('/\bSELECT\b/i', $stripped, $m, PREG_OFFSET_CAPTURE) === 1) {
             $offset = $m[0][1];
@@ -300,6 +307,7 @@ final class PgSqlParser
      */
     public function extractUpdateTable(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/UPDATE\s+(?:ONLY\s+)?("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)(?:\s+(?:AS\s+)?("[^"]+"|[a-zA-Z_]\w*))?/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
         }
@@ -312,6 +320,7 @@ final class PgSqlParser
      */
     public function extractUpdateAlias(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/UPDATE\s+(?:ONLY\s+)?(?:"[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)\s+(?:AS\s+)?("[^"]+"|[a-zA-Z_]\w*)\s+SET\b/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($m[1]);
         }
@@ -326,6 +335,7 @@ final class PgSqlParser
      */
     public function extractUpdateSets(string $sql): array
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/\bSET\s+(.+?)(?:\s+FROM\s+|\s+WHERE\s+|\s+RETURNING\s+|$)/is', $sql, $m) !== 1) {
             return [];
         }
@@ -350,6 +360,7 @@ final class PgSqlParser
      */
     public function extractWhereClause(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         $stripped = $this->stripStringLiterals($sql);
         if (preg_match('/\bWHERE\b/i', $stripped, $m, PREG_OFFSET_CAPTURE) !== 1) {
             return null;
@@ -417,6 +428,7 @@ final class PgSqlParser
      */
     public function extractUpdateFromClause(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/\bFROM\s+(.+?)(?:\s+WHERE\s+|\s+RETURNING\s+|$)/is', $sql, $m) === 1) {
             $stripped = $this->stripStringLiterals($sql);
             if (preg_match('/\bSET\b.*?\bFROM\b/is', $stripped) === 1) {
@@ -432,6 +444,7 @@ final class PgSqlParser
      */
     public function extractDeleteTable(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/DELETE\s+FROM\s+(?:ONLY\s+)?("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)(?:\s+(?:AS\s+)?("[^"]+"|[a-zA-Z_]\w*))?/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
         }
@@ -444,6 +457,7 @@ final class PgSqlParser
      */
     public function extractDeleteAlias(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/DELETE\s+FROM\s+(?:ONLY\s+)?(?:"[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)\s+(?:AS\s+)?("[^"]+"|[a-zA-Z_]\w*)\s+(?:USING\b|WHERE\b|RETURNING\b|$)/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($m[1]);
         }
@@ -456,6 +470,7 @@ final class PgSqlParser
      */
     public function extractDeleteUsingClause(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/\bUSING\s+(.+?)(?:\s+WHERE\s+|\s+RETURNING\s+|$)/is', $sql, $m) === 1) {
             return trim($m[1]);
         }
@@ -468,6 +483,7 @@ final class PgSqlParser
      */
     public function extractTruncateTable(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/TRUNCATE\s+(?:TABLE\s+)?(?:ONLY\s+)?("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
         }
@@ -480,6 +496,7 @@ final class PgSqlParser
      */
     public function extractCreateTableName(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/CREATE\s+(?:TEMPORARY\s+|TEMP\s+|UNLOGGED\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
         }
@@ -492,6 +509,7 @@ final class PgSqlParser
      */
     public function hasIfNotExists(string $sql): bool
     {
+        $sql = $this->maskComments($sql);
         return preg_match('/CREATE\s+(?:TEMPORARY\s+|TEMP\s+|UNLOGGED\s+)?TABLE\s+IF\s+NOT\s+EXISTS\b/i', $sql) === 1;
     }
 
@@ -500,6 +518,7 @@ final class PgSqlParser
      */
     public function hasCreateTableAsSelect(string $sql): bool
     {
+        $sql = $this->maskComments($sql);
         return preg_match('/CREATE\s+(?:TEMPORARY\s+|TEMP\s+|UNLOGGED\s+)?TABLE\s+.*?\bAS\s+SELECT\b/is', $sql) === 1;
     }
 
@@ -508,6 +527,7 @@ final class PgSqlParser
      */
     public function extractCreateTableSelectSql(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/\bAS\s+(SELECT\b.+)$/is', $sql, $m) === 1) {
             return trim($m[1]);
         }
@@ -520,6 +540,7 @@ final class PgSqlParser
      */
     public function hasCreateTableLike(string $sql): bool
     {
+        $sql = $this->maskComments($sql);
         return preg_match('/CREATE\s+(?:TEMPORARY\s+|TEMP\s+|UNLOGGED\s+)?TABLE\s+.*?\(\s*LIKE\s+/is', $sql) === 1;
     }
 
@@ -528,6 +549,7 @@ final class PgSqlParser
      */
     public function extractCreateTableLikeSource(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/\(\s*LIKE\s+("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
         }
@@ -540,6 +562,7 @@ final class PgSqlParser
      */
     public function extractDropTableName(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
         }
@@ -552,6 +575,7 @@ final class PgSqlParser
      */
     public function hasDropTableIfExists(string $sql): bool
     {
+        $sql = $this->maskComments($sql);
         return preg_match('/DROP\s+TABLE\s+IF\s+EXISTS\b/i', $sql) === 1;
     }
 
@@ -560,6 +584,7 @@ final class PgSqlParser
      */
     public function extractAlterTableName(string $sql): ?string
     {
+        $sql = $this->maskComments($sql);
         if (preg_match('/ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $sql, $m) === 1) {
             return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
         }
@@ -604,6 +629,7 @@ final class PgSqlParser
      */
     public function extractSelectTableNames(string $sql): array
     {
+        $sql = $this->maskComments($sql);
         $tables = [];
         $stripped = $this->stripStringLiterals($sql);
 
@@ -754,28 +780,6 @@ final class PgSqlParser
         }
 
         return null;
-    }
-
-    private function stripLeadingComments(string $sql): string
-    {
-        $result = $sql;
-        $changed = true;
-        while ($changed) {
-            $changed = false;
-            $result = ltrim($result);
-            if (str_starts_with($result, '--')) {
-                $pos = strpos($result, "\n");
-                $result = $pos !== false ? substr($result, $pos + 1) : '';
-                $changed = true;
-            }
-            if (str_starts_with($result, '/*')) {
-                $pos = strpos($result, '*/');
-                $result = $pos !== false ? substr($result, $pos + 2) : '';
-                $changed = true;
-            }
-        }
-
-        return $result;
     }
 
     /**
@@ -944,6 +948,11 @@ final class PgSqlParser
         }
 
         return $parts;
+    }
+
+    private function maskComments(string $sql): string
+    {
+        return PostgreSqlLexicalMasker::maskComments($sql);
     }
 
     private function stripStringLiterals(string $sql): string

--- a/packages/ztd-query-postgres/src/PostgreSqlLexicalMasker.php
+++ b/packages/ztd-query-postgres/src/PostgreSqlLexicalMasker.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+final class PostgreSqlLexicalMasker
+{
+    public static function maskComments(string $sql): string
+    {
+        $result = '';
+        $length = strlen($sql);
+        $i = 0;
+
+        while ($i < $length) {
+            $char = $sql[$i];
+
+            if ($char === '\'' || $char === '"') {
+                $tail = substr($sql, $i);
+                $quotedLength = self::quotedLength($tail, $char, self::isEscapeStringStart($sql, $i));
+                $result .= substr($tail, 0, $quotedLength);
+                $i += $quotedLength;
+                continue;
+            }
+
+            if ($char === '$') {
+                $tail = substr($sql, $i);
+                $quotedLength = self::dollarQuotedLength($tail);
+                if ($quotedLength !== null) {
+                    $result .= substr($tail, 0, $quotedLength);
+                    $i += $quotedLength;
+                    continue;
+                }
+            }
+
+            $pair = substr($sql, $i, 2);
+            if ($pair === '--') {
+                $commentLength = strcspn($sql, "\r\n", $i);
+                $result .= ' ';
+                $i += $commentLength;
+                continue;
+            }
+
+            if ($pair === '/*') {
+                $scan = $i;
+                $depth = 0;
+                while (true) {
+                    $open = strpos($sql, '/*', $scan);
+                    $close = strpos($sql, '*/', $scan);
+                    $openPosition = $open === false ? $length : $open;
+                    $closePosition = $close === false ? $length : $close;
+                    $markerPosition = min($openPosition, $closePosition);
+                    if ($markerPosition === $length) {
+                        $scan = $length;
+                        break;
+                    }
+                    $scan = $markerPosition + 2;
+                    if (substr($sql, $markerPosition, 2) === '/*') {
+                        $depth++;
+                        continue;
+                    }
+                    $depth--;
+                    if ($depth === 0) {
+                        break;
+                    }
+                }
+                $result .= ' ';
+                $i = $scan;
+                continue;
+            }
+
+            $result .= $char;
+            $i++;
+        }
+
+        return $result;
+    }
+
+    private static function quotedLength(string $sql, string $quote, bool $escapeBackslash): int
+    {
+        $length = strlen($sql);
+        $i = 1;
+
+        while ($i < $length) {
+            if ($escapeBackslash && $sql[$i] === '\\') {
+                $i += strlen(substr($sql, $i, 2));
+                continue;
+            }
+            if ($sql[$i] !== $quote) {
+                $i++;
+                continue;
+            }
+            if (str_starts_with(substr($sql, $i), $quote . $quote)) {
+                $i += 2;
+                continue;
+            }
+            $i++;
+            break;
+        }
+
+        return $i;
+    }
+
+    private static function dollarQuotedLength(string $sql): ?int
+    {
+        $delimiter = self::dollarQuoteDelimiter($sql);
+        if ($delimiter === null) {
+            return null;
+        }
+
+        $end = strpos($sql, $delimiter, strlen($delimiter));
+        if ($end === false) {
+            return strlen($sql);
+        }
+
+        return $end + strlen($delimiter);
+    }
+
+    private static function dollarQuoteDelimiter(string $sql): ?string
+    {
+        $length = strlen($sql);
+        $i = 1;
+        if ($i < $length && $sql[$i] === '$') {
+            return '$$';
+        }
+        if ($i >= $length || !self::isIdentifierStart($sql[$i])) {
+            return null;
+        }
+
+        while ($i < $length && (self::isIdentifierStart($sql[$i]) || ctype_digit($sql[$i]))) {
+            $i++;
+        }
+        if ($i >= $length || $sql[$i] !== '$') {
+            return null;
+        }
+
+        return substr($sql, 0, $i) . '$';
+    }
+
+    private static function isEscapeStringStart(string $sql, int $quotePosition): bool
+    {
+        $prefix = substr($sql, 0, $quotePosition);
+
+        $escapeMarker = substr($prefix, -1);
+        $preceding = substr(substr($prefix, 0, -1), -1);
+
+        return ($escapeMarker === 'E' || $escapeMarker === 'e')
+            && ($preceding === '' || !self::isIdentifierContinuation($preceding));
+    }
+
+    private static function isIdentifierStart(string $char): bool
+    {
+        return ctype_alpha($char) || $char === '_';
+    }
+
+    private static function isIdentifierContinuation(string $char): bool
+    {
+        return ctype_alnum($char) || $char === '_' || $char === '$';
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlMutationResolver::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 final class PgSqlMutationResolverTest extends TestCase
 {

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -6,9 +6,12 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
+use ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlParser::class)]
+#[UsesClass(PostgreSqlLexicalMasker::class)]
 final class PgSqlParserTest extends TestCase
 {
     public function testClassifySelect(): void
@@ -349,6 +352,46 @@ SELECT * FROM users'));
     {
         $parser = new PgSqlParser();
         self::assertSame('SELECT', $parser->classifyStatement('/* comment */ SELECT 1'));
+    }
+
+    public function testExtractSelectTableAfterBlockComment(): void
+    {
+        $parser = new PgSqlParser();
+        self::assertSame(['my_table'], $parser->extractSelectTableNames('SELECT * FROM/* table */my_table'));
+    }
+
+    public function testExtractSelectTableIgnoresKeywordsInsideLineComment(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = "-- SELECT * FROM other_table WHERE DELETE UPDATE INSERT\nSELECT * FROM items ORDER BY id";
+        self::assertSame(['items'], $parser->extractSelectTableNames($sql));
+    }
+
+    public function testExtractUpdateTableAfterNestedBlockComment(): void
+    {
+        $parser = new PgSqlParser();
+        self::assertSame('my_table', $parser->extractUpdateTable('UPDATE/* outer /* inner */ outer */my_table SET value = 1'));
+    }
+
+    public function testExtractDeleteTableAfterBlockComment(): void
+    {
+        $parser = new PgSqlParser();
+        self::assertSame('my_table', $parser->extractDeleteTable('DELETE FROM/* table */my_table WHERE id = 1'));
+    }
+
+    public function testExtractInsertTableAfterBlockComment(): void
+    {
+        $parser = new PgSqlParser();
+        self::assertSame('my_table', $parser->extractInsertTable('INSERT INTO/* table */my_table VALUES (1)'));
+    }
+
+    public function testCommentMarkersInsideQuotedValuesRemainData(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = 'UPDATE users SET note = \'/* not comment */\', payload = $tag$-- not comment$tag$';
+        $sets = $parser->extractUpdateSets($sql);
+        self::assertSame("'/* not comment */'", $sets['note']);
+        self::assertSame('$tag$-- not comment$tag$', $sets['payload']);
     }
 
     public function testClassifyCreateTempTable(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlQueryGuardTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlQueryGuardTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlQueryGuard::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 final class PgSqlQueryGuardTest extends QueryClassifierContractTest
 {
     protected function classify(string $sql): ?QueryKind

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -37,6 +37,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlRewriter::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(PgSqlQueryGuard::class)]
 #[UsesClass(PgSqlMutationResolver::class)]
@@ -2900,5 +2901,74 @@ final class PgSqlRewriterTest extends RewriterContractTest
         self::assertStringContainsString('"derived" AS MATERIALIZED', $plan->sql());
         self::assertStringContainsString('"x"', $plan->sql());
         self::assertStringContainsString('"y"', $plan->sql());
+    }
+
+    public function testSelectRewritesTableAfterBlockComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1]]);
+        $rewriter = $this->createRewriter($store, $registry);
+
+        $plan = $rewriter->rewrite('SELECT * FROM/* table */users');
+
+        self::assertSame(QueryKind::READ, $plan->kind());
+        self::assertStringContainsString('"users" AS MATERIALIZED', $plan->sql());
+    }
+
+    public function testSelectIgnoresSqlKeywordsInsideLeadingLineComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1]]);
+        $rewriter = $this->createRewriter($store, $registry);
+        $sql = "-- SELECT * FROM other_table WHERE DELETE UPDATE INSERT\nSELECT * FROM users";
+
+        $plan = $rewriter->rewrite($sql);
+
+        self::assertSame(QueryKind::READ, $plan->kind());
+        self::assertStringContainsString('"users" AS MATERIALIZED', $plan->sql());
+        self::assertStringNotContainsString('"other_table" AS MATERIALIZED', $plan->sql());
+    }
+
+    public function testInsertResolvesTargetAfterBlockComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite('INSERT INTO/* table */users (id) VALUES (1)');
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertInstanceOf(InsertMutation::class, $plan->mutation());
+        self::assertSame('users', $plan->mutation()->tableName());
+    }
+
+    public function testUpdateResolvesTargetAfterBlockComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite('UPDATE/* table */users SET id = 2 WHERE id = 1');
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertInstanceOf(UpdateMutation::class, $plan->mutation());
+        self::assertSame('users', $plan->mutation()->tableName());
+    }
+
+    public function testDeleteResolvesTargetAfterBlockComment(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite('DELETE FROM/* table */users WHERE id = 1');
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertInstanceOf(DeleteMutation::class, $plan->mutation());
+        self::assertSame('users', $plan->mutation()->tableName());
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -28,6 +28,7 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 
 #[CoversClass(PgSqlSessionFactory::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(PgSqlQueryGuard::class)]
 #[UsesClass(PgSqlRewriter::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(PgSqlTransformer::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(InsertTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PostgreSqlLexicalMaskerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PostgreSqlLexicalMaskerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker;
+
+#[CoversClass(PostgreSqlLexicalMasker::class)]
+final class PostgreSqlLexicalMaskerTest extends TestCase
+{
+    #[DataProvider('providerComments')]
+    public function testMasksCommentsAsSingleLexicalSeparators(string $sql, string $expected): void
+    {
+        self::assertSame($expected, PostgreSqlLexicalMasker::maskComments($sql));
+    }
+
+    #[DataProvider('providerQuotedForms')]
+    public function testPreservesCommentMarkersInsideQuotedForms(string $quoted, bool $terminated): void
+    {
+        $sql = 'SELECT ' . $quoted . '/* outside */1';
+        $expected = $terminated ? 'SELECT ' . $quoted . ' 1' : $sql;
+
+        self::assertSame($expected, PostgreSqlLexicalMasker::maskComments($sql));
+    }
+
+    public function testPreservesEscapeStringAtStatementStart(): void
+    {
+        $sql = "E'escaped \\' /* protected */'";
+
+        self::assertSame($sql, PostgreSqlLexicalMasker::maskComments($sql));
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerComments(): \Generator
+    {
+        yield 'empty query' => ['', ''];
+        yield 'line comment' => ['SELECT-- comment', 'SELECT '];
+        yield 'line comment with newline' => ["SELECT-- comment\n1", "SELECT \n1"];
+        yield 'line comment with carriage return' => ["SELECT-- comment\r1", "SELECT \r1"];
+        yield 'empty line comment' => ["--\nSELECT", " \nSELECT"];
+        yield 'separated minus signs' => ['SELECT- -1', 'SELECT- -1'];
+        yield 'block comment' => ['SELECT/* comment */1', 'SELECT 1'];
+        yield 'minimal block comment' => ['SELECT/**/1', 'SELECT 1'];
+        yield 'nested block comment' => ['SELECT/* outer /* inner */ outer */1', 'SELECT 1'];
+        yield 'adjacent block comments' => ['SELECT/**//**/1', 'SELECT  1'];
+        yield 'unterminated block comment' => ['SELECT/* comment', 'SELECT '];
+        yield 'unterminated nested block comment' => ['SELECT/* outer /* inner */', 'SELECT '];
+        yield 'separated slash and asterisk' => ['SELECT/ *1', 'SELECT/ *1'];
+        yield 'comment-like closing marker' => ['SELECT*/1', 'SELECT*/1'];
+        yield 'comment closing boundary' => ['SELECT/**/*1', 'SELECT *1'];
+        yield 'comment after identifier E suffix' => ["AE'closed'/* comment */", "AE'closed' "];
+        yield 'comment after uppercase identifier E escape lookalike' => ["ZE'escaped \\'/* comment */1", "ZE'escaped \\' 1"];
+        yield 'comment after lowercase identifier E escape lookalike' => ["zE'escaped \\'/* comment */1", "zE'escaped \\' 1"];
+        yield 'comment after underscore E escape lookalike' => ["_E'escaped \\'/* comment */1", "_E'escaped \\' 1"];
+        yield 'comment after number E suffix' => ["0E'closed'/* comment */", "0E'closed' "];
+        yield 'comment after dollar E suffix' => ["\$E'closed'/* comment */", "\$E'closed' "];
+        yield 'comment after native parameter' => ['$1/* comment */', '$1 '];
+        yield 'comment between invalid numeric tags' => ['$9$/* comment */$9$', '$9$ $9$'];
+        yield 'comment after invalid hyphenated tag' => ['$a-b$/* comment */1', '$a-b$ 1'];
+        yield 'comment after incomplete tag' => ['$tag/* comment */1', '$tag 1'];
+        yield 'incomplete tag at end' => ['$tag', '$tag'];
+        yield 'normal string does not use backslash escapes' => ["'escaped \\'/* comment */1", "'escaped \\' 1"];
+        yield 'qualified identifier E escape lookalike' => ["SELECT AE'escaped \\'/* comment */1", "SELECT AE'escaped \\' 1"];
+        yield 'underscored identifier E escape lookalike' => ["SELECT _AE'escaped \\'/* comment */1", "SELECT _AE'escaped \\' 1"];
+    }
+
+    /**
+     * @return \Generator<string, array{string, bool}>
+     */
+    public static function providerQuotedForms(): \Generator
+    {
+        yield 'single quoted line marker' => ["'-- comment'", true];
+        yield 'single quoted block marker' => ["'/* comment */'", true];
+        yield 'empty single quote' => ["''", true];
+        yield 'doubled single quote' => ["'value''/* comment */'", true];
+        yield 'triple single quote closing run' => ["'value'''", true];
+        yield 'unterminated single quote' => ["'/* comment", false];
+        yield 'double quoted line marker' => ['"-- comment"', true];
+        yield 'double quoted block marker' => ['"/* comment */"', true];
+        yield 'empty double quote' => ['""', true];
+        yield 'doubled double quote' => ['"value""/* comment */"', true];
+        yield 'unterminated double quote' => ['"/* comment', false];
+        yield 'uppercase escape string' => ["E'escaped \\' /* comment */'", true];
+        yield 'lowercase escape string' => ["e'escaped \\' -- comment'", true];
+        yield 'escape string closes immediately after escaped quote' => ["E'\\''", true];
+        yield 'escape string ending in backslash' => ["E'escaped \\", false];
+        yield 'untagged dollar quote' => ['$$/* comment */$$', true];
+        yield 'uppercase boundary dollar tag' => ['$A$-- comment$A$', true];
+        yield 'uppercase ending boundary dollar tag' => ['$Z$-- comment$Z$', true];
+        yield 'lowercase boundary dollar tag' => ['$a$-- comment$a$', true];
+        yield 'lowercase ending boundary dollar tag' => ['$z$-- comment$z$', true];
+        yield 'tagged dollar quote' => ['$tag$-- comment$tag$', true];
+        yield 'delimiter prefix inside dollar quote' => ['$tag$value $tag/* protected */$tag$', true];
+        yield 'identifier dollar quote' => ['$_tag9$/* comment */$_tag9$', true];
+        yield 'unterminated dollar quote' => ['$tag$/* comment */', false];
+        yield 'standalone dollar' => ['$', true];
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -18,6 +18,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 
 #[CoversClass(DeleteTransformer::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -18,6 +18,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 
 #[CoversClass(InsertTransformer::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -18,6 +18,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 
 #[CoversClass(UpdateTransformer::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]


### PR DESCRIPTION
## Summary

- replace leading-comment special handling with a length-preserving lexical comment mask
- recognize PostgreSQL single/E strings, double-quoted identifiers, dollar-quoted values, line comments, and nested block comments
- apply the same normalized token boundaries to statement classification and every PostgreSQL extraction path
- preserve offsets used by WHERE/SELECT extraction by masking comments with equal-length whitespace
- add parser, rewriter, and live PostgreSQL PDO regressions

## Validation

- PostgreSQL unit suite: 1,202 tests, 1,932 assertions
- PostgreSQL finite fuzz: 28 tests, 4,048 assertions
- PostgreSQL and PDO adapter lint/PHPStan pass
- live Testcontainers regression verifies commented SELECT, INSERT, UPDATE, DELETE, a leading UPDATE line comment, and misleading SQL keywords inside comments

Closes #69.
Closes #82.

## Stack

Depends on #192, which fixes the SQLite half of the same issues.