### PR TITLE
Parse schema constraint keywords as tokens

### DIFF
--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
@@ -529,4 +529,17 @@ final class MySqlSchemaParserTest extends SchemaParserContractTest
         self::assertSame('unique_0', $keys[0]);
         self::assertSame('unique_1', $keys[1]);
     }
+
+    public function testConstraintKeywordPrefixesRemainColumnNames(): void
+    {
+        $schemaParser = new MySqlSchemaParser(new MySqlParser());
+        $sql = 'CREATE TABLE bookings (id INT, check_in TEXT, checkout_date TEXT, unique_value TEXT, constraint_name TEXT, foreign_key_id INT)';
+        $definition = $schemaParser->parse($sql);
+
+        self::assertNotNull($definition);
+        self::assertSame(
+            ['id', 'check_in', 'checkout_date', 'unique_value', 'constraint_name', 'foreign_key_id'],
+            $definition->columns,
+        );
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
@@ -427,4 +427,33 @@ final class PostgreSqlCteShadowingTest extends TestCase
         }
     }
 
+    public function testInsertWithoutColumnListSupportsConstraintKeywordPrefixes(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'booking_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec(sprintf('CREATE TABLE %s (id INT PRIMARY KEY, guest TEXT, check_in TEXT, check_out TEXT)', $table));
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+            self::assertSame(1, $ztdPdo->exec(sprintf(
+                "INSERT INTO %s VALUES (1, 'Alice', '2024-01-01', '2024-01-03')",
+                $table,
+            )));
+
+            $bookings = $ztdPdo->query(sprintf('SELECT * FROM %s', $table));
+            self::assertNotFalse($bookings);
+            self::assertSame([
+                [
+                    'id' => 1,
+                    'guest' => 'Alice',
+                    'check_in' => '2024-01-01',
+                    'check_out' => '2024-01-03',
+                ],
+            ], $bookings->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
@@ -494,4 +494,24 @@ final class SqliteCteShadowingTest extends TestCase
         self::assertNotFalse($join);
         self::assertSame([['id' => 1, 'label' => 'join items']], $join->fetchAll());
     }
+
+    public function testInsertWithoutColumnListSupportsConstraintKeywordPrefixes(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $rawPdo->exec('CREATE TABLE bookings (id INT PRIMARY KEY, guest TEXT, check_in TEXT, check_out TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+        self::assertSame(1, $ztdPdo->exec("INSERT INTO bookings VALUES (1, 'Alice', '2024-01-01', '2024-01-03')"));
+
+        $bookings = $ztdPdo->query('SELECT * FROM bookings');
+        self::assertNotFalse($bookings);
+        self::assertSame([
+            [
+                'id' => 1,
+                'guest' => 'Alice',
+                'check_in' => '2024-01-01',
+                'check_out' => '2024-01-03',
+            ],
+        ], $bookings->fetchAll());
+    }
 }

--- a/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
@@ -274,14 +274,17 @@ final class PgSqlSchemaParser implements SchemaParser
 
     private function isConstraintEntry(string $entry): bool
     {
-        $upper = strtoupper(ltrim($entry));
+        $length = strspn($entry, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$');
+        $leadingKeyword = strtoupper(substr($entry, 0, $length));
 
-        return str_starts_with($upper, 'CONSTRAINT ')
-            || str_starts_with($upper, 'PRIMARY KEY')
-            || str_starts_with($upper, 'UNIQUE')
-            || str_starts_with($upper, 'CHECK')
-            || str_starts_with($upper, 'FOREIGN KEY')
-            || str_starts_with($upper, 'EXCLUDE');
+        return in_array($leadingKeyword, [
+            'CONSTRAINT',
+            'PRIMARY',
+            'UNIQUE',
+            'CHECK',
+            'FOREIGN',
+            'EXCLUDE',
+        ], true);
     }
 
     /**

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
@@ -1614,4 +1614,18 @@ final class PgSqlSchemaParserTest extends SchemaParserContractTest
         self::assertNotNull($def);
         self::assertSame(['id'], $def->primaryKeys);
     }
+
+    public function testConstraintKeywordPrefixesRemainColumnNames(): void
+    {
+        $parser = new PgSqlSchemaParser();
+        $sql = 'CREATE TABLE bookings (id INT, check_in TEXT, checkout_date TEXT, unique_value TEXT, constraint_name TEXT, foreign_key_id INT, exclude_reason TEXT, "CHECK" TEXT,   PRIMARY KEY (id))';
+        $def = $parser->parse($sql);
+
+        self::assertNotNull($def);
+        self::assertSame(
+            ['id', 'check_in', 'checkout_date', 'unique_value', 'constraint_name', 'foreign_key_id', 'exclude_reason', 'CHECK'],
+            $def->columns,
+        );
+        self::assertSame(['id'], $def->primaryKeys);
+    }
 }

--- a/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
@@ -45,9 +45,9 @@ final class SqliteSchemaParser implements SchemaParser
                 continue;
             }
 
-            $upperDef = strtoupper(ltrim($def));
+            $leadingKeyword = $this->leadingKeyword($def);
 
-            if (str_starts_with($upperDef, 'PRIMARY KEY')) {
+            if ($leadingKeyword === 'PRIMARY') {
                 if (preg_match('/^PRIMARY\s+KEY\s*\(([^)]+)\)/i', $def, $pkMatches) === 1) {
                     $pkCols = $this->parseColumnNameList($pkMatches[1]);
                     $primaryKeys = array_merge($primaryKeys, $pkCols);
@@ -55,7 +55,7 @@ final class SqliteSchemaParser implements SchemaParser
                 continue;
             }
 
-            if (str_starts_with($upperDef, 'UNIQUE')) {
+            if ($leadingKeyword === 'UNIQUE') {
                 if (preg_match('/^UNIQUE\s*\(([^)]+)\)/i', $def, $uniqueMatches) === 1) {
                     $uniqueCols = $this->parseColumnNameList($uniqueMatches[1]);
                     if ($uniqueCols !== []) {
@@ -66,7 +66,7 @@ final class SqliteSchemaParser implements SchemaParser
                 continue;
             }
 
-            if (str_starts_with($upperDef, 'CONSTRAINT')) {
+            if ($leadingKeyword === 'CONSTRAINT') {
                 if (preg_match('/^CONSTRAINT\s+(?:"(?:[^"]|"")*"|`(?:[^`]|``)*`|[^\s]+)\s+PRIMARY\s+KEY\s*\(([^)]+)\)/i', $def, $pkMatches) === 1) {
                     $pkCols = $this->parseColumnNameList($pkMatches[1]);
                     $primaryKeys = array_merge($primaryKeys, $pkCols);
@@ -81,7 +81,7 @@ final class SqliteSchemaParser implements SchemaParser
                 continue;
             }
 
-            if (str_starts_with($upperDef, 'FOREIGN KEY') || str_starts_with($upperDef, 'CHECK')) {
+            if ($leadingKeyword === 'FOREIGN' || $leadingKeyword === 'CHECK') {
                 continue;
             }
 
@@ -229,20 +229,21 @@ final class SqliteSchemaParser implements SchemaParser
         }
 
         $rest = trim(substr($def, strlen($matches[1])));
-        $upperRest = strtoupper($rest);
+        $leadingKeyword = $this->leadingKeyword($rest);
 
         $type = null;
-        if ($rest !== '' && !str_starts_with($upperRest, 'PRIMARY')
-            && !str_starts_with($upperRest, 'NOT')
-            && !str_starts_with($upperRest, 'UNIQUE')
-            && !str_starts_with($upperRest, 'CHECK')
-            && !str_starts_with($upperRest, 'DEFAULT')
-            && !str_starts_with($upperRest, 'REFERENCES')
-            && !str_starts_with($upperRest, 'CONSTRAINT')
-            && !str_starts_with($upperRest, 'COLLATE')
-            && !str_starts_with($upperRest, 'GENERATED')
-            && !str_starts_with($upperRest, 'AS')
-        ) {
+        if (!in_array($leadingKeyword, [
+            'PRIMARY',
+            'NOT',
+            'UNIQUE',
+            'CHECK',
+            'DEFAULT',
+            'REFERENCES',
+            'CONSTRAINT',
+            'COLLATE',
+            'GENERATED',
+            'AS',
+        ], true)) {
             $type = $this->extractColumnType($rest);
         }
 
@@ -258,6 +259,12 @@ final class SqliteSchemaParser implements SchemaParser
             'primaryKey' => $primaryKey,
             'unique' => $unique,
         ];
+    }
+
+    private function leadingKeyword(string $sql): string
+    {
+        $length = strspn($sql, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$');
+        return strtoupper(substr($sql, 0, $length));
     }
 
     /**

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
@@ -1905,4 +1905,17 @@ final class SqliteSchemaParserTest extends SchemaParserContractTest
         self::assertSame('TEXT', $result->columnTypes['col one']);
         self::assertSame('INTEGER', $result->columnTypes['col two']);
     }
+
+    public function testConstraintKeywordPrefixesRemainColumnNames(): void
+    {
+        $parser = new SqliteSchemaParser();
+        $sql = 'CREATE TABLE bookings (id INT, check_in TEXT, checkout_date TEXT, unique_value TEXT, constraint_name TEXT, foreign_key_id INT)';
+        $result = $parser->parse($sql);
+
+        self::assertNotNull($result);
+        self::assertSame(
+            ['id', 'check_in', 'checkout_date', 'unique_value', 'constraint_name', 'foreign_key_id'],
+            $result->columns,
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- classify table constraints by the complete leading identifier token
- preserve columns whose names begin with CHECK and other constraint keywords
- cover SQLite and PostgreSQL through live PDO inserts and guard MySQL behavior

## Verification
- MySQL: 888 tests, 2,218 assertions; lint and PHPStan pass
- PostgreSQL: 1,211 tests, 1,947 assertions; finite fuzz 4,048 assertions; lint and PHPStan pass
- SQLite: 1,097 tests, 1,957 assertions; finite fuzz 4,069 assertions; lint and PHPStan pass
- PDO adapter unit, SQLite integration, PostgreSQL integration, lint and PHPStan pass

Closes #70