### PR TITLE
Tokenize INSERT source clauses

### DIFF
--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
@@ -456,4 +456,40 @@ final class PostgreSqlCteShadowingTest extends TestCase
         }
     }
 
+    public function testQuotedInsertSourceKeywordsRemainIdentifiers(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $rawPdo->exec('CREATE TABLE "select" (id INTEGER PRIMARY KEY, val TEXT)');
+            $rawPdo->exec('CREATE TABLE "values" (id INTEGER PRIMARY KEY, val TEXT)');
+            $rawPdo->exec('CREATE TABLE keyword_columns (id INTEGER PRIMARY KEY, "select" TEXT, "values" TEXT)');
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO \"select\" VALUES (1, 'table-select')"));
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO \"values\" VALUES (2, 'table-values')"));
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO keyword_columns (id, \"select\", \"values\") VALUES (3, 'column-select', 'column-values')"));
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO \"select\" SELECT 4 AS id, 'insert-select' AS val"));
+
+            $selectRows = $ztdPdo->query('SELECT * FROM "select" ORDER BY id');
+            self::assertNotFalse($selectRows);
+            self::assertSame([
+                ['id' => 1, 'val' => 'table-select'],
+                ['id' => 4, 'val' => 'insert-select'],
+            ], $selectRows->fetchAll());
+
+            $valuesRows = $ztdPdo->query('SELECT * FROM "values"');
+            self::assertNotFalse($valuesRows);
+            self::assertSame([['id' => 2, 'val' => 'table-values']], $valuesRows->fetchAll());
+
+            $columnRows = $ztdPdo->query('SELECT id, "select", "values" FROM keyword_columns');
+            self::assertNotFalse($columnRows);
+            self::assertSame([
+                ['id' => 3, 'select' => 'column-select', 'values' => 'column-values'],
+            ], $columnRows->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
@@ -514,4 +514,35 @@ final class SqliteCteShadowingTest extends TestCase
             ],
         ], $bookings->fetchAll());
     }
