### PR TITLE
Mask PostgreSQL string literals lexically

### DIFF
--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
@@ -398,4 +398,33 @@ final class PostgreSqlCteShadowingTest extends TestCase
         }
     }
 
+    public function testPostgreSqlQuotedStringFormsPreserveWhereOffsets(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'literal_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec(sprintf('CREATE TABLE %s (id INTEGER PRIMARY KEY, body TEXT)', $table));
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+            $ztdPdo->exec(sprintf("INSERT INTO %s VALUES (1, 'original')", $table));
+
+            $ztdPdo->exec(sprintf("UPDATE %s SET body = 'it''s updated' WHERE id = 1", $table));
+            $body = $ztdPdo->query(sprintf('SELECT body FROM %s WHERE id = 1', $table));
+            self::assertNotFalse($body);
+            self::assertSame("it's updated", $body->fetchColumn());
+
+            $ztdPdo->exec(sprintf('UPDATE %s SET body = $text$reference to table$text$ WHERE id = 1', $table));
+            $body = $ztdPdo->query(sprintf('SELECT body FROM %s WHERE id = 1', $table));
+            self::assertNotFalse($body);
+            self::assertSame('reference to table', $body->fetchColumn());
+
+            $ztdPdo->exec(sprintf("UPDATE %s SET body = E'line1\\nline2' WHERE id = 1", $table));
+            $body = $ztdPdo->query(sprintf('SELECT body FROM %s WHERE id = 1', $table));
+            self::assertNotFalse($body);
+            self::assertSame("line1\nline2", $body->fetchColumn());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
 }

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -366,61 +366,13 @@ final class PgSqlParser
             return null;
         }
 
-        $strippedOffset = $m[0][1];
-        $originalOffset = $this->mapStrippedOffsetToOriginal($sql, $stripped, $strippedOffset);
-
-        $whereClause = substr($sql, $originalOffset + strlen('WHERE'));
+        $whereClause = substr($sql, $m[0][1] + strlen('WHERE'));
         $strippedTail = $this->stripStringLiterals($whereClause);
         if (preg_match('/\s+(?:RETURNING|ORDER\s+BY|LIMIT)\b/is', $strippedTail, $tailMatch, PREG_OFFSET_CAPTURE) === 1) {
-            $tailOffset = $this->mapStrippedOffsetToOriginal($whereClause, $strippedTail, $tailMatch[0][1]);
-            $whereClause = substr($whereClause, 0, $tailOffset);
+            $whereClause = substr_replace($whereClause, '', $tailMatch[0][1]);
         }
 
         return trim($whereClause);
