### PR TITLE
Handle PostgreSQL fuzz exceptions

### DIFF
--- a/packages/sql-faker/fuzz/Target/PgSyntaxTarget.php
+++ b/packages/sql-faker/fuzz/Target/PgSyntaxTarget.php
@@ -14,7 +14,7 @@ use SqlFaker\PostgreSqlProvider;
  * Fuzz target for PostgreSQL SQL syntax validation.
  *
  * This target converts fuzzer input to RNG seed, generates SQL via grammar,
- * and validates it against PostgreSQL. Errors (not Exceptions) indicate bugs.
+ * and validates it against PostgreSQL. Unexpected throwables indicate bugs.
  */
 final class PgSyntaxTarget
 {
@@ -83,10 +83,6 @@ final class PgSyntaxTarget
 
     private function validateSyntax(string $sql, int $seed): void
     {
-        if ($sql === '') {
-            return;
-        }
-
         try {
             $this->pdo->exec('SAVEPOINT fuzz_check');
             $this->pdo->exec($sql);

--- a/packages/sql-faker/fuzz/fuzz_pg_syntax.php
+++ b/packages/sql-faker/fuzz/fuzz_pg_syntax.php
@@ -54,4 +54,5 @@ $target = new PgSyntaxTarget($pdo, $maxDepth);
 
 /* Configure fuzzer via $config (provided by php-fuzzer) */
 /** @var \PhpFuzzer\Config $config */
+$config->setAllowedExceptions([]);
 $config->setTarget(Closure::fromCallable($target));


### PR DESCRIPTION
## Summary

- configure php-fuzzer to treat unexpected exceptions as crashes
- remove the PostgreSQL target's special case for empty SQL
- keep grammar-valid empty output free of assertions or synthetic exceptions

## Root cause

php-fuzzer allows every `Exception` by default. That policy can hide implementation failures thrown by SQL Faker even though the target is intended to treat unexpected throwables as bugs.

The entrypoint now sets an empty allowed-exception list. Empty SQL itself is not classified as a crash: PostgreSQL's grammar permits an empty `stmt`, and the target delegates it to PostgreSQL like any other generated value.

## Stack

- Depends on #208
- #206 depends on this pull request and establishes the Provider's non-empty public contract

## Validation

- SQL Faker unit suite: 1,013 tests / 1,804 assertions
- PHP-CS-Fixer and PHPStan: clean