+
+    public function testQuotedInsertSourceKeywordsRemainIdentifiers(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $rawPdo->exec('CREATE TABLE "select" (id INTEGER PRIMARY KEY, val TEXT)');
+        $rawPdo->exec('CREATE TABLE "values" (id INTEGER PRIMARY KEY, val TEXT)');
+        $rawPdo->exec('CREATE TABLE keyword_columns (id INTEGER PRIMARY KEY, "select" TEXT, "values" TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+        self::assertSame(1, $ztdPdo->exec("INSERT INTO \"select\" VALUES (1, 'table-select')"));
+        self::assertSame(1, $ztdPdo->exec("INSERT INTO \"values\" VALUES (2, 'table-values')"));
+        self::assertSame(1, $ztdPdo->exec("INSERT INTO keyword_columns (id, \"select\", \"values\") VALUES (3, 'column-select', 'column-values')"));
+        self::assertSame(1, $ztdPdo->exec("INSERT INTO \"select\" SELECT 4 AS id, 'insert-select' AS val"));
+
+        $selectRows = $ztdPdo->query('SELECT * FROM "select" ORDER BY id');
+        self::assertNotFalse($selectRows);
+        self::assertSame([
+            ['id' => 1, 'val' => 'table-select'],
+            ['id' => 4, 'val' => 'insert-select'],
+        ], $selectRows->fetchAll());
+
+        $valuesRows = $ztdPdo->query('SELECT * FROM "values"');
+        self::assertNotFalse($valuesRows);
+        self::assertSame([['id' => 2, 'val' => 'table-values']], $valuesRows->fetchAll());
+
+        $columnRows = $ztdPdo->query('SELECT id, "select", "values" FROM keyword_columns');
+        self::assertNotFalse($columnRows);
+        self::assertSame([
+            ['id' => 3, 'select' => 'column-select', 'values' => 'column-values'],
+        ], $columnRows->fetchAll());
+    }
 }

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -201,11 +201,15 @@ final class PgSqlParser
     {
         $sql = $this->maskComments($sql);
         $rows = [];
-        if (preg_match('/\bVALUES\s*(\(.+)/is', $sql, $m) !== 1) {
+        $source = $this->findInsertSourceClause($sql);
+        if ($source === null) {
+            return [];
+        }
+        if ($source['keyword'] !== 'VALUES') {
             return [];
         }
 
-        $rest = $m[1];
+        $rest = substr($sql, $source['offset'] + strlen($source['keyword']));
         $pos = 0;
         $len = strlen($rest);
 
@@ -278,12 +282,9 @@ final class PgSqlParser
     public function hasInsertSelect(string $sql): bool
     {
         $sql = $this->maskComments($sql);
-        $stripped = $this->stripStringLiterals($sql);
-        if (preg_match('/\bVALUES\b/i', $stripped) === 1) {
-            return false;
-        }
+        $source = $this->findInsertSourceClause($sql);
 
-        return preg_match('/INSERT\s+INTO\s+.*?\bSELECT\b/is', $stripped) === 1;
+        return $source !== null && $source['keyword'] === 'SELECT';
     }
 
     /**
@@ -292,11 +293,9 @@ final class PgSqlParser
     public function extractInsertSelectSql(string $sql): ?string
     {
         $sql = $this->maskComments($sql);
-        $stripped = $this->stripStringLiterals($sql);
-        if (preg_match('/\bSELECT\b/i', $stripped, $m, PREG_OFFSET_CAPTURE) === 1) {
-            $offset = $m[0][1];
-
-            return substr($sql, $offset);
+        $source = $this->findInsertSourceClause($sql);
+        if ($source !== null && $source['keyword'] === 'SELECT') {
+            return substr($sql, $source['offset']);
         }
 
         return null;
@@ -910,6 +909,63 @@ final class PgSqlParser
     private function stripStringLiterals(string $sql): string
     {
         return PostgreSqlLexicalMasker::maskStringLiterals($sql);
+    }
+
+    /**
+     * @return array{keyword: string, offset: int}|null
+     */
+    private function findInsertSourceClause(string $sql): ?array
+    {
+        $searchable = $this->stripStringLiterals($sql);
+        $length = strlen($searchable);
+        $depth = 0;
+        $foundInsert = false;
+
+        for ($i = 0; $i < $length; $i++) {
+            if ($searchable[$i] === '"') {
+                for ($i++; $i < $length; $i++) {
+                    if ($searchable[$i] !== '"') {
+                        continue;
+                    }
+                    break;
+                }
+                continue;
+            }
+
+            if ($searchable[$i] === '(') {
+                $depth++;
+                continue;
+            }
+
+            if ($searchable[$i] === ')') {
+                if ($depth > 0) {
+                    $depth--;
+                }
+                continue;
+            }
+
+            $tokenLength = strspn(
+                $searchable,
+                'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$',
+                $i,
+            );
+            if ($tokenLength === 0) {
+                continue;
+            }
+
+            if ($depth === 0 && ctype_alpha($searchable[$i])) {
+                $keyword = strtoupper(substr($searchable, $i, $tokenLength));
+                if (!$foundInsert) {
+                    $foundInsert = $keyword === 'INSERT';
+                } elseif ($keyword === 'VALUES' || $keyword === 'SELECT') {
+                    return ['keyword' => $keyword, 'offset' => $i];
+                }
+            }
+
+            $i += $tokenLength - 1;
+        }
+
+        return null;
     }
 
     private function extractDollarTag(string $sql, int $pos): ?string

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -3451,4 +3451,74 @@ SELECT * FROM users'));
         self::assertCount(1, $rows);
         self::assertCount(2, $rows[0]);
     }
+
+    public function testInsertValuesSourceIgnoresQuotedKeywordIdentifiers(): void
+    {
+        $parser = new PgSqlParser();
+        $tableSelect = "INSERT INTO \"select\" (id, val) VALUES (1, 'table-select')";
+        $tableValues = "INSERT INTO \"values\" (id, val) VALUES (2, 'table-values')";
+        $columnKeywords = "INSERT INTO test (id, \"select\", \"values\") VALUES (3, 'column-select', 'column-values')";
+
+        self::assertFalse($parser->hasInsertSelect($tableSelect));
+        self::assertNull($parser->extractInsertSelectSql($tableSelect));
+        self::assertSame([['1', "'table-select'"]], $parser->extractInsertValues($tableSelect));
+        self::assertFalse($parser->hasInsertSelect($tableValues));
+        self::assertNull($parser->extractInsertSelectSql($tableValues));
+        self::assertSame([['2', "'table-values'"]], $parser->extractInsertValues($tableValues));
+        self::assertFalse($parser->hasInsertSelect($columnKeywords));
+        self::assertNull($parser->extractInsertSelectSql($columnKeywords));
+        self::assertSame([['3', "'column-select'", "'column-values'"]], $parser->extractInsertValues($columnKeywords));
+    }
+
+    public function testInsertSelectSourceStartsAfterQuotedKeywordIdentifiers(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = 'INSERT INTO "select" ("select", "values") SELECT 1, 2';
+
+        self::assertTrue($parser->hasInsertSelect($sql));
+        self::assertSame('SELECT 1, 2', $parser->extractInsertSelectSql($sql));
+    }
+
+    public function testInsertSourceRequiresInsertStatement(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertSame([], $parser->extractInsertValues('SELECT VALUES (1)'));
+        self::assertSame([], $parser->extractInsertValues('VALUES (1)'));
+        self::assertFalse($parser->hasInsertSelect('VALUES SELECT 1'));
+        self::assertNull($parser->extractInsertSelectSql('VALUES SELECT 1'));
+    }
+
+    public function testInsertSourceHandlesQuotedIdentifierBoundaries(): void
+    {
+        $parser = new PgSqlParser();
+        $escapedIdentifier = 'INSERT INTO "quoted""select" ("values""column") SELECT 1';
+        $unterminatedIdentifier = 'INSERT INTO "unterminated SELECT 1';
+
+        self::assertTrue($parser->hasInsertSelect($escapedIdentifier));
+        self::assertSame('SELECT 1', $parser->extractInsertSelectSql($escapedIdentifier));
+        self::assertFalse($parser->hasInsertSelect($unterminatedIdentifier));
+        self::assertNull($parser->extractInsertSelectSql($unterminatedIdentifier));
+        self::assertSame([], $parser->extractInsertValues($unterminatedIdentifier));
+        self::assertFalse($parser->hasInsertSelect(''));
+    }
+
+    public function testInsertSourceDoesNotUnderflowParenthesisDepth(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = ') INSERT INTO target SELECT 1';
+
+        self::assertTrue($parser->hasInsertSelect($sql));
+        self::assertSame('SELECT 1', $parser->extractInsertSelectSql($sql));
+    }
+
+    public function testInsertSourceIgnoresNestedKeywordBeforeValues(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = 'INSERT INTO target (SELECT ignored) VALUES (1)';
+
+        self::assertFalse($parser->hasInsertSelect($sql));
+        self::assertNull($parser->extractInsertSelectSql($sql));
+        self::assertSame([['1']], $parser->extractInsertValues($sql));
+    }
 }

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -259,13 +259,15 @@ final class SqliteParser
     public function extractInsertValues(string $sql): array
     {
         $sql = $this->stripComments($sql);
-        $upper = strtoupper($sql);
-        $valuesPos = strpos($upper, 'VALUES');
-        if ($valuesPos === false) {
+        $source = $this->findInsertSourceClause($sql);
+        if ($source === null) {
+            return [];
+        }
+        if ($source['keyword'] !== 'VALUES') {
             return [];
         }
 
-        $rest = substr($sql, $valuesPos + 6);
+        $rest = substr($sql, $source['offset'] + strlen($source['keyword']));
 
         return $this->parseValueSets($rest);
     }
@@ -376,7 +378,9 @@ final class SqliteParser
     public function hasInsertSelect(string $sql): bool
     {
         $sql = $this->stripComments($sql);
-        return preg_match('/\bINTO\s+(?:"(?:[^"]|"")*"|[^\s(]+)\s*(?:\([^)]*\)\s*)?SELECT\b/i', $sql) === 1;
+        $source = $this->findInsertSourceClause($sql);
+
+        return $source !== null && $source['keyword'] === 'SELECT';
     }
 
     /**
@@ -385,8 +389,9 @@ final class SqliteParser
     public function extractInsertSelect(string $sql): ?string
     {
         $sql = $this->stripComments($sql);
-        if (preg_match('/\bINTO\s+(?:"(?:[^"]|"")*"|[^\s(]+)\s*(?:\([^)]*\)\s*)?(SELECT\b.+)$/is', $sql, $matches) === 1) {
-            return trim($matches[1]);
+        $source = $this->findInsertSourceClause($sql);
+        if ($source !== null && $source['keyword'] === 'SELECT') {
+            return substr($sql, $source['offset']);
         }
 
         return null;
@@ -460,7 +465,7 @@ final class SqliteParser
     }
 
     /**
-     * @return array<int, array{keyword: string, afterGroup: bool}>
+     * @return array<int, array{keyword: string, afterGroup: bool, offset: int}>
      */
     private function scanTopLevelKeywords(string $sql): array
     {
@@ -527,6 +532,7 @@ final class SqliteParser
                 continue;
             }
 
+            $start = $i;
             $tokenLength = strspn($sql, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$', $i);
             if ($tokenLength === 0) {
                 continue;
@@ -538,11 +544,35 @@ final class SqliteParser
                 $keywords[] = [
                     'keyword' => strtoupper($token),
                     'afterGroup' => $completedGroup,
+                    'offset' => $start,
                 ];
             }
         }
 
         return $keywords;
+    }
+
+    /**
+     * @return array{keyword: string, offset: int}|null
+     */
+    private function findInsertSourceClause(string $sql): ?array
+    {
+        $foundInsert = false;
+        foreach ($this->scanTopLevelKeywords($sql) as $token) {
+            if (!$foundInsert) {
+                $foundInsert = $token['keyword'] === 'INSERT' || $token['keyword'] === 'REPLACE';
+                continue;
+            }
+
+            if ($token['keyword'] === 'VALUES' || $token['keyword'] === 'SELECT') {
+                return [
+                    'keyword' => $token['keyword'],
+                    'offset' => $token['offset'],
+                ];
+            }
+        }
+
+        return null;
     }
 
     private function extractInsertTable(string $sql): ?string

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -2804,4 +2804,60 @@ SELECT * FROM users'));
         $parser = new SqliteParser();
         self::assertSame('t', $parser->extractTargetTable('replace t values (1)'));
     }