-    }
-
-    /**
-     * Map an offset in a stripped string back to the corresponding position in the original.
-     */
-    private function mapStrippedOffsetToOriginal(string $original, string $stripped, int $strippedOffset): int
-    {
-        if (strlen($original) === strlen($stripped)) {
-            return $strippedOffset;
-        }
-
-        $origLen = strlen($original);
-        $stripLen = strlen($stripped);
-        $si = 0;
-        $oi = 0;
-
-        while ($si < $strippedOffset && $oi < $origLen && $si < $stripLen) {
-            $char = $original[$oi];
-
-            if ($char === "'") {
-                $oi++;
-                while ($oi < $origLen) {
-                    if ($original[$oi] === '\\') {
-                        $oi += 2;
-                        continue;
-                    }
-                    if ($original[$oi] === "'") {
-                        if ($oi + 1 < $origLen && $original[$oi + 1] === "'") {
-                            $oi += 2;
-                            continue;
-                        }
-                        $oi++;
-                        break;
-                    }
-                    $oi++;
-                }
-                $si += 2;
-            } else {
-                $oi++;
-                $si++;
-            }
-        }
-
-        return $oi;
     }
 
     /**
@@ -957,11 +909,7 @@ final class PgSqlParser
 
     private function stripStringLiterals(string $sql): string
     {
-        $result = preg_replace("/E?'(?:[^'\\\\]|\\\\.)*'/", "''", $sql);
-        $result = $result !== null ? $result : $sql;
-        $result = preg_replace('/\$\w*\$.*?\$\w*\$/s', "''", $result);
-
-        return $result !== null ? $result : $sql;
+        return PostgreSqlLexicalMasker::maskStringLiterals($sql);
     }
 
     private function extractDollarTag(string $sql, int $pos): ?string

--- a/packages/ztd-query-postgres/src/PostgreSqlLexicalMasker.php
+++ b/packages/ztd-query-postgres/src/PostgreSqlLexicalMasker.php
@@ -6,6 +6,39 @@ namespace ZtdQuery\Platform\Postgres;
 
 final class PostgreSqlLexicalMasker
 {
+    public static function maskStringLiterals(string $sql): string
+    {
+        $result = '';
+        $length = strlen($sql);
+        $i = 0;
+
+        while ($i < $length) {
+            $char = $sql[$i];
+            if ($char === '\'') {
+                $tail = substr($sql, $i);
+                $quotedLength = self::quotedLength($tail, $char, self::isEscapeStringStart($sql, $i));
+                $result .= str_repeat(' ', $quotedLength);
+                $i += $quotedLength;
+                continue;
+            }
+
+            if ($char === '$' && self::isDollarQuoteStart($sql, $i)) {
+                $tail = substr($sql, $i);
+                $quotedLength = self::dollarQuotedLength($tail);
+                if ($quotedLength !== null) {
+                    $result .= str_repeat(' ', $quotedLength);
+                    $i += $quotedLength;
+                    continue;
+                }
+            }
+
+            $result .= $char;
+            $i++;
+        }
+
+        return $result;
+    }
+
     public static function maskComments(string $sql): string
     {
         $result = '';
@@ -23,7 +56,7 @@ final class PostgreSqlLexicalMasker
                 continue;
             }
 
-            if ($char === '$') {
+            if ($char === '$' && self::isDollarQuoteStart($sql, $i)) {
                 $tail = substr($sql, $i);
                 $quotedLength = self::dollarQuotedLength($tail);
                 if ($quotedLength !== null) {
@@ -135,6 +168,11 @@ final class PostgreSqlLexicalMasker
         }
 
         return substr($sql, 0, $i) . '$';
+    }
+
+    private static function isDollarQuoteStart(string $sql, int $position): bool
+    {
+        return $position === 0 || !self::isIdentifierContinuation($sql[$position - 1]);
     }
 
     private static function isEscapeStringStart(string $sql, int $quotePosition): bool

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -394,6 +394,34 @@ SELECT * FROM users'));
         self::assertSame('$tag$-- not comment$tag$', $sets['payload']);
     }
 
+    public function testExtractWhereClauseAfterDoubledQuoteString(): void
+    {
+        $parser = new PgSqlParser();
+        $where = $parser->extractWhereClause("UPDATE test SET body = 'it''s updated' WHERE id = 1");
+        self::assertSame('id = 1', $where);
+    }
+
+    public function testExtractWhereClauseAfterDollarQuotedString(): void
+    {
+        $parser = new PgSqlParser();
+        $where = $parser->extractWhereClause('UPDATE notes SET body = $$reference to notes table$$ WHERE id = 1');
+        self::assertSame('id = 1', $where);
+    }
+
+    public function testExtractWhereClauseAfterTaggedDollarQuotedString(): void
+    {
+        $parser = new PgSqlParser();
+        $where = $parser->extractWhereClause('UPDATE notes SET body = $text$WHERE id = fake$text$ WHERE id = 1');
+        self::assertSame('id = 1', $where);
+    }
+
+    public function testExtractWhereClauseAfterEscapeString(): void
+    {
+        $parser = new PgSqlParser();
+        $where = $parser->extractWhereClause("UPDATE docs SET content = E'line1\\nline2' WHERE id = 1");
+        self::assertSame('id = 1', $where);
+    }
+
     public function testClassifyCreateTempTable(): void
     {
         $parser = new PgSqlParser();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -2971,4 +2971,40 @@ final class PgSqlRewriterTest extends RewriterContractTest
         self::assertInstanceOf(DeleteMutation::class, $plan->mutation());
         self::assertSame('users', $plan->mutation()->tableName());
     }
+
+    public function testUpdatePreservesDoubledQuoteStringBeforeWhere(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('notes', new TableDefinition(['id', 'body'], ['id' => 'INTEGER', 'body' => 'TEXT'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite("UPDATE notes SET body = 'it''s updated' WHERE id = 1");
+
+        self::assertStringContainsString("'it''s updated' AS \"body\"", $plan->sql());
+        self::assertStringContainsString('WHERE id = 1', $plan->sql());
+    }
+
+    public function testUpdatePreservesDollarQuotedStringBeforeWhere(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('notes', new TableDefinition(['id', 'body'], ['id' => 'INTEGER', 'body' => 'TEXT'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite('UPDATE notes SET body = $$reference to notes table$$ WHERE id = 1');
+
+        self::assertStringContainsString('$$reference to notes table$$ AS "body"', $plan->sql());
+        self::assertStringContainsString('WHERE id = 1', $plan->sql());
+    }
+
+    public function testUpdatePreservesEscapeStringBeforeWhere(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('notes', new TableDefinition(['id', 'body'], ['id' => 'INTEGER', 'body' => 'TEXT'], ['id'], [], []));
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $plan = $rewriter->rewrite("UPDATE notes SET body = E'line1\\nline2' WHERE id = 1");
+
+        self::assertStringContainsString("E'line1\\nline2' AS \"body\"", $plan->sql());
+        self::assertStringContainsString('WHERE id = 1', $plan->sql());
+    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PostgreSqlLexicalMaskerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PostgreSqlLexicalMaskerTest.php
@@ -34,6 +34,14 @@ final class PostgreSqlLexicalMaskerTest extends TestCase
         self::assertSame($sql, PostgreSqlLexicalMasker::maskComments($sql));
     }
 
+    #[DataProvider('providerStringLiterals')]
+    public function testMasksStringLiteralsWithoutChangingOffsets(string $sql, string $expected): void
+    {
+        $masked = PostgreSqlLexicalMasker::maskStringLiterals($sql);
+        self::assertSame($expected, $masked);
+        self::assertSame(strlen($sql), strlen($masked));
+    }
+
     /**
      * @return \Generator<string, array{string, string}>
      */
