### PR TITLE
fix: preserve unknown-schema mutation semantics

### DIFF
--- a/packages/ztd-query-core/src/Shadow/Mutation/DropTableMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/DropTableMutation.php
@@ -41,7 +41,7 @@ final class DropTableMutation implements ShadowMutation
         }
 
         $this->registry->unregister($this->tableName);
-        $store->set($this->tableName, []);
+        $store->remove($this->tableName);
     }
 
     /**

--- a/packages/ztd-query-core/src/Shadow/ShadowStore.php
+++ b/packages/ztd-query-core/src/Shadow/ShadowStore.php
@@ -21,7 +21,7 @@ class ShadowStore
     /**
      * Tables explicitly initialized as fixtures or virtual schema entries.
      *
-     * @var array<string, true>
+     * @var array<string, string>
      */
     private array $initializedTables = [];
 
@@ -33,7 +33,7 @@ class ShadowStore
     public function set(string $tableName, array $rows): void
     {
         $this->fixtures[$tableName] = $rows;
-        $this->initializedTables[$tableName] = true;
+        $this->initializedTables[$tableName] = $tableName;
     }
 
     /**
@@ -98,7 +98,7 @@ class ShadowStore
         if (!array_key_exists($tableName, $this->fixtures)) {
             $this->fixtures[$tableName] = [];
         }
-        $this->initializedTables[$tableName] = true;
+        $this->initializedTables[$tableName] = $tableName;
     }
 
     /**

--- a/packages/ztd-query-core/src/Shadow/ShadowStore.php
+++ b/packages/ztd-query-core/src/Shadow/ShadowStore.php
@@ -19,6 +19,13 @@ class ShadowStore
     private array $fixtures = [];
 
     /**
+     * Tables explicitly initialized as fixtures or virtual schema entries.
+     *
+     * @var array<string, true>
+     */
+    private array $initializedTables = [];
+
+    /**
      * Replace all shadow rows for a table.
      *
      * @param array<int, array<string, mixed>> $rows
@@ -26,6 +33,7 @@ class ShadowStore
     public function set(string $tableName, array $rows): void
     {
         $this->fixtures[$tableName] = $rows;
+        $this->initializedTables[$tableName] = true;
     }
 
     /**
@@ -36,6 +44,31 @@ class ShadowStore
     public function get(string $tableName): array
     {
         return $this->fixtures[$tableName] ?? [];
+    }
+
+    /**
+     * Whether the store contains a shadow entry for a table, including an
+     * intentionally empty table.
+     */
+    public function has(string $tableName): bool
+    {
+        return array_key_exists($tableName, $this->fixtures);
+    }
+
+    /**
+     * Return the typed presence state for a shadow table.
+     */
+    public function state(string $tableName): ShadowTableState
+    {
+        if (!$this->has($tableName)) {
+            return ShadowTableState::Missing;
+        }
+
+        if (isset($this->initializedTables[$tableName])) {
+            return ShadowTableState::Initialized;
+        }
+
+        return ShadowTableState::Materialized;
     }
 
     /**
@@ -54,6 +87,7 @@ class ShadowStore
     public function clear(): void
     {
         $this->fixtures = [];
+        $this->initializedTables = [];
     }
 
     /**
@@ -64,6 +98,15 @@ class ShadowStore
         if (!array_key_exists($tableName, $this->fixtures)) {
             $this->fixtures[$tableName] = [];
         }
+        $this->initializedTables[$tableName] = true;
+    }
+
+    /**
+     * Remove both rows and explicit table context from the store.
+     */
+    public function remove(string $tableName): void
+    {
+        unset($this->fixtures[$tableName], $this->initializedTables[$tableName]);
     }
 
     /**

--- a/packages/ztd-query-core/src/Shadow/ShadowTableState.php
+++ b/packages/ztd-query-core/src/Shadow/ShadowTableState.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow;
+
+/**
+ * Describes how much table context is available in the shadow store.
+ */
+enum ShadowTableState
+{
+    case Missing;
+    case Materialized;
+    case Initialized;
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
@@ -13,6 +13,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(ShadowStore::class)]
 #[UsesClass(MissingPrimaryKeyException::class)]
+#[UsesClass(ShadowTableState::class)]
 class ShadowStoreTest extends TestCase
 {
     public function testInsertAppendsRows(): void

--- a/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\MissingPrimaryKeyException;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(ShadowStore::class)]
 #[UsesClass(MissingPrimaryKeyException::class)]
@@ -31,6 +32,42 @@ class ShadowStoreTest extends TestCase
         $store = new ShadowStore();
 
         self::assertSame([], $store->get('missing'));