+
+    public function testInsertValuesSourceIgnoresQuotedKeywordIdentifiers(): void
+    {
+        $parser = new SqliteParser();
+        $tableSelect = "INSERT INTO \"select\" (id, val) VALUES (1, 'table-select')";
+        $tableValues = "INSERT INTO \"values\" (id, val) VALUES (2, 'table-values')";
+        $columnKeywords = "INSERT INTO test (id, \"select\", \"values\") VALUES (3, 'column-select', 'column-values')";
+
+        self::assertFalse($parser->hasInsertSelect($tableSelect));
+        self::assertNull($parser->extractInsertSelect($tableSelect));
+        self::assertSame([['1', "'table-select'"]], $parser->extractInsertValues($tableSelect));
+        self::assertFalse($parser->hasInsertSelect($tableValues));
+        self::assertNull($parser->extractInsertSelect($tableValues));
+        self::assertSame([['2', "'table-values'"]], $parser->extractInsertValues($tableValues));
+        self::assertFalse($parser->hasInsertSelect($columnKeywords));
+        self::assertNull($parser->extractInsertSelect($columnKeywords));
+        self::assertSame([['3', "'column-select'", "'column-values'"]], $parser->extractInsertValues($columnKeywords));
+    }
+
+    public function testInsertSelectSourceStartsAfterQuotedKeywordIdentifiers(): void
+    {
+        $parser = new SqliteParser();
+        $sql = 'INSERT INTO "select" ("select", "values") SELECT 1, 2';
+
+        self::assertTrue($parser->hasInsertSelect($sql));
+        self::assertSame('SELECT 1, 2', $parser->extractInsertSelect($sql));
+    }
+
+    public function testInsertSourceRequiresInsertOrReplaceStatement(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame([], $parser->extractInsertValues('SELECT VALUES (1)'));
+        self::assertSame([], $parser->extractInsertValues('VALUES (1)'));
+        self::assertFalse($parser->hasInsertSelect('VALUES SELECT 1'));
+        self::assertNull($parser->extractInsertSelect('VALUES SELECT 1'));
+    }
+
+    public function testReplaceUsesValuesAndSelectSources(): void
+    {
+        $parser = new SqliteParser();
+        $values = 'REPLACE INTO target VALUES (1)';
+        $select = 'REPLACE INTO target SELECT 1';
+
+        self::assertSame([['1']], $parser->extractInsertValues($values));
+        self::assertFalse($parser->hasInsertSelect($values));
+        self::assertTrue($parser->hasInsertSelect($select));
+        self::assertSame('SELECT 1', $parser->extractInsertSelect($select));
+    }
+
+    public function testInsertSelectSourceTrimsTrailingWhitespace(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame('SELECT 1', $parser->extractInsertSelect("INSERT INTO target SELECT 1 \n\t"));
+    }
 }


### PR DESCRIPTION
## Summary
- locate INSERT VALUES and SELECT sources through quote-aware top-level token scanning
- keep quoted SELECT and VALUES table or column names as identifiers
- apply the same root fix to SQLite and PostgreSQL and verify both through live PDO sessions

## Verification
- PostgreSQL: 1,213 tests, 1,958 assertions; finite fuzz 4,048 assertions; lint and PHPStan pass
- SQLite: 1,099 tests, 1,968 assertions; finite fuzz 4,069 assertions; lint and PHPStan pass
- SQLite and PostgreSQL PDO integration: quoted tables, quoted columns, VALUES, and INSERT SELECT pass
- PDO adapter lint and PHPStan pass

Closes #86