### PR TITLE
fix: type simulation error boundaries

### DIFF
--- a/packages/ztd-query-core/src/Exception/ColumnAlreadyExistsException.php
+++ b/packages/ztd-query-core/src/Exception/ColumnAlreadyExistsException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when attempting to add a column that already exists.
  */
-final class ColumnAlreadyExistsException extends RuntimeException
+final class ColumnAlreadyExistsException extends SimulationException
 {
     /**
      * The SQL statement that attempted to add the column.

--- a/packages/ztd-query-core/src/Exception/ColumnNotFoundException.php
+++ b/packages/ztd-query-core/src/Exception/ColumnNotFoundException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when a referenced column does not exist.
  */
-final class ColumnNotFoundException extends RuntimeException
+final class ColumnNotFoundException extends SimulationException
 {
     /**
      * The SQL statement that referenced the non-existent column.

--- a/packages/ztd-query-core/src/Exception/DuplicateKeyException.php
+++ b/packages/ztd-query-core/src/Exception/DuplicateKeyException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when a PRIMARY KEY or UNIQUE constraint is violated.
  */
-final class DuplicateKeyException extends RuntimeException
+final class DuplicateKeyException extends SimulationException
 {
     /**
      * The SQL statement that caused the violation.

--- a/packages/ztd-query-core/src/Exception/ForeignKeyViolationException.php
+++ b/packages/ztd-query-core/src/Exception/ForeignKeyViolationException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when a FOREIGN KEY constraint is violated.
  */
-final class ForeignKeyViolationException extends RuntimeException
+final class ForeignKeyViolationException extends SimulationException
 {
     /**
      * The SQL statement that caused the violation.

--- a/packages/ztd-query-core/src/Exception/MissingPrimaryKeyException.php
+++ b/packages/ztd-query-core/src/Exception/MissingPrimaryKeyException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Exception;
+
+/**
+ * Exception thrown when an UPDATE result cannot be matched to a shadow row.
+ */
+final class MissingPrimaryKeyException extends SimulationException
+{
+    private string $tableName;
+
+    public function __construct(string $tableName)
+    {
+        parent::__construct("UPDATE simulation requires primary keys for '$tableName'.");
+        $this->tableName = $tableName;
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+}

--- a/packages/ztd-query-core/src/Exception/NotNullViolationException.php
+++ b/packages/ztd-query-core/src/Exception/NotNullViolationException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when a NOT NULL constraint is violated.
  */
-final class NotNullViolationException extends RuntimeException
+final class NotNullViolationException extends SimulationException
 {
     /**
      * The SQL statement that caused the violation.

--- a/packages/ztd-query-core/src/Exception/SchemaNotFoundException.php
+++ b/packages/ztd-query-core/src/Exception/SchemaNotFoundException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when a referenced table does not exist.
  */
-final class SchemaNotFoundException extends RuntimeException
+final class SchemaNotFoundException extends SimulationException
 {
     /**
      * The SQL statement that referenced the non-existent table.

--- a/packages/ztd-query-core/src/Exception/SimulationException.php
+++ b/packages/ztd-query-core/src/Exception/SimulationException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Exception;
+
+use RuntimeException;
+
+/**
+ * Base type for failures produced by ZTD simulation rather than the driver.
+ */
+abstract class SimulationException extends RuntimeException
+{
+}

--- a/packages/ztd-query-core/src/Exception/SqlParseException.php
+++ b/packages/ztd-query-core/src/Exception/SqlParseException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when SQL parsing fails due to syntax errors.
  */
-final class SqlParseException extends RuntimeException
+final class SqlParseException extends SimulationException
 {
     /**
      * The SQL statement that failed to parse.

--- a/packages/ztd-query-core/src/Exception/TableAlreadyExistsException.php
+++ b/packages/ztd-query-core/src/Exception/TableAlreadyExistsException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when attempting to create a table that already exists.
  */
-final class TableAlreadyExistsException extends RuntimeException
+final class TableAlreadyExistsException extends SimulationException
 {
     /**
      * The SQL statement that attempted to create the table.

--- a/packages/ztd-query-core/src/Exception/UnknownSchemaException.php
+++ b/packages/ztd-query-core/src/Exception/UnknownSchemaException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when a query references unknown tables or columns.
  */
-final class UnknownSchemaException extends RuntimeException
+final class UnknownSchemaException extends SimulationException
 {
     /**
      * The SQL statement that referenced unknown schema.

--- a/packages/ztd-query-core/src/Exception/UnsupportedSqlException.php
+++ b/packages/ztd-query-core/src/Exception/UnsupportedSqlException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Exception;
 
-use RuntimeException;
-
 /**
  * Exception thrown when an unsupported SQL statement is executed.
  */
-final class UnsupportedSqlException extends RuntimeException
+final class UnsupportedSqlException extends SimulationException
 {
     /**
      * The unsupported SQL statement.

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -11,11 +11,13 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Connection\StatementInterface;
+use ZtdQuery\Exception\SimulationException;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Shadow\Mutation\ShadowMutation;
 use ZtdQuery\Shadow\ShadowStore;
 
 /**
@@ -207,7 +209,7 @@ final class Session
         if ($mutation === null) {
             throw new RuntimeException('ZTD Write Protection: Missing shadow mutation for write simulation.');
         }
-        $mutation->apply($this->shadowStore, $rows);
+        $this->applyMutation($mutation, $rows);
 
         return GenericExecuteResult::fromBufferedRows($rows, QueryKind::WRITE_SIMULATED);
     }
@@ -231,7 +233,7 @@ final class Session
         }
 
         $rows = $this->resultSelectRunner->run($plan->sql(), $executor);
-        $mutation->apply($this->shadowStore, $rows);
+        $this->applyMutation($mutation, $rows);
 
         return $rows;
     }
@@ -265,8 +267,24 @@ final class Session
         }
 
         $rows = $this->resultSelectRunner->run($plan->sql(), fn (string $s) => $this->connection->query($s));
-        $mutation->apply($this->shadowStore, $rows);
+        $this->applyMutation($mutation, $rows);
 
         return count($rows);
+    }
+
+    /**
+     * Apply a mutation without leaking simulation-specific exception types
+     * through the connection adapter boundary.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     * @throws DatabaseException When shadow mutation application fails.
+     */
+    private function applyMutation(ShadowMutation $mutation, array $rows): void
+    {
+        try {
+            $mutation->apply($this->shadowStore, $rows);
+        } catch (SimulationException $e) {
+            throw new DatabaseException($e->getMessage(), null, 0, $e);
+        }
     }
 }

--- a/packages/ztd-query-core/src/Shadow/ShadowStore.php
+++ b/packages/ztd-query-core/src/Shadow/ShadowStore.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Shadow;
 
+use ZtdQuery\Exception\MissingPrimaryKeyException;
+
 /**
  * Holds in-memory shadow rows for tables.
  */
@@ -120,7 +122,7 @@ class ShadowStore
         }
 
         if ($primaryKeys === []) {
-            throw new \RuntimeException("UPDATE simulation requires primary keys for '$tableName'.");
+            throw new MissingPrimaryKeyException($tableName);
         }
 
         $currentRows = &$this->fixtures[$tableName];

--- a/packages/ztd-query-core/tests/Unit/Exception/MissingPrimaryKeyExceptionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Exception/MissingPrimaryKeyExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\MissingPrimaryKeyException;
+use ZtdQuery\Exception\SimulationException;
+
+#[CoversClass(MissingPrimaryKeyException::class)]
+final class MissingPrimaryKeyExceptionTest extends TestCase
+{
+    public function testCarriesTableContext(): void
+    {
+        $exception = new MissingPrimaryKeyException('users');
+
+        self::assertInstanceOf(SimulationException::class, $exception);
+        self::assertSame('users', $exception->getTableName());
+        self::assertSame("UPDATE simulation requires primary keys for 'users'.", $exception->getMessage());
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Exception/SimulationExceptionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Exception/SimulationExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ZtdQuery\Exception\SimulationException;
+
+#[CoversClass(SimulationException::class)]
+final class SimulationExceptionTest extends TestCase
+{
+    public function testProvidesTypedRuntimeExceptionBoundary(): void
+    {
+        $exception = new class ('simulation failed') extends SimulationException {
+        };
+
+        self::assertInstanceOf(RuntimeException::class, $exception);
+        self::assertSame('simulation failed', $exception->getMessage());
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -26,6 +26,8 @@ use ZtdQuery\Shadow\ShadowStore;
 #[UsesClass(ShadowStore::class)]
 #[UsesClass(TableDefinitionRegistry::class)]
 #[UsesClass(ResultSelectRunner::class)]
+#[UsesClass(DatabaseException::class)]
+#[UsesClass(RewritePlan::class)]
 #[UsesClass(UpdateMutation::class)]
 #[UsesClass(MissingPrimaryKeyException::class)]
 final class SessionTest extends TestCase
@@ -75,6 +77,7 @@ final class SessionTest extends TestCase
             $session->processExecutedStatement($plan, new FakeStatement([['id' => 1, 'name' => 'Bob']]));
             self::fail('Expected a database exception.');
         } catch (DatabaseException $exception) {
+            self::assertSame(0, $exception->getCode());
             self::assertInstanceOf(MissingPrimaryKeyException::class, $exception->getPrevious());
         }
     }

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -9,10 +9,16 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Tests\Fake\FakeConnection;
 use Tests\Fake\FakeSqlRewriter;
+use Tests\Fake\FakeStatement;
 use ZtdQuery\Config\ZtdConfig;
+use ZtdQuery\Connection\Exception\DatabaseException;
+use ZtdQuery\Exception\MissingPrimaryKeyException;
 use ZtdQuery\ResultSelectRunner;
+use ZtdQuery\Rewrite\QueryKind;
+use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Session;
+use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(Session::class)]
@@ -20,6 +26,8 @@ use ZtdQuery\Shadow\ShadowStore;
 #[UsesClass(ShadowStore::class)]
 #[UsesClass(TableDefinitionRegistry::class)]
 #[UsesClass(ResultSelectRunner::class)]
+#[UsesClass(UpdateMutation::class)]
+#[UsesClass(MissingPrimaryKeyException::class)]
 final class SessionTest extends TestCase
 {
     public function testEnableAndDisable(): void
@@ -43,5 +51,31 @@ final class SessionTest extends TestCase
 
         $session->enable();
         self::assertTrue($session->isEnabled());
+    }
+
+    public function testMutationFailureIsConvertedToDatabaseException(): void
+    {
+        $shadowStore = new ShadowStore();
+        $shadowStore->set('users', [['id' => 1, 'name' => 'Alice']]);
+        $registry = new TableDefinitionRegistry();
+        $session = new Session(
+            new FakeSqlRewriter($shadowStore, $registry),
+            $shadowStore,
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            new FakeConnection(),
+        );
+        $plan = new RewritePlan(
+            "SELECT 1 AS id, 'Bob' AS name",
+            QueryKind::WRITE_SIMULATED,
+            new UpdateMutation('users', []),
+        );
+
+        try {
+            $session->processExecutedStatement($plan, new FakeStatement([['id' => 1, 'name' => 'Bob']]));
+            self::fail('Expected a database exception.');
+        } catch (DatabaseException $exception) {
+            self::assertInstanceOf(MissingPrimaryKeyException::class, $exception->getPrevious());
+        }
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Shadow;
 
-use ZtdQuery\Shadow\ShadowStore;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\MissingPrimaryKeyException;
+use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(ShadowStore::class)]
 class ShadowStoreTest extends TestCase
@@ -92,7 +93,7 @@ class ShadowStoreTest extends TestCase
         $store = new ShadowStore();
         $store->set('users', [['id' => 1, 'name' => 'Alice']]);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(MissingPrimaryKeyException::class);
         $store->update('users', [['id' => 1, 'name' => 'Updated']], []);
     }
 

--- a/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Tests\Unit\Shadow;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\MissingPrimaryKeyException;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(ShadowStore::class)]
+#[UsesClass(MissingPrimaryKeyException::class)]
 class ShadowStoreTest extends TestCase
 {
     public function testInsertAppendsRows(): void

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -13,7 +13,9 @@ use Fuzz\Robustness\Invariant\RewriteExceptionTypeChecker;
 use Fuzz\Robustness\Invariant\RewritePlanConsistencyChecker;
 use Fuzz\Robustness\Invariant\ShadowStoreConsistencyChecker;
 use SqlFaker\MySqlProvider;
-use Throwable;
+use ZtdQuery\Exception\SimulationException;
+use ZtdQuery\Exception\UnknownSchemaException;
+use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlQueryGuard;
@@ -90,14 +92,18 @@ final class RobustnessTarget
         }
 
         try {
-            $plan = $this->rewriter->rewrite($sql);
+            try {
+                $plan = $this->rewriter->rewrite($sql);
+            } catch (UnsupportedSqlException | UnknownSchemaException) {
+                return;
+            }
 
             if ($plan->kind() === QueryKind::WRITE_SIMULATED || $plan->kind() === QueryKind::DDL_SIMULATED) {
                 $mutation = $plan->mutation();
                 if ($mutation !== null) {
                     try {
                         $mutation->apply($this->shadowStore, []);
-                    } catch (Throwable) {
+                    } catch (SimulationException) {
                     }
 
                     $violation = $this->storeChecker->check($sql);
@@ -106,10 +112,9 @@ final class RobustnessTarget
                     }
                 }
             }
-        } catch (Throwable) {
+        } finally {
+            $this->resetShadowStore();
         }
-
-        $this->resetShadowStore();
     }
 
     private function resetShadowStore(): void

--- a/packages/ztd-query-mysqli-adapter/src/ZtdMysqliStatement.php
+++ b/packages/ztd-query-mysqli-adapter/src/ZtdMysqliStatement.php
@@ -7,6 +7,7 @@ namespace ZtdQuery\Adapter\Mysqli;
 use mysqli_result;
 use mysqli_stmt;
 use mysqli_warning;
+use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\ExecuteResult;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Session;
@@ -179,10 +180,14 @@ final class ZtdMysqliStatement extends mysqli_stmt
         $this->cachedMysqliResult = $this->delegate->get_result();
 
         if ($this->cachedMysqliResult !== false) {
-            $this->result = $this->session->processExecutedStatement(
-                $this->plan,
-                new MysqliResultStatement($this->cachedMysqliResult, $this->delegate->affected_rows)
-            );
+            try {
+                $this->result = $this->session->processExecutedStatement(
+                    $this->plan,
+                    new MysqliResultStatement($this->cachedMysqliResult, $this->delegate->affected_rows)
+                );
+            } catch (DatabaseException $e) {
+                throw new ZtdMysqliException($e->getMessage(), 0, $e);
+            }
         } else {
             // No result set (e.g., for WRITE operations that don't return rows)
             $this->result = $this->session->createEmptyWriteResult();

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdoStatement.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdoStatement.php
@@ -7,6 +7,7 @@ namespace ZtdQuery\Adapter\Pdo;
 use Iterator;
 use PDO;
 use PDOStatement as NativePdoStatement;
+use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\ExecuteResult;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Session;
@@ -112,10 +113,14 @@ final class ZtdPdoStatement extends NativePdoStatement
             return false;
         }
 
-        $this->result = $this->session->processExecutedStatement(
-            $this->plan,
-            new PdoStatement($this->statement)
-        );
+        try {
+            $this->result = $this->session->processExecutedStatement(
+                $this->plan,
+                new PdoStatement($this->statement)
+            );
+        } catch (DatabaseException $e) {
+            throw new ZtdPdoException($e->getMessage(), 0, $e);
+        }
 
         return $this->result->isSuccess();
     }

--- a/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoStatementTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoStatementTest.php
@@ -95,6 +95,7 @@ final class ZtdPdoStatementTest extends TestCase
             $stmt->execute();
             self::fail('Expected a ZTD PDO exception.');
         } catch (ZtdPdoException $exception) {
+            self::assertSame(0, $exception->getCode());
             $databaseException = $exception->getPrevious();
             self::assertInstanceOf(DatabaseException::class, $databaseException);
             self::assertInstanceOf(MissingPrimaryKeyException::class, $databaseException->getPrevious());

--- a/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoStatementTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoStatementTest.php
@@ -9,18 +9,23 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\PdoStatement;
+use ZtdQuery\Adapter\Pdo\ZtdPdoException;
 use ZtdQuery\Adapter\Pdo\ZtdPdoStatement;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
+use ZtdQuery\Connection\Exception\DatabaseException;
+use ZtdQuery\Exception\MissingPrimaryKeyException;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Session;
+use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(ZtdPdoStatement::class)]
 #[UsesClass(PdoStatement::class)]
+#[UsesClass(ZtdPdoException::class)]
 final class ZtdPdoStatementTest extends TestCase
 {
     public function testExecuteDelegatesWhenNoPlan(): void
@@ -62,6 +67,38 @@ final class ZtdPdoStatementTest extends TestCase
         $session = new Session(static::createStub(SqlRewriter::class), new ShadowStore(), new ResultSelectRunner(), ZtdConfig::default(), static::createStub(ConnectionInterface::class));
         $stmt = new ZtdPdoStatement($inner, $session, $plan);
         self::assertTrue($stmt->execute());
+    }
+
+    public function testExecuteWrapsSimulationFailureAsAdapterException(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $inner = $pdo->prepare("SELECT 1 AS id, 'Bob' AS name");
+        self::assertNotFalse($inner);
+
+        $shadowStore = new ShadowStore();
+        $shadowStore->set('users', [['id' => 1, 'name' => 'Alice']]);
+        $session = new Session(
+            static::createStub(SqlRewriter::class),
+            $shadowStore,
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            static::createStub(ConnectionInterface::class),
+        );
+        $plan = new RewritePlan(
+            "SELECT 1 AS id, 'Bob' AS name",
+            QueryKind::WRITE_SIMULATED,
+            new UpdateMutation('users', []),
+        );
+        $stmt = new ZtdPdoStatement($inner, $session, $plan);
+
+        try {
+            $stmt->execute();
+            self::fail('Expected a ZTD PDO exception.');
+        } catch (ZtdPdoException $exception) {
+            $databaseException = $exception->getPrevious();
+            self::assertInstanceOf(DatabaseException::class, $databaseException);
+            self::assertInstanceOf(MissingPrimaryKeyException::class, $databaseException->getPrevious());
+        }
     }
 
     public function testBindValueDelegatesToInner(): void

--- a/packages/ztd-query-postgres/fuzz/Robustness/Invariant/ShadowStoreConsistencyChecker.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Invariant/ShadowStoreConsistencyChecker.php
@@ -16,31 +16,19 @@ final class ShadowStoreConsistencyChecker
     }
 
     /**
-     * Check that all shadow store tables maintain array-of-arrays structure.
+     * Check that every shadow store entry has a usable table key.
+     *
+     * Empty row sets are valid after CREATE, DELETE, and TRUNCATE.
      */
     public function check(string $sql): ?InvariantViolation
     {
-        $allData = $this->store->getAll();
-
-        foreach ($allData as $tableName => $rows) {
-            if ($rows === []) {
+        foreach (array_keys($this->store->getAll()) as $tableName) {
+            if ($tableName === '') {
                 return new InvariantViolation(
-                    'INV-L4-01',
-                    sprintf('ShadowStore table "%s" is empty', $tableName),
+                    'SHADOW_EMPTY_KEY',
+                    'ShadowStore contains an empty table name key',
                     $sql,
-                    ['table' => $tableName]
                 );
-            }
-
-            foreach ($rows as $index => $row) {
-                if ($row === []) {
-                    return new InvariantViolation(
-                        'INV-L4-01',
-                        sprintf('ShadowStore table "%s" row %d is empty', $tableName, $index),
-                        $sql,
-                        ['table' => $tableName, 'row_index' => $index]
-                    );
-                }
             }
         }
 

--- a/packages/ztd-query-postgres/fuzz/Robustness/Invariant/ShadowStoreConsistencyCheckerTest.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Invariant/ShadowStoreConsistencyCheckerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fuzz\Robustness\Invariant;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Shadow\ShadowStore;
+
+#[CoversNothing]
+final class ShadowStoreConsistencyCheckerTest extends TestCase
+{
+    public function testAllowsEmptyInitializedTable(): void
+    {
+        $store = new ShadowStore();
+        $store->ensure('events');
+
+        self::assertNull((new ShadowStoreConsistencyChecker($store))->check('CREATE TABLE events (id INT)'));
+    }
+
+    public function testRejectsEmptyTableName(): void
+    {
+        $store = new ShadowStore();
+        $store->ensure('');
+
+        $violation = (new ShadowStoreConsistencyChecker($store))->check('SELECT 1');
+
+        self::assertNotNull($violation);
+        self::assertSame('SHADOW_EMPTY_KEY', $violation->id());
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
@@ -13,7 +13,9 @@ use Fuzz\Robustness\Invariant\RewriteExceptionTypeChecker;
 use Fuzz\Robustness\Invariant\RewritePlanConsistencyChecker;
 use Fuzz\Robustness\Invariant\ShadowStoreConsistencyChecker;
 use SqlFaker\PostgreSqlProvider;
-use Throwable;
+use ZtdQuery\Exception\SimulationException;
+use ZtdQuery\Exception\UnknownSchemaException;
+use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlMutationResolver;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\PgSqlQueryGuard;
@@ -88,14 +90,18 @@ final class RobustnessTarget
         }
 
         try {
-            $plan = $this->rewriter->rewrite($sql);
+            try {
+                $plan = $this->rewriter->rewrite($sql);
+            } catch (UnsupportedSqlException | UnknownSchemaException) {
+                return;
+            }
 
             if ($plan->kind() === QueryKind::WRITE_SIMULATED || $plan->kind() === QueryKind::DDL_SIMULATED) {
                 $mutation = $plan->mutation();
                 if ($mutation !== null) {
                     try {
                         $mutation->apply($this->shadowStore, []);
-                    } catch (Throwable) {
+                    } catch (SimulationException) {
                     }
 
                     $violation = $this->storeChecker->check($sql);
@@ -104,10 +110,9 @@ final class RobustnessTarget
                     }
                 }
             }
-        } catch (Throwable) {
+        } finally {
+            $this->resetShadowStore();
         }
-
-        $this->resetShadowStore();
     }
 
     private function resetShadowStore(): void

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RobustnessTarget.php
@@ -13,7 +13,9 @@ use Fuzz\Robustness\Invariant\RewriteExceptionTypeChecker;
 use Fuzz\Robustness\Invariant\RewritePlanConsistencyChecker;
 use Fuzz\Robustness\Invariant\ShadowStoreConsistencyChecker;
 use SqlFaker\SqliteProvider;
-use Throwable;
+use ZtdQuery\Exception\SimulationException;
+use ZtdQuery\Exception\UnknownSchemaException;
+use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteMutationResolver;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
@@ -88,14 +90,18 @@ final class RobustnessTarget
         }
 
         try {
-            $plan = $this->rewriter->rewrite($sql);
+            try {
+                $plan = $this->rewriter->rewrite($sql);
+            } catch (UnsupportedSqlException | UnknownSchemaException) {
+                return;
+            }
 
             if ($plan->kind() === QueryKind::WRITE_SIMULATED || $plan->kind() === QueryKind::DDL_SIMULATED) {
                 $mutation = $plan->mutation();
                 if ($mutation !== null) {
                     try {
                         $mutation->apply($this->shadowStore, []);
-                    } catch (Throwable) {
+                    } catch (SimulationException) {
                     }
 
                     $violation = $this->storeChecker->check($sql);
@@ -104,10 +110,9 @@ final class RobustnessTarget
                     }
                 }
             }
-        } catch (Throwable) {
+        } finally {
+            $this->resetShadowStore();
         }
-
-        $this->resetShadowStore();
     }
 
     private function resetShadowStore(): void


### PR DESCRIPTION
## Summary

- introduce a typed `SimulationException` hierarchy for expected simulation failures
- translate simulation failures to the configured database exception at the session boundary
- keep unexpected defects visible to robustness fuzzing instead of swallowing every `Throwable`
- cover exception translation in core and PDO/MySQLi adapter tests

## Recurrence prevention

Robustness targets now allow only the explicit simulation/rewrite exception contract. New internal defects fail fuzzing instead of being misclassified as expected input errors.

## Validation

- core unit: 289 tests
- MySQL unit: 888 tests
- PostgreSQL unit + fuzz PHPUnit: 1,295 + 30 tests
- SQLite unit + fuzz PHPUnit: 1,178 + 28 tests
- PDO unit: 265 tests
- MySQLi unit: 52 tests

Fixes #2