+    }
+
+    public function testHasDistinguishesMissingFromIntentionallyEmptyTable(): void
+    {
+        $store = new ShadowStore();
+
+        self::assertFalse($store->has('events'));
+
+        $store->ensure('events');
+
+        self::assertTrue($store->has('events'));
+        self::assertSame([], $store->get('events'));
+    }
+
+    public function testStateDistinguishesMutationMaterializationFromInitialization(): void
+    {
+        $store = new ShadowStore();
+
+        self::assertSame(ShadowTableState::Missing, $store->state('events'));
+
+        $store->insert('events', [['id' => 1]]);
+        self::assertSame(ShadowTableState::Materialized, $store->state('events'));
+
+        $store->ensure('events');
+        self::assertSame(ShadowTableState::Initialized, $store->state('events'));
+    }
+
+    public function testRemoveClearsRowsAndInitialization(): void
+    {
+        $store = new ShadowStore();
+        $store->set('events', [['id' => 1]]);
+
+        $store->remove('events');
+
+        self::assertSame(ShadowTableState::Missing, $store->state('events'));
+        self::assertSame([], $store->get('events'));
     }
 
     public function testGetAllReturnsCurrentTables(): void

--- a/packages/ztd-query-core/tests/Unit/Shadow/ShadowTableStateTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ShadowTableStateTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Shadow\ShadowTableState;
+
+#[CoversClass(ShadowTableState::class)]
+final class ShadowTableStateTest extends TestCase
+{
+    public function testDefinesAllPresenceStates(): void
+    {
+        self::assertSame(
+            [ShadowTableState::Missing, ShadowTableState::Materialized, ShadowTableState::Initialized],
+            ShadowTableState::cases(),
+        );
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlMutationResolver.php
+++ b/packages/ztd-query-mysql/src/MySqlMutationResolver.php
@@ -36,6 +36,7 @@ use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 /**
  * Resolves the appropriate ShadowMutation for a given SQL statement.
@@ -119,12 +120,15 @@ final class MySqlMutationResolver
         if ($targetTable === null) {
             throw new UnsupportedSqlException($sql, 'Cannot resolve table name');
         }
-        $this->shadowStore->ensure($targetTable);
+        $definition = $this->registry->get($targetTable);
+        if ($definition === null && $this->shadowStore->state($targetTable) !== ShadowTableState::Initialized) {
+            throw new UnknownSchemaException($sql, $targetTable, 'table');
+        }
 
+        $this->shadowStore->ensure($targetTable);
         $columns = $this->shadowStore->get($targetTable);
         $columnNames = $columns !== [] ? array_keys($columns[0]) : null;
         if ($columnNames === null) {
-            $definition = $this->registry->get($targetTable);
             $columnNames = $definition?->columns;
         }
         if ($columnNames === null) {
@@ -139,8 +143,7 @@ final class MySqlMutationResolver
             $tablesPrimaryKeys = [];
             foreach ($tables as $tableName => $tableInfo) {
                 $definition = $this->registry->get($tableName);
-                $existingRows = $this->shadowStore->get($tableName);
-                if ($definition === null && $existingRows === []) {
+                if ($definition === null && $this->shadowStore->state($tableName) !== ShadowTableState::Initialized) {
                     throw new UnknownSchemaException($sql, $tableName, 'table');
                 }
                 $this->shadowStore->ensure($tableName);
@@ -176,6 +179,10 @@ final class MySqlMutationResolver
             throw new UnsupportedSqlException($sql, 'Cannot resolve DELETE target');
         }
 
+        if (!$this->registry->has($targetTable) && $this->shadowStore->state($targetTable) !== ShadowTableState::Initialized) {
+            throw new UnknownSchemaException($sql, $targetTable, 'table');
+        }
+
         $this->shadowStore->ensure($targetTable);
 
         $tables = $projection['tables'];
@@ -184,8 +191,7 @@ final class MySqlMutationResolver
             $tablesPrimaryKeys = [];
             foreach ($tables as $tableName => $tableInfo) {
                 $definition = $this->registry->get($tableName);
-                $existingRows = $this->shadowStore->get($tableName);
-                if ($definition === null && $existingRows === []) {
+                if ($definition === null && $this->shadowStore->state($tableName) !== ShadowTableState::Initialized) {
                     throw new UnknownSchemaException($sql, $tableName, 'table');
                 }
                 $this->shadowStore->ensure($tableName);
@@ -195,10 +201,6 @@ final class MySqlMutationResolver
         }
 
         $definition = $this->registry->get($targetTable);
-        $existingRows = $this->shadowStore->get($targetTable);
-        if ($definition === null && $existingRows === []) {
-            throw new UnknownSchemaException($sql, $targetTable, 'table');
-        }
 
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
         return new DeleteMutation($targetTable, $primaryKeys);

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -15,14 +15,10 @@ use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
-use ZtdQuery\Shadow\ShadowTableState;
 use PhpMyAdmin\SqlParser\Statements\AlterStatement;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
-use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
-use PhpMyAdmin\SqlParser\Statements\InsertStatement;
 use PhpMyAdmin\SqlParser\Statements\ReplaceStatement;
 use PhpMyAdmin\SqlParser\Statements\TruncateStatement;
-use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use PhpMyAdmin\SqlParser\Statements\WithStatement;
 
 /**
@@ -139,10 +135,6 @@ final class MySqlRewriter implements SqlRewriter
             return new RewritePlan('SELECT 1 WHERE FALSE', QueryKind::DDL_SIMULATED, $mutation);
         }
 
-        if ($statement instanceof UpdateStatement || $statement instanceof DeleteStatement || $statement instanceof InsertStatement) {
-            $this->ensureDmlTables($statement, $sql);
-        }
-
         $mutation = $this->mutationResolver->resolve($sql, $statement, $kind);
 
         if ($statement instanceof TruncateStatement) {
@@ -208,33 +200,6 @@ final class MySqlRewriter implements SqlRewriter
         }
 
         return $context;
-    }
-
-    /**
-     * Ensure DML target tables exist in shadow store.
-     */
-    private function ensureDmlTables(Statement $statement, string $sql): void
-    {
-        if ($statement instanceof UpdateStatement) {
-            if ($statement->tables === [] || !isset($statement->tables[0])) {
-                return;
-            }
-            $targetExpr = $statement->tables[0];
-            $targetTable = self::resolveExprTableName($targetExpr);
-            if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
-                $this->shadowStore->ensure($targetTable);
-            }
-        }
-
-        if ($statement instanceof DeleteStatement) {
-            if ($statement->from !== null && $statement->from !== []) {
-                $targetExpr = $statement->from[0];
-                $targetTable = self::resolveExprTableName($targetExpr);
-                if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
-                    $this->shadowStore->ensure($targetTable);
-                }
-            }
-        }
     }
 
     /**
@@ -320,12 +285,6 @@ final class MySqlRewriter implements SqlRewriter
         }
 
         return false;
-    }
-
-    private function mutationTableExists(string $tableName): bool
-    {
-        return $this->registry->has($tableName)
-            || $this->shadowStore->state($tableName) === ShadowTableState::Initialized;
     }
 
     private function hasSchemaContext(): bool

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 use PhpMyAdmin\SqlParser\Statements\AlterStatement;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
@@ -220,7 +221,7 @@ final class MySqlRewriter implements SqlRewriter
             }
             $targetExpr = $statement->tables[0];
             $targetTable = self::resolveExprTableName($targetExpr);
-            if ($targetTable !== null) {
+            if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
                 $this->shadowStore->ensure($targetTable);
             }
         }
@@ -229,7 +230,7 @@ final class MySqlRewriter implements SqlRewriter
             if ($statement->from !== null && $statement->from !== []) {
                 $targetExpr = $statement->from[0];
                 $targetTable = self::resolveExprTableName($targetExpr);
-                if ($targetTable !== null) {
+                if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
                     $this->shadowStore->ensure($targetTable);
                 }
             }
@@ -310,7 +311,7 @@ final class MySqlRewriter implements SqlRewriter
 
     private function tableExists(string $tableName): bool
     {
-        if ($this->shadowStore->get($tableName) !== []) {
+        if ($this->shadowStore->has($tableName)) {
             return true;
         }
 
@@ -319,6 +320,12 @@ final class MySqlRewriter implements SqlRewriter
         }
 
         return false;
+    }
+
+    private function mutationTableExists(string $tableName): bool
+    {
+        return $this->registry->has($tableName)
+            || $this->shadowStore->state($tableName) === ShadowTableState::Initialized;
     }
 
     private function hasSchemaContext(): bool

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -33,6 +33,7 @@ use ZtdQuery\Shadow\Mutation\MultiUpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Platform\MySql\Mutation\AlterTableMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(MySqlMutationResolver::class)]
 #[UsesClass(MySqlParser::class)]
@@ -834,6 +835,7 @@ final class MySqlMutationResolverTest extends TestCase
         self::assertInstanceOf(UpdateMutation::class, $mutation);
         self::assertSame('users', $mutation->tableName());
         self::assertSame([], $shadowStore->get('users'));
+        self::assertSame(ShadowTableState::Initialized, $shadowStore->state('users'));
     }
 
     public function testResolveUpdateThrowsWhenNoSchemaAvailable(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
@@ -1610,5 +1611,23 @@ final class MySqlMutationResolverTest extends TestCase
         $mutation = $resolver->resolve($sql, $statements[0], QueryKind::DDL_SIMULATED);
 
         self::assertInstanceOf(CreateTableLikeMutation::class, $mutation);
+    }
+
+    public function testUpdateDoesNotTreatRowsFromUnknownInsertAsSchema(): void
+    {
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $shadowStore = new ShadowStore();
+        $shadowStore->insert('late_table', [['id' => 1, 'name' => 'Alice']]);
+        $registry = new TableDefinitionRegistry();
+        $selectTransformer = new SelectTransformer();
+        $updateTransformer = new UpdateTransformer($parser, $selectTransformer);
+        $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
+        $resolver = new MySqlMutationResolver($shadowStore, $registry, $schemaParser, $updateTransformer, $deleteTransformer);
+        $sql = "UPDATE late_table SET name = 'Bob' WHERE id = 1";
+        $statements = $parser->parse($sql);
+
+        $this->expectException(UnknownSchemaException::class);
+        $resolver->resolve($sql, $statements[0], QueryKind::WRITE_SIMULATED);
     }
 }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -35,6 +35,7 @@ use ZtdQuery\Shadow\Mutation\ReplaceMutation;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(MySqlRewriter::class)]
 #[UsesClass(MySqlParser::class)]
@@ -2792,5 +2793,19 @@ final class MySqlRewriterTest extends RewriterContractTest
         self::assertSame('SELECT 1 WHERE FALSE', $plan->sql());
         self::assertNotNull($plan->mutation());
         self::assertInstanceOf(TruncateMutation::class, $plan->mutation());
+    }
+
+    public function testUpdateDoesNotPromoteMaterializedUnknownTable(): void
+    {
+        $store = new ShadowStore();
+        $store->insert('late_table', [['id' => 1, 'name' => 'Alice']]);
+        $rewriter = $this->createRewriter($store, new TableDefinitionRegistry());
+
+        try {
+            $rewriter->rewrite("UPDATE late_table SET name = 'Bob' WHERE id = 1");
+            self::fail('Expected an unknown schema exception.');
+        } catch (UnknownSchemaException) {
+            self::assertSame(ShadowTableState::Materialized, $store->state('late_table'));
+        }
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/SqliteErrorHandlingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/SqliteErrorHandlingTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Large;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\ZtdPdo;
 use ZtdQuery\Adapter\Pdo\ZtdPdoException;
+use ZtdQuery\Config\UnknownSchemaBehavior;
 use ZtdQuery\Config\UnsupportedSqlBehavior;
 use ZtdQuery\Config\ZtdConfig;
 
@@ -21,6 +22,56 @@ use ZtdQuery\Config\ZtdConfig;
 #[Large]
 final class SqliteErrorHandlingTest extends TestCase
 {
+    public function testLateTableUpdateAndDeletePassThroughByDefault(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $ztd = ZtdPdo::fromPdo($rawPdo);
+
+        $rawPdo->exec('CREATE TABLE late_table (id INTEGER PRIMARY KEY, value TEXT NOT NULL)');
+        $rawPdo->exec("INSERT INTO late_table VALUES (1, 'physical')");
+
+        self::assertSame(1, $ztd->exec("UPDATE late_table SET value = 'updated' WHERE id = 1"));
+        $valueStatement = $rawPdo->query('SELECT value FROM late_table WHERE id = 1');
+        self::assertNotFalse($valueStatement);
+        self::assertSame('updated', $valueStatement->fetchColumn());
+        self::assertSame(1, $ztd->exec('DELETE FROM late_table WHERE id = 1'));
+        $countStatement = $rawPdo->query('SELECT COUNT(*) FROM late_table');
+        self::assertNotFalse($countStatement);
+        self::assertSame(0, $countStatement->fetchColumn());
+    }
+
+    public function testLateTableMutationRespectsExceptionBehavior(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $config = new ZtdConfig(
+            UnsupportedSqlBehavior::Ignore,
+            UnknownSchemaBehavior::Exception,
+        );
+        $ztd = ZtdPdo::fromPdo($rawPdo, $config);
+
+        $rawPdo->exec('CREATE TABLE late_table (id INTEGER PRIMARY KEY, value TEXT NOT NULL)');
+        $rawPdo->exec("INSERT INTO late_table VALUES (1, 'physical')");
+
+        $this->expectException(ZtdPdoException::class);
+        $this->expectExceptionMessage('Unknown table: late_table');
+        $ztd->exec("UPDATE late_table SET value = 'updated' WHERE id = 1");
+    }
+
+    public function testRowsFromLateTableInsertDoNotBypassPassthroughBehavior(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $ztd = ZtdPdo::fromPdo($rawPdo);
+
+        $rawPdo->exec('CREATE TABLE late_table (id INTEGER PRIMARY KEY, value TEXT NOT NULL)');
+        $rawPdo->exec("INSERT INTO late_table VALUES (1, 'physical')");
+        self::assertSame(1, $ztd->exec("INSERT INTO late_table (id, value) VALUES (2, 'shadow')"));
+
+        self::assertSame(1, $ztd->exec("UPDATE late_table SET value = 'updated' WHERE id = 1"));
+        $statement = $rawPdo->query('SELECT value FROM late_table WHERE id = 1');
+        self::assertNotFalse($statement);
+        self::assertSame('updated', $statement->fetchColumn());
+    }
+
     public function testUnsupportedSqlWithExceptionBehavior(): void
     {
         $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -20,6 +20,7 @@ use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 /**
  * Resolves the appropriate ShadowMutation for a given PostgreSQL SQL statement.
@@ -100,9 +101,12 @@ final class PgSqlMutationResolver
             throw new UnsupportedSqlException($sql, 'Cannot resolve UPDATE target');
         }
 
-        $this->shadowStore->ensure($targetTable);
-
         $definition = $this->registry->get($targetTable);
+        if ($definition === null && $this->shadowStore->state($targetTable) !== ShadowTableState::Initialized) {
+            throw new UnknownSchemaException($sql, $targetTable, 'table');
+        }
+
+        $this->shadowStore->ensure($targetTable);
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
         return new UpdateMutation($targetTable, $primaryKeys);
@@ -115,14 +119,12 @@ final class PgSqlMutationResolver
             throw new UnsupportedSqlException($sql, 'Cannot resolve DELETE target');
         }
 
-        $this->shadowStore->ensure($targetTable);
-
         $definition = $this->registry->get($targetTable);
-        $existingRows = $this->shadowStore->get($targetTable);
-        if ($definition === null && $existingRows === []) {
+        if ($definition === null && $this->shadowStore->state($targetTable) !== ShadowTableState::Initialized) {
             throw new UnknownSchemaException($sql, $targetTable, 'table');
         }
 
+        $this->shadowStore->ensure($targetTable);
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
         return new DeleteMutation($targetTable, $primaryKeys);

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -12,7 +12,6 @@ use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
-use ZtdQuery\Shadow\ShadowTableState;
 
 /**
  * PostgreSQL rewrite implementation for ZTD.
@@ -140,10 +139,6 @@ final class PgSqlRewriter implements SqlRewriter
             return new RewritePlan('SELECT 1 WHERE FALSE', QueryKind::DDL_SIMULATED, $mutation);
         }
 
-        if ($statementType === 'UPDATE' || $statementType === 'DELETE') {
-            $this->ensureDmlTarget($sql, $statementType);
-        }
-
         $mutation = $this->mutationResolver->resolve($sql, $statementType ?? '', $kind);
 
         if ($statementType === 'TRUNCATE') {
@@ -208,23 +203,6 @@ final class PgSqlRewriter implements SqlRewriter
         return $context;
     }
 
-    private function ensureDmlTarget(string $sql, string $statementType): void
-    {
-        if ($statementType === 'UPDATE') {
-            $targetTable = $this->parser->extractUpdateTable($sql);
-            if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
-                $this->shadowStore->ensure($targetTable);
-            }
-        }
-
-        if ($statementType === 'DELETE') {
-            $targetTable = $this->parser->extractDeleteTable($sql);
-            if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
-                $this->shadowStore->ensure($targetTable);
-            }
-        }
-    }
-
     private function tableExists(string $tableName): bool
     {
         if ($this->shadowStore->has($tableName)) {
@@ -236,12 +214,6 @@ final class PgSqlRewriter implements SqlRewriter
         }
 
         return false;
-    }
-
-    private function mutationTableExists(string $tableName): bool
-    {
-        return $this->registry->has($tableName)
-            || $this->shadowStore->state($tableName) === ShadowTableState::Initialized;
     }
 
     private function hasSchemaContext(): bool

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -12,6 +12,7 @@ use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 /**
  * PostgreSQL rewrite implementation for ZTD.
@@ -211,14 +212,14 @@ final class PgSqlRewriter implements SqlRewriter
     {
         if ($statementType === 'UPDATE') {
             $targetTable = $this->parser->extractUpdateTable($sql);
-            if ($targetTable !== null) {
+            if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
                 $this->shadowStore->ensure($targetTable);
             }
         }
 
         if ($statementType === 'DELETE') {
             $targetTable = $this->parser->extractDeleteTable($sql);
-            if ($targetTable !== null) {
+            if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
                 $this->shadowStore->ensure($targetTable);
             }
         }
@@ -226,7 +227,7 @@ final class PgSqlRewriter implements SqlRewriter
 
     private function tableExists(string $tableName): bool
     {
-        if ($this->shadowStore->get($tableName) !== []) {
+        if ($this->shadowStore->has($tableName)) {
             return true;
         }
 
@@ -235,6 +236,12 @@ final class PgSqlRewriter implements SqlRewriter
         }
 
         return false;
+    }
+
+    private function mutationTableExists(string $tableName): bool
+    {
+        return $this->registry->has($tableName)
+            || $this->shadowStore->state($tableName) === ShadowTableState::Initialized;
     }
 
     private function hasSchemaContext(): bool

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -1700,7 +1700,7 @@ final class PgSqlMutationResolverTest extends TestCase
         self::assertSame('new_table', $mutation->tableName());
     }
 
-    public function testResolveUpdateNoRegistryStillWorks(): void
+    public function testResolveUpdateNoRegistryThrowsUnknownSchema(): void
     {
         $shadowStore = new ShadowStore();
         $registry = new TableDefinitionRegistry();
@@ -1710,14 +1710,12 @@ final class PgSqlMutationResolverTest extends TestCase
             new PgSqlSchemaParser(),
             new PgSqlParser()
         );
-        $mutation = $resolver->resolve(
+        $this->expectException(UnknownSchemaException::class);
+        $resolver->resolve(
             "UPDATE new_table SET name = 'Bob' WHERE id = 1",
             'UPDATE',
             QueryKind::WRITE_SIMULATED
         );
-
-        self::assertInstanceOf(UpdateMutation::class, $mutation);
-        self::assertSame('new_table', $mutation->tableName());
     }
 
     public function testResolveCreateTableAsSelectWithLowercaseSelectAndAs(): void
@@ -2312,7 +2310,7 @@ final class PgSqlMutationResolverTest extends TestCase
         self::assertInstanceOf(UpsertMutation::class, $mutation);
     }
 
-    public function testResolveUpdateNoRegistryCreatesEmptyPrimaryKeys(): void
+    public function testResolveUpdateNoRegistryDoesNotCreateUnsafeMutation(): void
     {
         $shadowStore = new ShadowStore();
         $registry = new TableDefinitionRegistry();
@@ -2322,13 +2320,12 @@ final class PgSqlMutationResolverTest extends TestCase
             new PgSqlSchemaParser(),
             new PgSqlParser()
         );
-        $mutation = $resolver->resolve(
+        $this->expectException(UnknownSchemaException::class);
+        $resolver->resolve(
             "UPDATE unknown_table SET name = 'Bob' WHERE id = 1",
             'UPDATE',
             QueryKind::WRITE_SIMULATED
         );
-
-        self::assertInstanceOf(UpdateMutation::class, $mutation);
     }
 
     public function testResolveCreateTableAsSelectLowercaseSelectExtractsCorrectColumns(): void
@@ -2745,5 +2742,24 @@ final class PgSqlMutationResolverTest extends TestCase
         $rows = $shadowStore->get('users');
         self::assertNotEmpty($rows);
         self::assertSame('Bob', $rows[0]['name']);
+    }
+
+    public function testUpdateDoesNotTreatRowsFromUnknownInsertAsSchema(): void
+    {
+        $shadowStore = new ShadowStore();
+        $shadowStore->insert('late_table', [['id' => 1, 'name' => 'Alice']]);
+        $resolver = new PgSqlMutationResolver(
+            $shadowStore,
+            new TableDefinitionRegistry(),
+            new PgSqlSchemaParser(),
+            new PgSqlParser()
+        );
+
+        $this->expectException(UnknownSchemaException::class);
+        $resolver->resolve(
+            "UPDATE late_table SET name = 'Bob' WHERE id = 1",
+            'UPDATE',
+            QueryKind::WRITE_SIMULATED
+        );
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -23,6 +23,7 @@ use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
@@ -173,7 +174,7 @@ final class PgSqlMutationResolverTest extends TestCase
             QueryKind::WRITE_SIMULATED
         );
 
-        self::assertSame([], $shadowStore->get('users'));
+        self::assertSame(ShadowTableState::Initialized, $shadowStore->state('users'));
     }
 
     public function testResolveUpdateWithoutTableThrows(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Tests\Contract\RewriterContractTest;
+use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Exception\UnsupportedSqlException;
@@ -32,6 +33,7 @@ use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
@@ -3006,5 +3008,19 @@ final class PgSqlRewriterTest extends RewriterContractTest
 
         self::assertStringContainsString("E'line1\\nline2' AS \"body\"", $plan->sql());
         self::assertStringContainsString('WHERE id = 1', $plan->sql());
+    }
+
+    public function testUpdateDoesNotPromoteMaterializedUnknownTable(): void
+    {
+        $store = new ShadowStore();
+        $store->insert('late_table', [['id' => 1, 'name' => 'Alice']]);
+        $rewriter = $this->createRewriter($store, new TableDefinitionRegistry());
+
+        try {
+            $rewriter->rewrite("UPDATE late_table SET name = 'Bob' WHERE id = 1");
+            self::fail('Expected an unknown schema exception.');
+        } catch (UnknownSchemaException) {
+            self::assertSame(ShadowTableState::Materialized, $store->state('late_table'));
+        }
     }
 }

--- a/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
+++ b/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
@@ -20,6 +20,7 @@ use ZtdQuery\Shadow\Mutation\ShadowMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 /**
  * Resolves the appropriate ShadowMutation for a given SQLite SQL statement.
@@ -74,9 +75,12 @@ final class SqliteMutationResolver
             throw new UnsupportedSqlException($sql, 'Cannot resolve UPDATE target');
         }
 
-        $this->shadowStore->ensure($targetTable);
-
         $definition = $this->registry->get($targetTable);
+        if ($definition === null && $this->shadowStore->state($targetTable) !== ShadowTableState::Initialized) {
+            throw new UnknownSchemaException($sql, $targetTable, 'table');
+        }
+
+        $this->shadowStore->ensure($targetTable);
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
         return new UpdateMutation($targetTable, $primaryKeys);
@@ -95,14 +99,12 @@ final class SqliteMutationResolver
         if (preg_match('/^DELETE\s+FROM\s+(?:"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s;]+)\s*;?\s*$/i', $trimmed) === 1) {
         }
 
-        $this->shadowStore->ensure($targetTable);
-
         $definition = $this->registry->get($targetTable);
-        $existingRows = $this->shadowStore->get($targetTable);
-        if ($definition === null && $existingRows === []) {
+        if ($definition === null && $this->shadowStore->state($targetTable) !== ShadowTableState::Initialized) {
             throw new UnknownSchemaException($sql, $targetTable, 'table');
         }
 
+        $this->shadowStore->ensure($targetTable);
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
         return new DeleteMutation($targetTable, $primaryKeys);

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -13,7 +13,6 @@ use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
-use ZtdQuery\Shadow\ShadowTableState;
 
 /**
  * SQLite rewrite implementation for ZTD.
@@ -116,15 +115,6 @@ final class SqliteRewriter implements SqlRewriter
             return new RewritePlan('SELECT 1 WHERE 0', QueryKind::DDL_SIMULATED, $mutation);
         }
 
-        $type = $this->parser->classifyStatement($stmtSql);
-
-        if ($type === 'UPDATE' || $type === 'DELETE') {
-            $targetTable = $this->parser->extractTargetTable($stmtSql);
-            if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
-                $this->shadowStore->ensure($targetTable);
-            }
-        }
-
         $mutation = $this->mutationResolver->resolve($stmtSql, $kind);
 
         $stripped = trim($this->parser->stripComments($stmtSql));
@@ -219,12 +209,6 @@ final class SqliteRewriter implements SqlRewriter
         }
 
         return false;
-    }
-
-    private function mutationTableExists(string $tableName): bool
-    {
-        return $this->registry->has($tableName)
-            || $this->shadowStore->state($tableName) === ShadowTableState::Initialized;
     }
 
     private function hasSchemaContext(): bool

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -13,6 +13,7 @@ use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 /**
  * SQLite rewrite implementation for ZTD.
@@ -119,7 +120,7 @@ final class SqliteRewriter implements SqlRewriter
 
         if ($type === 'UPDATE' || $type === 'DELETE') {
             $targetTable = $this->parser->extractTargetTable($stmtSql);
-            if ($targetTable !== null) {
+            if ($targetTable !== null && $this->mutationTableExists($targetTable)) {
                 $this->shadowStore->ensure($targetTable);
             }
         }
@@ -209,7 +210,7 @@ final class SqliteRewriter implements SqlRewriter
 
     private function tableExists(string $tableName): bool
     {
-        if ($this->shadowStore->get($tableName) !== []) {
+        if ($this->shadowStore->has($tableName)) {
             return true;
         }
 
@@ -218,6 +219,12 @@ final class SqliteRewriter implements SqlRewriter
         }
 
         return false;
+    }
+
+    private function mutationTableExists(string $tableName): bool
+    {
+        return $this->registry->has($tableName)
+            || $this->shadowStore->state($tableName) === ShadowTableState::Initialized;
     }
 
     private function hasSchemaContext(): bool

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
@@ -910,14 +910,13 @@ final class SqliteMutationResolverTest extends TestCase
         self::assertSame('orders', $mutation->tableName());
     }
 
-    public function testResolveUpdateEnsuresShadowStore(): void
+    public function testResolveUpdateWithoutContextThrowsUnknownSchema(): void
     {
         $store = new ShadowStore();
         $registry = new TableDefinitionRegistry();
         $resolver = new SqliteMutationResolver($store, $registry, new SqliteSchemaParser(), new SqliteParser());
-        $mutation = $resolver->resolve("UPDATE t SET x = 1", QueryKind::WRITE_SIMULATED);
-        self::assertInstanceOf(UpdateMutation::class, $mutation);
-        self::assertSame('t', $mutation->tableName());
+        $this->expectException(UnknownSchemaException::class);
+        $resolver->resolve("UPDATE t SET x = 1", QueryKind::WRITE_SIMULATED);
     }
 
     public function testResolveDeleteTableName(): void
@@ -1671,14 +1670,13 @@ final class SqliteMutationResolverTest extends TestCase
         self::assertArrayNotHasKey('val', $def->columnTypes);
     }
 
-    public function testResolveUpdateReturnsMutationWithTargetTable(): void
+    public function testResolveUpdateWithoutTargetContextThrowsUnknownSchema(): void
     {
         $store = new ShadowStore();
         $registry = new TableDefinitionRegistry();
         $resolver = new SqliteMutationResolver($store, $registry, new SqliteSchemaParser(), new SqliteParser());
-        $mutation = $resolver->resolve("UPDATE users SET x = 1", QueryKind::WRITE_SIMULATED);
-        self::assertNotNull($mutation);
-        self::assertSame('users', $mutation->tableName());
+        $this->expectException(UnknownSchemaException::class);
+        $resolver->resolve("UPDATE users SET x = 1", QueryKind::WRITE_SIMULATED);
     }
 
     public function testResolveInsertIsReplaceReturnsPrimaryKeys(): void
@@ -2454,14 +2452,17 @@ final class SqliteMutationResolverTest extends TestCase
         self::assertSame(['id'], $def->notNullColumns);
     }
 
-    public function testResolveUpdateEnsuresShadowStoreEntryCreated(): void
+    public function testResolveUnknownUpdateDoesNotCreateShadowStoreEntry(): void
     {
         $store = new ShadowStore();
         $registry = new TableDefinitionRegistry();
         $resolver = new SqliteMutationResolver($store, $registry, new SqliteSchemaParser(), new SqliteParser());
-        self::assertSame([], $store->getAll());
-        $resolver->resolve("UPDATE t SET x = 1", QueryKind::WRITE_SIMULATED);
-        self::assertArrayHasKey('t', $store->getAll());
+        try {
+            $resolver->resolve("UPDATE t SET x = 1", QueryKind::WRITE_SIMULATED);
+            self::fail('Expected an unknown schema exception.');
+        } catch (UnknownSchemaException) {
+            self::assertSame([], $store->getAll());
+        }
     }
 
     public function testResolveDeleteEnsuresShadowStoreEntryCreated(): void
@@ -2615,5 +2616,20 @@ final class SqliteMutationResolverTest extends TestCase
         self::assertNotNull($def);
         self::assertSame([0, 1], array_keys($def->primaryKeys));
         self::assertSame(['a', 'c'], $def->primaryKeys);
+    }
+
+    public function testUpdateDoesNotTreatRowsFromUnknownInsertAsSchema(): void
+    {
+        $store = new ShadowStore();
+        $store->insert('late_table', [['id' => 1, 'name' => 'Alice']]);
+        $resolver = new SqliteMutationResolver(
+            $store,
+            new TableDefinitionRegistry(),
+            new SqliteSchemaParser(),
+            new SqliteParser(),
+        );
+
+        $this->expectException(UnknownSchemaException::class);
+        $resolver->resolve("UPDATE late_table SET name = 'Bob' WHERE id = 1", QueryKind::WRITE_SIMULATED);
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
@@ -24,6 +24,7 @@ use ZtdQuery\Shadow\Mutation\ReplaceMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(SqliteMutationResolver::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
@@ -1154,7 +1155,7 @@ final class SqliteMutationResolverTest extends TestCase
         $mutation = $resolver->resolve("UPDATE users SET name = 'Bob' WHERE id = 1", QueryKind::WRITE_SIMULATED);
         self::assertNotNull($mutation);
         self::assertInstanceOf(UpdateMutation::class, $mutation);
-        self::assertSame([], $store->get('users'));
+        self::assertSame(ShadowTableState::Initialized, $store->state('users'));
     }
 
     public function testResolveUpdatePrimaryKeysFromDefinition(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\RewriterContractTest;
+use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
@@ -34,6 +35,7 @@ use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(SqliteRewriter::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
@@ -1664,5 +1666,19 @@ final class SqliteRewriterTest extends RewriterContractTest
         $sql = $plan->sql();
         self::assertStringContainsString('"users"', $sql);
         self::assertStringContainsString('"orders"', $sql);
+    }
+
+    public function testUpdateDoesNotPromoteMaterializedUnknownTable(): void
+    {
+        $store = new ShadowStore();
+        $store->insert('late_table', [['id' => 1, 'name' => 'Alice']]);
+        $rewriter = $this->createRewriter($store, new TableDefinitionRegistry());
+
+        try {
+            $rewriter->rewrite("UPDATE late_table SET name = 'Bob' WHERE id = 1");
+            self::fail('Expected an unknown schema exception.');
+        } catch (UnknownSchemaException) {
+            self::assertSame(ShadowTableState::Materialized, $store->state('late_table'));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- model shadow-table presence as `Missing`, `Materialized`, or `Initialized`
- preserve passthrough semantics for DML against tables whose schema is unknown
- keep prior shadow mutations on the simulation path and clear state on DROP
- apply the same state contract to MySQL, PostgreSQL, and SQLite

## Recurrence prevention

The decision is now driven by a typed shadow state rather than an empty-array check. Unit coverage spans all three dialects and SQLite adapter integration covers passthrough, strict mode, and prior-shadow mutation behavior.

## Validation

- core unit: 293 tests
- MySQL unit: 889 tests
- PostgreSQL unit: 1,296 tests
- SQLite unit: 1,179 tests
- SQLite adapter error integration: 8 tests

Stacked on #213.

Fixes #39