### PR TITLE
Constrain PHPUnit for ParaTest compatibility

### DIFF
--- a/packages/ztd-query-mysql/composer.json
+++ b/packages/ztd-query-mysql/composer.json
@@ -14,7 +14,7 @@
         "nikic/php-fuzzer": "^0.0.11",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^10.5 || ^11 || ^12 || ^13",
+        "phpunit/phpunit": "^10.5 || ^11 || ^12 || >=13.0 <13.3",
         "brianium/paratest": "^6.11 || ^7",
         "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
         "k-kinzal/phpstan-custom-rules": "@dev",

--- a/packages/ztd-query-sqlite/composer.json
+++ b/packages/ztd-query-sqlite/composer.json
@@ -13,7 +13,7 @@
         "nikic/php-fuzzer": "^0.0.11",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^10.5 || ^11 || ^12 || ^13",
+        "phpunit/phpunit": "^10.5 || ^11 || ^12 || >=13.0 <13.3",
         "infection/infection": "^0.28 || ^0.29 || ^0.30 || ^0.31 || ^0.32",
         "brianium/paratest": "^6.11 || ^7",
         "k-kinzal/phpstan-custom-rules": "@dev",


### PR DESCRIPTION
## Summary

- constrain PHPUnit 13 to versions below 13.3 in the MySQL and SQLite packages
- match the existing PostgreSQL compatibility boundary
- prevent ParaTest 7.24 from passing PHPUnit 13.3's deprecated `--do-not-cache-result` option under fail-on-deprecation CI

## Verification

- Composer resolves PHPUnit 13.1.14 for both packages on PHP 8.5
- PHPUnit 13.3.1 is rejected by the root constraints
- Composer manifests validate successfully