### PR TITLE
Prevent empty PostgreSQL Provider output

### DIFF
--- a/packages/sql-faker/src/Grammar/RandomStringGenerator.php
+++ b/packages/sql-faker/src/Grammar/RandomStringGenerator.php
@@ -50,6 +50,8 @@ final class RandomStringGenerator
 
     /**
      * Generate a random integer literal string.
+     *
+     * @return non-empty-string
      */
     public function integerString(int $min = 1, int $max = 9999999999): string
     {
@@ -74,6 +76,8 @@ final class RandomStringGenerator
 
     /**
      * Generate a random decimal literal string.
+     *
+     * @return non-empty-string
      */
     public function decimalString(int $precision = 13, int $scale = 6): string
     {
@@ -124,6 +128,8 @@ final class RandomStringGenerator
 
     /**
      * Generate a random float literal string with exponent.
+     *
+     * @return non-empty-string
      */
     public function floatString(string $mantissa, int $minExponent = -20, int $maxExponent = 20): string
     {
@@ -132,6 +138,8 @@ final class RandomStringGenerator
 
     /**
      * Generate a random parameter index string.
+     *
+     * @return non-empty-string
      */
     public function parameterIndex(int $min = 1, int $max = 10): string
     {

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -54,7 +54,7 @@ final class PostgreSqlProvider extends Base
      *
      * @param StatementType|null $type Statement type (null for random)
      * @param int $maxDepth Maximum recursion depth (PHP_INT_MAX = unlimited)
-     * @return string Generated SQL statement
+     * @return non-empty-string Generated SQL statement
      */
     public function sql(?StatementType $type = null, int $maxDepth = PHP_INT_MAX): string
     {
@@ -63,119 +63,147 @@ final class PostgreSqlProvider extends Base
             $type = $this->generator->randomElement(StatementType::cases());
         }
 
-        return $this->sql->generate($type->value, $maxDepth);
+        return $this->generateRequired($type->value, $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL SELECT statement.
+     *
+     * @return non-empty-string
      */
     public function selectStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate(StatementType::Select->value, $maxDepth);
+        return $this->generateRequired(StatementType::Select->value, $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL INSERT statement.
+     *
+     * @return non-empty-string
      */
     public function insertStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate(StatementType::Insert->value, $maxDepth);
+        return $this->generateRequired(StatementType::Insert->value, $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL UPDATE statement.
+     *
+     * @return non-empty-string
      */
     public function updateStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate(StatementType::Update->value, $maxDepth);
+        return $this->generateRequired(StatementType::Update->value, $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL DELETE statement.
+     *
+     * @return non-empty-string
      */
     public function deleteStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate(StatementType::Delete->value, $maxDepth);
+        return $this->generateRequired(StatementType::Delete->value, $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL CREATE TABLE statement.
+     *
+     * @return non-empty-string
      */
     public function createTableStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate(StatementType::CreateTable->value, $maxDepth);
+        return $this->generateRequired(StatementType::CreateTable->value, $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL ALTER TABLE statement.
+     *
+     * @return non-empty-string
      */
     public function alterTableStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate(StatementType::AlterTable->value, $maxDepth);
+        return $this->generateRequired(StatementType::AlterTable->value, $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL DROP TABLE statement.
+     *
+     * @return non-empty-string
      */
     public function dropTableStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate(StatementType::DropTable->value, $maxDepth);
+        return $this->generateRequired(StatementType::DropTable->value, $maxDepth);
     }
 
     /**
      * Generate any PostgreSQL statement.
+     *
+     * @return non-empty-string
      */
     public function simpleStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate(StatementType::SimpleStatement->value, $maxDepth);
+        return $this->generateRequired(StatementType::SimpleStatement->value, $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL TRUNCATE statement.
+     *
+     * @return non-empty-string
      */
     public function truncateStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('TruncateStmt', $maxDepth);
+        return $this->generateRequired('TruncateStmt', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL CREATE INDEX statement.
+     *
+     * @return non-empty-string
      */
     public function createIndexStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('IndexStmt', $maxDepth);
+        return $this->generateRequired('IndexStmt', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL transaction statement (BEGIN/COMMIT/ROLLBACK).
+     *
+     * @return non-empty-string
      */
     public function transactionStatement(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('TransactionStmt', $maxDepth);
+        return $this->generateRequired('TransactionStmt', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL expression.
+     *
+     * @return non-empty-string
      */
     public function expr(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('a_expr', $maxDepth);
+        return $this->generateRequired('a_expr', $maxDepth);
     }
 
     /**
      * Generate a simple PostgreSQL expression.
+     *
+     * @return non-empty-string
      */
     public function simpleExpr(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('c_expr', $maxDepth);
+        return $this->generateRequired('c_expr', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL literal.
+     *
+     * @return non-empty-string
      */
     public function literal(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('AexprConst', $maxDepth);
+        return $this->generateRequired('AexprConst', $maxDepth);
     }
 
     /**
@@ -188,72 +216,89 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL ORDER BY clause.
+     *
+     * @return non-empty-string
      */
     public function sortClause(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('sort_clause', $maxDepth);
+        return $this->generateRequired('sort_clause', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL LIMIT clause.
+     *
+     * @return non-empty-string
      */
     public function selectLimit(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('select_limit', $maxDepth);
+        return $this->generateRequired('select_limit', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL table reference.
+     *
+     * @return non-empty-string
      */
     public function tableRef(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('table_ref', $maxDepth);
+        return $this->generateRequired('table_ref', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL joined table.
+     *
+     * @return non-empty-string
      */
     public function joinedTable(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('joined_table', $maxDepth);
+        return $this->generateRequired('joined_table', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL qualified name (table identifier).
+     *
+     * @return non-empty-string
      */
     public function qualifiedName(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('qualified_name', $maxDepth);
+        return $this->generateRequired('qualified_name', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL subquery.
+     *
+     * @return non-empty-string
      */
     public function subquery(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('select_with_parens', $maxDepth);
+        return $this->generateRequired('select_with_parens', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL WITH clause (CTE).
+     *
+     * @return non-empty-string
      */
     public function withClause(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('with_clause', $maxDepth);
+        return $this->generateRequired('with_clause', $maxDepth);
     }
 
     /**
      * Generate a PostgreSQL identifier via grammar derivation.
      *
      * @param int $maxDepth Maximum recursion depth
+     * @return non-empty-string
      */
     public function identifier(int $maxDepth = PHP_INT_MAX): string
     {
-        return $this->sql->generate('ColId', $maxDepth);
+        return $this->generateRequired('ColId', $maxDepth);
     }
 
     /**
      * Generate a double-quote-quoted PostgreSQL identifier.
+     *
+     * @return non-empty-string
      */
     public function quotedIdentifier(int $minLength = 1, int $maxLength = 63): string
     {
@@ -262,6 +307,8 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL string literal.
+     *
+     * @return non-empty-string
      */
     public function stringLiteral(int $minLength = 1, int $maxLength = 255): string
     {
@@ -270,6 +317,8 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL integer literal.
+     *
+     * @return non-empty-string
      */
     public function integerLiteral(int $min = 1, int $max = 2147483647): string
     {
@@ -278,6 +327,8 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL decimal literal.
+     *
+     * @return non-empty-string
      */
     public function decimalLiteral(int $precision = 10, int $scale = 2): string
     {
@@ -286,6 +337,8 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL float literal with exponent (FCONST).
+     *
+     * @return non-empty-string
      */
     public function floatLiteral(int $precision = 10, int $scale = 2, int $minExponent = -307, int $maxExponent = 308): string
     {
@@ -294,6 +347,8 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL hexadecimal literal (X'...' / XCONST).
+     *
+     * @return non-empty-string
      */
     public function hexLiteral(int $minLength = 1, int $maxLength = 16): string
     {
@@ -302,6 +357,8 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL bit string literal (B'...' / BCONST).
+     *
+     * @return non-empty-string
      */
     public function binaryLiteral(int $minLength = 1, int $maxLength = 64): string
     {
@@ -310,6 +367,8 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL dollar-quoted string ($$...$$).
+     *
+     * @return non-empty-string
      */
     public function dollarQuotedString(int $minLength = 1, int $maxLength = 255): string
     {
@@ -318,9 +377,27 @@ final class PostgreSqlProvider extends Base
 
     /**
      * Generate a PostgreSQL parameter marker ($1, $2, etc.).
+     *
+     * @return non-empty-string
      */
     public function parameterMarker(int $min = 1, int $max = 99): string
     {
         return '$' . $this->rsg->parameterIndex($min, $max);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function generateRequired(string $startRule, int $maxDepth): string
+    {
+        $targetDepth = $maxDepth;
+        while (true) {
+            $value = $this->sql->generate($startRule, $targetDepth);
+            if ($value !== '') {
+                return $value;
+            }
+
+            $targetDepth = max(2, $targetDepth);
+        }
     }
 }

--- a/packages/sql-faker/tests/Unit/Grammar/LexicalGrammarTest.php
+++ b/packages/sql-faker/tests/Unit/Grammar/LexicalGrammarTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 use SqlFaker\Grammar\LexicalGrammar;
 use SqlFaker\MySqlProvider;
 use SqlFaker\PostgreSqlProvider;
+use SqlFaker\PostgreSql\StatementType as PostgreSqlStatementType;
 use SqlFaker\SqliteProvider;
 
 #[CoversNothing]
@@ -54,14 +55,24 @@ final class LexicalGrammarTest extends TestCase
         yield 'MySQL 9.1' => ['mysql-9.1.0'];
     }
 
-    public function testSupportedPostgreSqlVersionBindsGrammarAndLexerProfileTogether(): void
+    #[DataProvider('providerPostgreSqlStatementType')]
+    public function testSupportedPostgreSqlVersionBindsGrammarAndLexerProfileTogether(PostgreSqlStatementType $type): void
     {
         $faker = Factory::create();
         $faker->seed(20260814);
         $provider = new PostgreSqlProvider($faker, 'pg-17.2');
-        $statements = array_map(static fn (int $iteration): string => $provider->sql(maxDepth: 20), range(1, 20));
 
-        self::assertNotContains('', $statements);
+        self::assertNotSame('', $provider->sql($type, maxDepth: 20), $type->name);
+    }
+
+    /**
+     * @return iterable<string, array{PostgreSqlStatementType}>
+     */
+    public static function providerPostgreSqlStatementType(): iterable
+    {
+        foreach (PostgreSqlStatementType::cases() as $type) {
+            yield $type->name => [$type];
+        }
     }
 
     public function testSupportedSqliteVersionBindsGrammarAndLexerProfileTogether(): void

--- a/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
@@ -146,6 +146,20 @@ final class SqlGeneratorTest extends TestCase
         self::assertSame('SHORT', $result);
     }
 
+    public function testGeneratePreservesEmptyStartProduction(): void
+    {
+        $grammar = new Grammar('stmt', [
+            'stmt' => new ProductionRule('stmt', [
+                new Production([]),
+                new Production([new Terminal('SELECT')]),
+            ]),
+        ]);
+        $faker = Factory::create();
+        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+
+        self::assertSame('', $generator->generate('stmt', 1));
+    }
+
     public function testGenerateThrowsOnDerivationLimit(): void
     {
         $reflection = new ReflectionClass(SqlGenerator::class);

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -271,9 +271,9 @@ final class PostgreSqlProviderTest extends TestCase
         $faker->seed(0);
         $provider = new PostgreSqlProvider($faker);
 
-        $result = $provider->whereClause(maxDepth: 6);
+        $result = $provider->whereClause(maxDepth: 1);
 
-        self::assertMatchesRegularExpression('/^$|WHERE/', $result);
+        self::assertSame('', $result);
     }
 
     public function testSortClause(): void
@@ -745,13 +745,32 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertNotSame('', $result);
     }
 
-    public function testSimpleStatementReturnsNonEmpty(): void
+    #[DataProvider('providerNullableSimpleStatementSeed')]
+    public function testSimpleStatementReturnsNonEmpty(int $seed): void
     {
         $faker = Factory::create();
-        $faker->seed(12345);
+        $faker->seed($seed);
         $provider = new PostgreSqlProvider($faker);
 
-        self::assertNotSame('', $provider->simpleStatement(maxDepth: 6));
+        self::assertNotSame('', $provider->simpleStatement(maxDepth: 20));
+    }
+
+    public function testSimpleStatementReturnsNonEmptyAtMinimumDepth(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(0);
+        $provider = new PostgreSqlProvider($faker);
+
+        self::assertNotSame('', $provider->simpleStatement(maxDepth: 1));
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function providerNullableSimpleStatementSeed(): iterable
+    {
+        yield 'PHP 8.1 and 8.2 random mode' => [252];
+        yield 'PHP 8.3 and later random mode' => [68];
     }
 
     /**


### PR DESCRIPTION
## Summary

- keep `SqlGenerator::generate()` faithful to PostgreSQL grammar, including empty productions
- guarantee non-empty results at the `PostgreSqlProvider` public boundary
- expose concrete SQL APIs as `non-empty-string`
- keep optional fragments such as `whereClause()` nullable

## Root cause

PostgreSQL's `stmt` grammar intentionally contains an empty production. Removing that production in the generic generator changes grammar semantics. The non-empty requirement belongs to Provider methods that promise a concrete SQL value.

## Algorithm

Provider methods for statements, expressions, identifiers, and required clauses use rejection sampling. When generation returns an empty value, the Provider retries and raises the effective target depth to at least two so minimum-depth generation does not deterministically select the empty root production.

The helper returns only after observing a non-empty value, which lets PHPStan verify the `non-empty-string` return type without an assertion or synthetic exception. `SqlGenerator::generate()` remains a plain `string` generator.

## Stack

- Depends on #205
- #185 depends on this pull request

## Validation

- full SQL Faker unit suite: 1,023 tests / 1,814 assertions
- fixed seeds for PHP 8.1/8.2 and PHP 8.3+
- minimum-depth statement generation remains non-empty
- optional WHERE clause remains empty at minimum depth
- generic generator preserves an empty start production
- original fuzz reproducer now generates a non-empty statement
- PHP-CS-Fixer, PHPStan, Composer validation, and diff check: clean
- final CI Infection: 44 mutations, 95% covered MSI