### PR TITLE
Run Merge Gatekeeper for stacked pull requests

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - stacked
   check_suite:
     types:
       - completed


### PR DESCRIPTION
## Summary

- run Merge Gatekeeper when existing pull requests are added to a native GitHub stack
- keep the `main` base filter and the existing `check_suite` / `status` fallbacks

## Root cause

Native stacked pull requests are evaluated against the stack base, so a workflow filtered to `main` already applies to every pull request in the stack. When existing pull requests are first added to a stack, GitHub emits the `pull_request` action `stacked`. GitHub Actions only subscribes to `opened`, `synchronize`, and `reopened` by default, so Merge Gatekeeper did not run for pull requests that were added to the stack after their original creation.

The `check_suite` fallback does not cover this case because GitHub prevents recursive workflow runs for check suites created by GitHub Actions.

## Change

Explicitly subscribe to:

- `opened`
- `synchronize`
- `reopened`
- `stacked`

## Stack

- Depends on #184
- #205 depends on this pull request

## Validation

- YAML syntax check
- `git diff --check`
- live GitHub Actions checks on the rebuilt native stack