### PR TITLE
Escape PostgreSQL JSON operators for PDO

### DIFF
--- a/packages/ztd-query-pdo-adapter/src/PostgreSqlPlaceholderEscaper.php
+++ b/packages/ztd-query-pdo-adapter/src/PostgreSqlPlaceholderEscaper.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Pdo;
+
+final class PostgreSqlPlaceholderEscaper
+{
+    public static function escape(string $sql): string
+    {
+        $result = '';
+        $length = strlen($sql);
+        $expectsOperand = true;
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $sql[$i];
+            $next = $i + 1 < $length ? $sql[$i + 1] : '';
+
+            if (ctype_space($char)) {
+                $result .= $char;
+                continue;
+            }
+
+            if ($char === '-' && $next === '-') {
+                $commentLength = strcspn($sql, "\r\n", $i);
+                $result .= substr($sql, $i, $commentLength);
+                $i += $commentLength - 1;
+                continue;
+            }
+
+            if ($char === '/' && $next === '*') {
+                $start = $i;
+                $scan = $i;
+                $depth = 0;
+                while (true) {
+                    $open = strpos($sql, '/*', $scan);
+                    $close = strpos($sql, '*/', $scan);
+                    $openPosition = $open === false ? $length : $open;
+                    $closePosition = $close === false ? $length : $close;
+                    $markerPosition = min($openPosition, $closePosition);
+                    if ($markerPosition === $length) {
+                        $scan = $length;
+                        break;
+                    }
+                    $scan = $markerPosition + 2;
+                    if (substr($sql, $markerPosition, 2) === '/*') {
+                        $depth++;
+                        continue;
+                    }
+                    $depth--;
+                    if ($depth === 0) {
+                        break;
+                    }
+                }
+                $result .= substr($sql, $start, $scan - $start);
+                $i = $scan - 1;
+                continue;
+            }
+
+            if ($char === '\'' || $char === '"') {
+                $quote = $char;
+                $escapeBackslash = $quote === '\'' && self::isEscapeStringStart($sql, $i);
+                $result .= $char;
+                for ($i++; $i < $length; $i++) {
+                    $result .= $sql[$i];
+                    if ($escapeBackslash && $sql[$i] === '\\') {
+                        $escapedCharacter = substr($sql, $i + 1, 1);
+                        $result .= $escapedCharacter;
+                        $i += strlen($escapedCharacter);
+                        continue;
+                    }
+                    if ($sql[$i] !== $quote) {
+                        continue;
+                    }
+                    if (substr($sql, $i, 2) === $quote . $quote) {
+                        $result .= $sql[++$i];
+                        continue;
+                    }
+                    break;
+                }
+                $expectsOperand = false;
+                continue;
+            }
+
+            if ($char === '$') {
+                $delimiter = self::dollarQuoteDelimiter($sql, $i);
+                if ($delimiter !== null) {
+                    $end = strpos($sql, $delimiter, $i + strlen($delimiter));
+                    if ($end === false) {
+                        $result .= substr($sql, $i);
+                        break;
+                    }
+                    $quotedLength = $end + strlen($delimiter) - $i;
+                    $result .= substr($sql, $i, $quotedLength);
+                    $i += $quotedLength - 1;
+                    $expectsOperand = false;
+                    continue;
+                }
+            }
+
+            if ($char === '?') {
+                if ($next === '?') {
+                    $result .= '??';
+                    $i++;
+                    $expectsOperand = true;
+                    continue;
+                }
+                if ($next === '|' || $next === '&') {
+                    $result .= '??' . $next;
+                    $i++;
+                    $expectsOperand = true;
+                    continue;
+                }
+                if ($expectsOperand) {
+                    $result .= '?';
+                    $expectsOperand = false;
+                    continue;
+                }
+
+                $result .= '??';
+                $expectsOperand = true;
+                continue;
+            }
+
+            if ($char === ':') {
+                if ($next === ':') {
+                    $result .= '::';
+                    $i++;
+                    $expectsOperand = true;
+                    continue;
+                }
+            }
+
+            if (self::isIdentifierStart($char)) {
+                $colonPrefixed = str_ends_with($result, ':');
+                $wordLength = strspn($sql, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789$', $i);
+                $word = substr($sql, $i, $wordLength);
+                $result .= $word;
+                $i += $wordLength - 1;
+                $expectsOperand = !$colonPrefixed && self::keywordExpectsOperand(strtoupper($word));
+                continue;
+            }
+
+            if (ctype_digit($char)) {
+                $numberLength = strspn($sql, '0123456789.', $i);
+                $result .= substr($sql, $i, $numberLength);
+                $i += $numberLength - 1;
+                $expectsOperand = false;
+                continue;
+            }
+
+            $result .= $char;
+            $expectsOperand = match ($char) {
+                ')', ']' => false,
+                '(', '[', ',', ';', '.', '=', '<', '>', '!', '~', '+', '-', '*', '/', '%', '^', '|', '&', '#', '@' => true,
+                default => $expectsOperand,
+            };
+        }
+
+        return $result;
+    }
+
+    private static function keywordExpectsOperand(string $keyword): bool
+    {
+        return in_array($keyword, [
+            'ALL',
+            'AND',
+            'ANY',
+            'AS',
+            'BETWEEN',
+            'BY',
+            'CASE',
+            'CONFLICT',
+            'DELETE',
+            'DISTINCT',
+            'DO',
+            'ELSE',
+            'FIRST',
+            'FROM',
+            'HAVING',
+            'ILIKE',
+            'IN',
+            'INSERT',
+            'INTO',
+            'IS',
+            'JOIN',
+            'LAST',
+            'LIKE',
+            'LIMIT',
+            'NOT',
+            'OFFSET',
+            'ON',
+            'OR',
+            'RETURNING',
+            'SELECT',
+            'SET',
+            'SIMILAR',
+            'SOME',
+            'THEN',
+            'UPDATE',
+            'USING',
+            'VALUE',
+            'VALUES',
+            'WHEN',
+            'WHERE',
+            'ZONE',
+        ], true);
+    }
+
+    private static function isIdentifierStart(string $char): bool
+    {
+        return $char >= 'A' && $char <= 'Z'
+            || $char >= 'a' && $char <= 'z'
+            || $char === '_';
+    }
+
+    private static function isIdentifierContinuation(string $char): bool
+    {
+        return self::isIdentifierStart($char)
+            || ctype_digit($char)
+            || $char === '$';
+    }
+
+    private static function isEscapeStringStart(string $sql, int $quotePosition): bool
+    {
+        $prefix = substr($sql, 0, $quotePosition);
+
+        return (str_ends_with($prefix, 'E') || str_ends_with($prefix, 'e'))
+            && (strlen($prefix) === 1 || !self::isIdentifierContinuation(substr($prefix, -2, 1)));
+    }
+
+    private static function dollarQuoteDelimiter(string $sql, int $position): ?string
+    {
+        $length = strlen($sql);
+        $i = $position + 1;
+        if ($i < $length && $sql[$i] === '$') {
+            return '$$';
+        }
+        if ($i >= $length || !self::isIdentifierStart($sql[$i])) {
+            return null;
+        }
+
+        while ($i < $length && (self::isIdentifierStart($sql[$i]) || ctype_digit($sql[$i]))) {
+            $i++;
+        }
+        if ($i >= $length || $sql[$i] !== '$') {
+            return null;
+        }
+
+        return substr($sql, $position, $i - $position) . '$';
+    }
+}

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
@@ -172,7 +172,12 @@ class ZtdPdo extends PDO
             throw new ZtdPdoException($e->getMessage(), 0, $e);
         }
 
