### PR TITLE
Ignore SQLite table names inside strings

### DIFF
--- a/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
@@ -474,4 +474,24 @@ final class SqliteCteShadowingTest extends TestCase
         self::assertNotFalse($ids);
         self::assertSame([1], $ids->fetchAll(\PDO::FETCH_COLUMN));
     }
+
+    public function testSqliteStringLiteralsDoNotCreateTableReferences(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $rawPdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+        $ztdPdo->exec("INSERT INTO items VALUES (1, 'test')");
+
+        $lower = $ztdPdo->query("SELECT id, 'from items' AS label FROM items LIMIT 1");
+        self::assertNotFalse($lower);
+        self::assertSame([['id' => 1, 'label' => 'from items']], $lower->fetchAll());
+
+        $upper = $ztdPdo->query("SELECT id, 'FROM items' AS label FROM items LIMIT 1");
+        self::assertNotFalse($upper);
+        self::assertSame([['id' => 1, 'label' => 'FROM items']], $upper->fetchAll());
+
+        $join = $ztdPdo->query("SELECT id, 'join items' AS label FROM items LIMIT 1");
+        self::assertNotFalse($join);
+        self::assertSame([['id' => 1, 'label' => 'join items']], $join->fetchAll());
+    }
 }

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -207,6 +207,7 @@ final class SqliteParser
     public function extractSelectTables(string $sql): array
     {
         $sql = $this->stripComments($sql);
+        $sql = $this->maskStringLiterals($sql);
         $tables = [];
 
         if (preg_match('/\bFROM\s+(.+?)(?:\s+WHERE\b|\s+GROUP\s+BY\b|\s+HAVING\b|\s+ORDER\s+BY\b|\s+LIMIT\b|\s+UNION\b|$)/is', $sql, $matches) === 1) {
@@ -397,6 +398,39 @@ final class SqliteParser
     public function stripComments(string $sql): string
     {
         return trim(SqliteLexicalMasker::maskComments($sql));
+    }
+
+    public function maskStringLiterals(string $sql): string
+    {
+        $result = '';
+        $length = strlen($sql);
+        $i = 0;
+
+        while ($i < $length) {
+            if ($sql[$i] !== '\'') {
+                $result .= $sql[$i++];
+                continue;
+            }
+
+            $start = $i++;
+            while (true) {
+                $end = strpos($sql, '\'', $i);
+                if ($end === false) {
+                    $i = $length;
+                    break;
+                }
+                $i = $end;
+                if (str_starts_with(substr($sql, $i), "''")) {
+                    $i += 2;
+                    continue;
+                }
+                $i++;
+                break;
+            }
+            $result .= str_repeat(' ', $i - $start);
+        }
+
+        return $result;
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
+use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Rewrite\SqlTransformer;
@@ -22,11 +23,13 @@ final class SelectTransformer implements SqlTransformer
 {
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
+    private SqliteParser $parser;
 
     public function __construct(?CastRenderer $castRenderer = null, ?IdentifierQuoter $quoter = null)
     {
         $this->castRenderer = $castRenderer ?? new SqliteCastRenderer();
         $this->quoter = $quoter ?? new SqliteIdentifierQuoter();
+        $this->parser = new SqliteParser();
     }
 
     /**
@@ -34,9 +37,10 @@ final class SelectTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
+        $searchableSql = $this->parser->maskStringLiterals($this->parser->stripComments($sql));
         $ctes = [];
         foreach ($tables as $tableName => $tableContext) {
-            if (stripos($sql, $tableName) === false) {
+            if (stripos($searchableSql, $tableName) === false) {
                 continue;
             }
 

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -381,6 +381,61 @@ SELECT * FROM users'));
         self::assertSame(['items'], $parser->extractSelectTables($sql));
     }
 
+    public function testExtractSelectTableIgnoresFromInsideStringLiteral(): void
+    {
+        $parser = new SqliteParser();
+        $sql = "SELECT id, 'from other_table' AS label FROM items LIMIT 1";
+        self::assertSame(['items'], $parser->extractSelectTables($sql));
+    }
+
+    public function testExtractSelectTableIgnoresJoinInsideStringLiteral(): void
+    {
+        $parser = new SqliteParser();
+        $sql = "SELECT id, 'JOIN other_table' AS label FROM items LIMIT 1";
+        self::assertSame(['items'], $parser->extractSelectTables($sql));
+    }
+
+    public function testStringLiteralMaskPreservesOffsetsAndQuotedIdentifiers(): void
+    {
+        $parser = new SqliteParser();
+        $sql = "SELECT 'FROM hidden', \"quoted\", `backtick`, [bracket] FROM items";
+        $masked = $parser->maskStringLiterals($sql);
+        self::assertSame(strlen($sql), strlen($masked));
+        self::assertSame(strpos($sql, 'FROM items'), strpos($masked, 'FROM items'));
+        self::assertStringContainsString('"quoted"', $masked);
+        self::assertStringContainsString('`backtick`', $masked);
+        self::assertStringContainsString('[bracket]', $masked);
+    }
+
+    #[DataProvider('providerStringLiteralMasks')]
+    public function testMaskStringLiteralsUsesSqliteQuoteBoundaries(string $sql, string $expected): void
+    {
+        $parser = new SqliteParser();
+        $masked = $parser->maskStringLiterals($sql);
+        self::assertSame($expected, $masked);
+        self::assertSame(strlen($sql), strlen($masked));
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerStringLiteralMasks(): \Generator
+    {
+        yield 'empty query' => ['', ''];
+        yield 'query without strings' => ['SELECT value FROM items', 'SELECT value FROM items'];
+        yield 'empty string' => ["''", '  '];
+        yield 'single quoted string' => ["SELECT 'FROM hidden' FROM items", 'SELECT ' . str_repeat(' ', 13) . ' FROM items'];
+        yield 'doubled single quote' => ["'value''FROM' FROM items", str_repeat(' ', 13) . ' FROM items'];
+        yield 'doubled quote before closing quote' => ["'a''' FROM items", str_repeat(' ', 5) . ' FROM items'];
+        yield 'unterminated string' => ["'FROM hidden", str_repeat(' ', 12)];
+        yield 'multiple strings' => ["'FROM' || 'JOIN' FROM items", str_repeat(' ', 6) . ' || ' . str_repeat(' ', 6) . ' FROM items'];
+        yield 'newline in string' => ["'FROM\nJOIN' FROM items", str_repeat(' ', 11) . ' FROM items'];
+        yield 'double quoted identifier' => ['"FROM" FROM items', '"FROM" FROM items'];
+        yield 'backtick identifier' => ['`FROM` FROM items', '`FROM` FROM items'];
+        yield 'bracket identifier' => ['[FROM] FROM items', '[FROM] FROM items'];
+        yield 'backslash does not escape quote' => ["'closed \\' FROM items", str_repeat(' ', 10) . ' FROM items'];
+    }
+
     public function testExtractUpdateTargetAcrossBlockComment(): void
     {
         $parser = new SqliteParser();

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -11,6 +11,8 @@ use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
+use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
+use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\Transformer\SelectTransformer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -19,6 +21,8 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[CoversClass(SelectTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
+#[UsesClass(SqliteLexicalMasker::class)]
+#[UsesClass(SqliteParser::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
     protected function createTransformer(): SqlTransformer
@@ -112,6 +116,29 @@ final class SelectTransformerTest extends TransformerContractTest
 
         self::assertStringContainsString('"users"', $result);
         self::assertStringNotContainsString('"orders"', $result);
+    }
+
+    public function testTransformSkipsTableMentionedOnlyInsideStringLiteral(): void
+    {
+        $transformer = new SelectTransformer();
+        $tables = [
+            'items' => [
+                'rows' => [['id' => 1]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+            'users' => [
+                'rows' => [['id' => 2]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        $result = $transformer->transform("SELECT id, 'FROM items' AS label FROM users", $tables);
+
+        self::assertStringContainsString('"users" AS', $result);
+        self::assertStringNotContainsString('"items" AS', $result);
+        self::assertStringContainsString("'FROM items' AS label", $result);
     }
 
     public function testTransformWithExistingCte(): void


### PR DESCRIPTION
## Summary

- add a length-preserving SQLite single-quoted string mask
- use the mask while extracting SELECT table references
- make the SELECT transformer search only comment/string-free SQL when deciding which shadow CTEs to emit
- preserve original literal text and quoted identifiers in the rewritten SQL
- add parser, transformer, and SQLite PDO end-to-end regressions for lower/upper-case FROM and JOIN text

## Validation

- SQLite unit suite: 1,096 tests, 1,955 assertions
- SQLite finite fuzz: 28 tests, 4,069 assertions
- SQLite and PDO adapter lint/PHPStan pass
- SQLite PDO regression returns the expected row and unchanged labels for all reported patterns

Closes #67.

## Stack

Depends on #194.