### PR TITLE
Use fixed Infection path handling across packages

### DIFF
--- a/packages/ztd-query-core/composer.json
+++ b/packages/ztd-query-core/composer.json
@@ -11,7 +11,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.92",
         "phpunit/phpunit": "^10.5 || ^11 || ^12 || ^13",
-        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
+        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32 || ^0.34.1",
         "k-kinzal/phpstan-custom-rules": "@dev",
         "brianium/paratest": "^6.11 || ^7"
     },

--- a/packages/ztd-query-mysql/composer.json
+++ b/packages/ztd-query-mysql/composer.json
@@ -16,7 +16,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5 || ^11 || ^12 || >=13.0 <13.3",
         "brianium/paratest": "^6.11 || ^7",
-        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
+        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32 || ^0.34.1",
         "k-kinzal/phpstan-custom-rules": "@dev",
         "phpbench/phpbench": "^1.4"
     },

--- a/packages/ztd-query-mysqli-adapter/composer.json
+++ b/packages/ztd-query-mysqli-adapter/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.92",
-        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
+        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32 || ^0.34.1",
         "k-kinzal/sql-faker": "@dev",
         "k-kinzal/sql-fixture": "@dev",
         "k-kinzal/testcontainers-php": "^0.5.1",

--- a/packages/ztd-query-pdo-adapter/composer.json
+++ b/packages/ztd-query-pdo-adapter/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.92",
-        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
+        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32 || ^0.34.1",
         "k-kinzal/sql-faker": "@dev",
         "k-kinzal/sql-fixture": "@dev",
         "k-kinzal/testcontainers-php": "^0.5.1",

--- a/packages/ztd-query-sqlite/composer.json
+++ b/packages/ztd-query-sqlite/composer.json
@@ -14,7 +14,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5 || ^11 || ^12 || >=13.0 <13.3",
-        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
+        "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32 || ^0.34.1",
         "brianium/paratest": "^6.11 || ^7",
         "k-kinzal/phpstan-custom-rules": "@dev",
         "phpbench/phpbench": "^1.4"


### PR DESCRIPTION
## Summary

- allow Infection 0.34.1+ in the five packages that still selected the affected 0.32 release on PHP 8.5
- preserve older Infection ranges for the PHP 8.1 and PHP 8.2 compatibility matrix
- keep the GitHub Actions workflows unchanged

## Root cause

Infection before 0.34.1 resolves repository-root-relative Git diff paths from the package working directory when `--git-diff-lines` runs in a monorepo subdirectory. This makes source changes fail with `Could not resolve the path ...`. Infection 0.34.1 fixed the working-directory/configuration-directory handling.

PostgreSQL, SQL Faker, and SQL Fixture already included the corrected constraint; Core, MySQL, SQLite, PDO Adapter, and MySQLi Adapter were missed.

## Validation

- JSON syntax checked for all five manifests
- Composer dependency resolution selects Infection 0.34.2 on PHP 8.5 for all five packages
- Infection 0.34.2 processes changed package source files without a `diff.relative` workaround