-        $stmt = $this->pdo->prepare($plan->sql(), $options);
+        $preparedSql = $plan->sql();
+        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
+            $preparedSql = PostgreSqlPlaceholderEscaper::escape($preparedSql);
+        }
+
+        $stmt = $this->pdo->prepare($preparedSql, $options);
         if ($stmt === false) {
             return false;
         }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
@@ -492,4 +492,41 @@ final class PostgreSqlCteShadowingTest extends TestCase
         }
     }
 
+    public function testJsonExistenceOperatorsRemainDistinctFromPlaceholders(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'json_docs_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec(sprintf('CREATE TABLE %s (id INTEGER PRIMARY KEY, name TEXT, meta JSONB)', $table));
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+            $ztdPdo->exec(sprintf("INSERT INTO %s VALUES (1, 'Doc A', '{\"author\":\"Alice\",\"reviewed\":true}'::jsonb)", $table));
+            $ztdPdo->exec(sprintf("INSERT INTO %s VALUES (2, 'Doc B', '{\"author\":\"Bob\"}'::jsonb)", $table));
+
+            $exists = $ztdPdo->query(sprintf("SELECT name FROM %s WHERE meta ? 'reviewed'", $table));
+            self::assertNotFalse($exists);
+            self::assertSame(['Doc A'], $exists->fetchAll(\PDO::FETCH_COLUMN));
+
+            $existsAny = $ztdPdo->query(sprintf("SELECT name FROM %s WHERE meta ?| array['reviewed', 'missing']", $table));
+            self::assertNotFalse($existsAny);
+            self::assertSame(['Doc A'], $existsAny->fetchAll(\PDO::FETCH_COLUMN));
+
+            $existsAll = $ztdPdo->query(sprintf("SELECT name FROM %s WHERE meta ?& array['author', 'reviewed']", $table));
+            self::assertNotFalse($existsAll);
+            self::assertSame(['Doc A'], $existsAll->fetchAll(\PDO::FETCH_COLUMN));
+
+            $preparedOperator = $ztdPdo->prepare(sprintf('SELECT name FROM %s WHERE meta ? ? ORDER BY name', $table));
+            self::assertNotFalse($preparedOperator);
+            self::assertTrue($preparedOperator->execute(['author']));
+            self::assertSame(['Doc A', 'Doc B'], $preparedOperator->fetchAll(\PDO::FETCH_COLUMN));
+
+            $preparedValue = $ztdPdo->prepare(sprintf('SELECT name FROM %s WHERE id = ?', $table));
+            self::assertNotFalse($preparedValue);
+            self::assertTrue($preparedValue->execute([2]));
+            self::assertSame(['Doc B'], $preparedValue->fetchAll(\PDO::FETCH_COLUMN));
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
 }

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PostgreSqlPlaceholderEscaperTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PostgreSqlPlaceholderEscaperTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\PostgreSqlPlaceholderEscaper;
+
+#[CoversClass(PostgreSqlPlaceholderEscaper::class)]
+final class PostgreSqlPlaceholderEscaperTest extends TestCase
+{
+    public function testEscapesPostgreSqlJsonExistenceOperators(): void
+    {
+        $sql = "SELECT meta ? 'reviewed', meta ?| array['author', 'reviewed'], meta ?& array['author', 'reviewed'] FROM docs";
+
+        self::assertSame(
+            "SELECT meta ?? 'reviewed', meta ??| array['author', 'reviewed'], meta ??& array['author', 'reviewed'] FROM docs",
+            PostgreSqlPlaceholderEscaper::escape($sql),
+        );
+    }
+
+    public function testPreservesPositionalPlaceholdersInOperandPositions(): void
+    {
+        $sql = 'SELECT ? FROM docs WHERE id = ? AND score BETWEEN ? AND ? ORDER BY ? LIMIT ? OFFSET ?';
+
+        self::assertSame($sql, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    public function testDistinguishesJsonOperatorFromItsPlaceholderOperand(): void
+    {
+        $sql = 'SELECT * FROM docs WHERE meta ? ? AND details ? :key AND id = ?';
+
+        self::assertSame(
+            'SELECT * FROM docs WHERE meta ?? ? AND details ?? :key AND id = ?',
+            PostgreSqlPlaceholderEscaper::escape($sql),
+        );
+    }
+
+    public function testLeavesQuotedAndCommentedQuestionMarksUntouched(): void
+    {
+        $sql = "SELECT '?' AS literal, \"?\" FROM docs -- ?\nWHERE body = \$tag\$?\$tag\$ AND meta ? 'key' /* ? */";
+
+        self::assertSame(
+            "SELECT '?' AS literal, \"?\" FROM docs -- ?\nWHERE body = \$tag\$?\$tag\$ AND meta ?? 'key' /* ? */",
+            PostgreSqlPlaceholderEscaper::escape($sql),
+        );
+    }
+
+    public function testPreservesAlreadyEscapedOperatorAndNativeParameters(): void
+    {
+        $sql = "SELECT * FROM docs WHERE meta ?? ? AND id = \$1 AND note = E'question\\'? mark'";
+
+        self::assertSame($sql, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    #[DataProvider('providerQuestionMarkBoundaries')]
+    public function testHandlesQuestionMarkBoundaries(string $sql, string $expected): void
+    {
+        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    #[DataProvider('providerCommentForms')]
+    public function testPreservesQuestionMarksInCommentForms(string $sql, string $expected): void
+    {
+        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    #[DataProvider('providerQuotedForms')]
+    public function testPreservesQuestionMarksInQuotedForms(string $sql, string $expected): void
+    {
+        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    #[DataProvider('providerDollarQuotedStringsAndNativeParameters')]
+    public function testPreservesDollarQuotedStringsAndNativeParameters(string $sql, string $expected): void
+    {
+        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    #[DataProvider('providerOperands')]
+    public function testTracksNamedParametersIdentifiersAndNumbersAsOperands(string $sql, string $expected): void
+    {
+        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    #[DataProvider('providerKeywords')]
+    public function testKeywordsRequireAFollowingOperand(string $sql): void
+    {
+        self::assertSame($sql, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    #[DataProvider('providerPunctuation')]
+    public function testPunctuationDeterminesWhetherAnOperandFollows(string $sql, string $expected): void
+    {
+        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerQuestionMarkBoundaries(): \Generator
+    {
+        yield 'empty query' => ['', ''];
+        yield 'placeholder' => ['?', '?'];
+        yield 'escaped question mark' => ['??', '??'];
+        yield 'any operator' => ['?|', '??|'];
+        yield 'all operator' => ['?&', '??&'];
+        yield 'operator after operand' => ['meta ?', 'meta ??'];
+        yield 'operator with placeholder operand' => ['meta ? ?', 'meta ?? ?'];
+        yield 'alternating operators and placeholders' => ['meta ? ? ?', 'meta ?? ? ??'];
+        yield 'escaped operator with placeholder' => ['meta ?? ?', 'meta ?? ?'];
+        yield 'any operator with placeholder' => ["meta ?| ? 'key'", "meta ??| ? 'key'"];
+        yield 'all operator with placeholder' => ["meta ?& ? 'key'", "meta ??& ? 'key'"];
+        yield 'opening parenthesis' => ['(?', '(?'];
+        yield 'opening bracket' => ['[?', '[?'];
+        yield 'colon' => ['meta : ?', 'meta : ??'];
+        yield 'cast with placeholder' => ['meta::? ?', 'meta::? ??'];
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerCommentForms(): \Generator
+    {
+        yield 'line comment' => ['-- ?', '-- ?'];
+        yield 'line comment with carriage return' => ["-- ?\rSELECT ?", "-- ?\rSELECT ?"];
+        yield 'line comment preserving state before newline' => ["meta--meta ?\n? 'key'", "meta--meta ?\n?? 'key'"];
+        yield 'line comment preserving state before carriage return' => ["meta--meta ?\r? 'key'", "meta--meta ?\r?? 'key'"];
+        yield 'line comment at end of input' => ['meta--meta ?', 'meta--meta ?'];
+        yield 'separated minus signs' => ['meta- -meta ?', 'meta- -meta ??'];
+        yield 'block comment' => ['/* ? */ SELECT ?', '/* ? */ SELECT ?'];
+        yield 'nested block comment' => ['/* outer ? /* nested ? */ tail ? */ SELECT ?', '/* outer ? /* nested ? */ tail ? */ SELECT ?'];
+        yield 'block comment preserving state' => ["meta/*meta ?*/? 'key'", "meta/*meta ?*/?? 'key'"];
+        yield 'empty block comment' => ["meta/**/? 'key'", "meta/**/?? 'key'"];
+        yield 'nested block comment preserving state' => ["meta/*outer /* inner meta ? */ outer meta ?*/? 'key'", "meta/*outer /* inner meta ? */ outer meta ?*/?? 'key'"];
+        yield 'minimal block comment' => ['/**/', '/**/'];
+        yield 'unterminated minimal block comment' => ['/*/', '/*/'];
+        yield 'unterminated block comment ending in asterisk' => ['/**', '/**'];
+        yield 'unterminated nested block comment' => ['/*/*/', '/*/*/'];
+        yield 'closed nested block comment' => ['/*/**/*/', '/*/**/*/'];
+        yield 'unterminated block comment' => ['SELECT 1 /* unterminated ?', 'SELECT 1 /* unterminated ?'];
+        yield 'unterminated block comment preserving state' => ['meta/*unterminated meta ?', 'meta/*unterminated meta ?'];
+        yield 'separated slash and asterisk' => ["meta/ *meta ?*/? 'key'", "meta/ *meta ??*/? 'key'"];
+        yield 'comment between operator operands' => ["meta /* ? */ ? 'key'", "meta /* ? */ ?? 'key'"];
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerQuotedForms(): \Generator
+    {
+        yield 'single quoted question mark' => ["'?' ? 'key'", "'?' ?? 'key'"];
+        yield 'single quoted expression' => ["'meta ?' ? 'key'", "'meta ?' ?? 'key'"];
+        yield 'doubled single quote' => ["'it''s ?' ? 'key'", "'it''s ?' ?? 'key'"];
+        yield 'expression after doubled single quote' => ["'meta ''nested ?' ? 'key'", "'meta ''nested ?' ?? 'key'"];
+        yield 'double quoted question mark' => ["\"?\" ? 'key'", "\"?\" ?? 'key'"];
+        yield 'double quoted expression' => ["\"meta ?\" ? 'key'", "\"meta ?\" ?? 'key'"];
+        yield 'doubled double quote' => ["\"a\"\"?\" ? 'key'", "\"a\"\"?\" ?? 'key'"];
+        yield 'expression after doubled double quote' => ["\"meta \"\"nested ?\" ? 'key'", "\"meta \"\"nested ?\" ?? 'key'"];
+        yield 'uppercase escape string' => ["E'meta \\' quoted ?' ? 'key'", "E'meta \\' quoted ?' ?? 'key'"];
+        yield 'lowercase escape string' => ["e'meta \\' quoted ?' ? 'key'", "e'meta \\' quoted ?' ?? 'key'"];
+        yield 'escape string after whitespace' => [" E'meta \\' quoted ?' ? 'key'", " E'meta \\' quoted ?' ?? 'key'"];
+        yield 'escape string after operator' => ["!E'meta \\' quoted ?' ? 'key'", "!E'meta \\' quoted ?' ?? 'key'"];
+        yield 'standard string backslash is not an escape' => ["'\\' meta ?' ? 'key'", "'\\' meta ??' ? 'key'"];
+        yield 'quoted identifier backslash is not an escape' => ['"meta \\" rest ?" ? \'key\'', '"meta \\" rest ??" ? \'key\''];
+        yield 'escape string ending in backslash' => ["E'meta \\", "E'meta \\"];
+        yield 'escaped quote before trailing question mark' => ["E'abc \\'?", "E'abc \\'?"];
+        yield 'escaped character before closing quote' => ["E'\\a'?", "E'\\a'??"];
+        yield 'escape semantics survive doubled quote' => ["E'a''\\' meta ?' ? 'key'", "E'a''\\' meta ?' ?? 'key'"];
+        yield 'identifier E suffix is not an escape prefix' => ["AE'meta \\' quoted ?' ? 'key'", "AE'meta \\' quoted ??' ? 'key'"];
+        yield 'prefixed identifier E suffix is not an escape prefix' => ["!AE'meta \\' quoted ?' ? 'key'", "!AE'meta \\' quoted ??' ? 'key'"];
+        yield 'operator delimits an escape prefix' => ["A!E'meta \\' quoted ?' ? 'key'", "A!E'meta \\' quoted ?' ?? 'key'"];
+        yield 'number E suffix is not an escape prefix' => ["0E'meta \\' quoted ?' ? 'key'", "0E'meta \\' quoted ??' ? 'key'"];
+        yield 'dollar E suffix is not an escape prefix' => ["\$E'meta \\' quoted ?' ? 'key'", "\$E'meta \\' quoted ??' ? 'key'"];
+        yield 'unterminated doubled single quote' => ["'a''", "'a''"];
+        yield 'unterminated doubled double quote' => ['"a""', '"a""'];
+        yield 'unterminated single quote' => ["'unterminated ?", "'unterminated ?"];
+        yield 'unterminated single quoted expression' => ["'unterminated meta ?", "'unterminated meta ?"];
+        yield 'unterminated double quote' => ["\"unterminated ?", "\"unterminated ?"];
+        yield 'unterminated double quoted expression' => ["\"unterminated meta ?", "\"unterminated meta ?"];
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerDollarQuotedStringsAndNativeParameters(): \Generator
+    {
+        yield 'untagged dollar quote' => ["\$\$meta ?\$\$ ? 'key'", "\$\$meta ?\$\$ ?? 'key'"];
+        yield 'unterminated dollar quote' => ["\$tag\$ ?", "\$tag\$ ?"];
+        yield 'prefixed unterminated dollar quote' => ["prefix \$tag\$meta ?", "prefix \$tag\$meta ?"];
+        yield 'tagged dollar quote' => ["\$tag\$meta ?\$tag\$ ? 'key'", "\$tag\$meta ?\$tag\$ ?? 'key'"];
+        yield 'prefixed tagged dollar quote' => ["prefix \$A\$meta ?\$A\$ ? 'key'", "prefix \$A\$meta ?\$A\$ ?? 'key'"];
+        yield 'standalone dollar' => ['$', '$'];
+        yield 'unterminated dollar tag' => ['$A', '$A'];
+        yield 'empty dollar quoted string' => ['$A$', '$A$'];
+        yield 'empty dollar quote followed by dollar identifier' => ['$A$$A$B$?', '$A$$A$B$??'];
+        yield 'one digit native parameter' => ["\$1 ? ?", "\$1 ?? ?"];
+        yield 'two digit native parameter' => ["\$19 ? ?", "\$19 ?? ?"];
+        yield 'zero native parameter boundary' => ["\$0? 'key'", "\$0?? 'key'"];
+        yield 'nine native parameter boundary' => ["\$9? 'key'", "\$9?? 'key'"];
+        yield 'ten native parameter boundary' => ["\$10? 'key'", "\$10?? 'key'"];
+        yield 'ninety native parameter boundary' => ["\$90? 'key'", "\$90?? 'key'"];
+        yield 'invalid numeric dollar tag' => ["\$9\$ ? 'key'", "\$9\$ ?? 'key'"];
+
+        foreach (['tag', '_tag', 'A0', 'Z9', 'a0', 'z9'] as $tag) {
+            $sql = sprintf('$%1$s$meta ?$%1$s$ ? \'key\'', $tag);
+            $expected = sprintf('$%1$s$meta ?$%1$s$ ?? \'key\'', $tag);
+            yield $tag => [$sql, $expected];
+        }
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerOperands(): \Generator
+    {
+        foreach ([':name', ':a_b9$', 'A', 'Z', 'a', 'z', '_value', 'value0', 'value9', 'value$', '0', '9', '123.45'] as $operand) {
+            yield $operand . ' separated' => [$operand . " ? 'key'", $operand . " ?? 'key'"];
+        }
+
+        foreach ([':A0', ':Z9', ':a0', ':z9', ':_value', ':value$', 'A', 'Z', 'a', 'z', '_value', 'value0', 'value9', 'value$', '0', '9', '10', '90', '1.', '1.0'] as $operand) {
+            yield $operand . ' adjacent' => [$operand . "? 'key'", $operand . "?? 'key'"];
+        }
+
+        yield 'cast' => ["value::jsonb ? 'key'", "value::jsonb ?? 'key'"];
+        yield 'keyword named parameter' => [":SELECT ? 'key'", ":SELECT ?? 'key'"];
+        yield 'adjacent keyword named parameter' => [":FROM? 'key'", ":FROM?? 'key'"];
+        yield 'standalone colon' => [':', ':'];
+    }
+
+    /**
+     * @return \Generator<string, array{string}>
+     */
+    public static function providerKeywords(): \Generator
+    {
+        $keywords = [
+            'ALL',
+            'AND',
+            'ANY',
+            'AS',
+            'BETWEEN',
+            'BY',
+            'CASE',
+            'CONFLICT',
+            'DELETE',
+            'DISTINCT',
+            'DO',
+            'ELSE',
+            'FIRST',
+            'FROM',
+            'HAVING',
+            'ILIKE',
+            'IN',
+            'INSERT',
+            'INTO',
+            'IS',
+            'JOIN',
+            'LAST',
+            'LIKE',
+            'LIMIT',
+            'NOT',
+            'OFFSET',
+            'ON',
+            'OR',
+            'RETURNING',
+            'SELECT',
+            'SET',
+            'SIMILAR',
+            'SOME',
+            'THEN',
+            'UPDATE',
+            'USING',
+            'VALUE',
+            'VALUES',
+            'WHEN',
+            'WHERE',
+            'ZONE',
+        ];
+
+        foreach ($keywords as $keyword) {
+            yield $keyword . ' uppercase' => [$keyword . ' ?'];
+            yield $keyword . ' lowercase' => [strtolower($keyword) . ' ?'];
+        }
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function providerPunctuation(): \Generator
+    {
+        foreach (['(', '[', ',', ';', '.', '=', '<', '>', '!', '~', '+', '-', '*', '/', '%', '^', '|', '&', '#', '@'] as $prefix) {
+            yield $prefix => ['meta' . $prefix . '?', 'meta' . $prefix . '?'];
+        }
+
+        yield 'closing parenthesis' => ["() ? 'key'", "() ?? 'key'"];
+        yield 'closing bracket' => ["[] ? 'key'", "[] ?? 'key'"];
+    }
+}


### PR DESCRIPTION
## Summary
- escape PostgreSQL JSON existence operators only at PDO prepare boundaries
- distinguish infix operators from positional placeholders with a quote-aware lexical state machine
- preserve question marks inside strings, identifiers, dollar quotes, comments, and already escaped SQL

## Verification
- PDO adapter unit: 37 tests, 70 assertions
- live PostgreSQL: query with ?, ?|, and ?&; prepared JSON operator plus placeholder; normal positional placeholder
- PDO adapter format and PHPStan pass

PHP PDO documents doubled question marks as the PostgreSQL operator escape: https://www.php.net/manual/en/pdo.prepare.php

Closes #48