@@ -65,9 +73,13 @@ final class PostgreSqlLexicalMaskerTest extends TestCase
         yield 'comment after invalid hyphenated tag' => ['$a-b$/* comment */1', '$a-b$ 1'];
         yield 'comment after incomplete tag' => ['$tag/* comment */1', '$tag 1'];
         yield 'incomplete tag at end' => ['$tag', '$tag'];
+        yield 'standalone dollar at end' => ['$', '$'];
         yield 'normal string does not use backslash escapes' => ["'escaped \\'/* comment */1", "'escaped \\' 1"];
         yield 'qualified identifier E escape lookalike' => ["SELECT AE'escaped \\'/* comment */1", "SELECT AE'escaped \\' 1"];
         yield 'underscored identifier E escape lookalike' => ["SELECT _AE'escaped \\'/* comment */1", "SELECT _AE'escaped \\' 1"];
+        yield 'identifier-attached dollar tag is not quoted' => ['name$tag$/* comment */$tag$', 'name$tag$ $tag$'];
+        yield 'digit-attached dollar tag is not quoted' => ['0$tag$/* comment */$tag$', '0$tag$ $tag$'];
+        yield 'underscore-attached dollar tag is not quoted' => ['_$tag$/* comment */$tag$', '_$tag$ $tag$'];
     }
 
     /**
@@ -100,5 +112,32 @@ final class PostgreSqlLexicalMaskerTest extends TestCase
         yield 'identifier dollar quote' => ['$_tag9$/* comment */$_tag9$', true];
         yield 'unterminated dollar quote' => ['$tag$/* comment */', false];
         yield 'standalone dollar' => ['$', true];
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerStringLiterals(): \Generator
+    {
+        yield 'empty query' => ['', ''];
+        yield 'empty string' => ["''", '  '];
+        yield 'single quoted string' => ["SELECT 'WHERE' FROM name", 'SELECT ' . str_repeat(' ', 7) . ' FROM name'];
+        yield 'doubled single quote' => ["'value''WHERE' FROM name", str_repeat(' ', 14) . ' FROM name'];
+        yield 'unterminated string' => ["'WHERE", str_repeat(' ', 6)];
+        yield 'uppercase escape string' => ["E'escaped \\' WHERE' FROM name", 'E' . str_repeat(' ', 18) . ' FROM name'];
+        yield 'lowercase escape string' => ["e'escaped \\' WHERE' FROM name", 'e' . str_repeat(' ', 18) . ' FROM name'];
+        yield 'standard backslash does not escape quote' => ["'closed \\' WHERE name", str_repeat(' ', 10) . ' WHERE name'];
+        yield 'untagged dollar quote' => ['$$WHERE$$ FROM name', str_repeat(' ', 9) . ' FROM name'];
+        yield 'tagged dollar quote' => ['$tag$WHERE$tag$ FROM name', str_repeat(' ', 15) . ' FROM name'];
+        yield 'prefixed untagged dollar quote' => ['SELECT $$WHERE$$ FROM name', 'SELECT ' . str_repeat(' ', 9) . ' FROM name'];
+        yield 'prefixed tagged dollar quote' => ['SELECT $tag$WHERE$tag$ FROM name', 'SELECT ' . str_repeat(' ', 15) . ' FROM name'];
+        yield 'unterminated dollar quote' => ['$tag$WHERE', str_repeat(' ', 10)];
+        yield 'double quoted identifier' => ['"WHERE" FROM name', '"WHERE" FROM name'];
+        yield 'native parameter' => ['$1 FROM name', '$1 FROM name'];
+        yield 'invalid numeric tag' => ['$9$WHERE$9$ FROM name', '$9$WHERE$9$ FROM name'];
+        yield 'identifier-attached tag' => ['name$tag$WHERE$tag$ FROM name', 'name$tag$WHERE$tag$ FROM name'];
+        yield 'digit-attached tag' => ['0$tag$WHERE$tag$ FROM name', '0$tag$WHERE$tag$ FROM name'];
+        yield 'underscore-attached tag' => ['_$tag$WHERE$tag$ FROM name', '_$tag$WHERE$tag$ FROM name'];
+        yield 'newlines preserve length' => ["'line1\nline2' FROM name", str_repeat(' ', 13) . ' FROM name'];
     }
 }


### PR DESCRIPTION
## Summary

- replace regex-based PostgreSQL string stripping with a length-preserving lexical scan
- recognize doubled-quote strings, E strings with backslash escapes, bit/hex/Unicode prefixes, and tagged or untagged dollar quotes
- preserve newlines and byte offsets while masking literal contents
- remove the obsolete offset remapping algorithm; WHERE/tail offsets now map directly to the original SQL
- add parser properties, rewriter regressions, and a live PostgreSQL PDO roundtrip

## Validation

- PostgreSQL unit suite: 1,210 tests, 1,945 assertions
- PostgreSQL finite fuzz: 28 tests, 4,048 assertions
- PostgreSQL and PDO adapter lint/PHPStan pass
- live PostgreSQL regression updates and reads doubled-quote, tagged dollar-quote, and E-string values

Closes #25.
Closes #88.
Closes #89.

## Stack

Depends on #193.