### PR TITLE
fix: preserve typed shadow values

### DIFF
--- a/packages/ztd-query-core/src/Platform/ValueRenderer.php
+++ b/packages/ztd-query-core/src/Platform/ValueRenderer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform;
+
+use ZtdQuery\Schema\ColumnType;
+
+/**
+ * Encodes a PHP value as a dialect-specific, typed SQL expression.
+ */
+interface ValueRenderer
+{
+    public function renderValue(mixed $value, ?ColumnType $type = null): string;
+}

--- a/packages/ztd-query-core/tests/Unit/Platform/ValueRendererTest.php
+++ b/packages/ztd-query-core/tests/Unit/Platform/ValueRendererTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Platform;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\ValueRenderer;
 
-#[CoversClass(ValueRenderer::class)]
+#[CoversNothing]
 final class ValueRendererTest extends TestCase
 {
     public function testDeclaresTypedValueRenderingContract(): void

--- a/packages/ztd-query-core/tests/Unit/Platform/ValueRendererTest.php
+++ b/packages/ztd-query-core/tests/Unit/Platform/ValueRendererTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\ValueRenderer;
+
+#[CoversClass(ValueRenderer::class)]
+final class ValueRendererTest extends TestCase
+{
+    public function testDeclaresTypedValueRenderingContract(): void
+    {
+        $reflection = new \ReflectionClass(ValueRenderer::class);
+
+        self::assertTrue($reflection->isInterface());
+        self::assertTrue($reflection->hasMethod('renderValue'));
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlValueRenderer.php
+++ b/packages/ztd-query-mysql/src/MySqlValueRenderer.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use Stringable;
+use ZtdQuery\Platform\CastRenderer;
+use ZtdQuery\Platform\ValueRenderer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+/**
+ * Encodes shadow values without relying on MySQL string escape modes.
+ */
+final class MySqlValueRenderer implements ValueRenderer
+{
+    public function __construct(private readonly CastRenderer $castRenderer = new MySqlCastRenderer())
+    {
+    }
+
+    public function renderValue(mixed $value, ?ColumnType $type = null): string
+    {
+        if ($value === null) {
+            return 'NULL';
+        }
+
+        if ($type === null && is_bool($value)) {
+            return $value ? 'TRUE' : 'FALSE';
+        }
+
+        if ($type === null && is_float($value)) {
+            return var_export($value, true);
+        }
+
+        if ($type === null && $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        $resolvedType = $type ?? $this->inferType($value);
+        $expression = $this->renderExpression($value, $resolvedType, $type !== null);
+
+        return $this->castRenderer->renderCast($expression, $resolvedType);
+    }
+
+    private function renderExpression(mixed $value, ColumnType $type, bool $typed): string
+    {
+        if ($type->family === ColumnTypeFamily::BINARY) {
+            return "X'" . bin2hex($this->stringValue($value)) . "'";
+        }
+
+        if (is_bool($value)) {
+            return $this->quoteValue($value ? '1' : '0');
+        }
+
+        if (is_int($value) && !$typed) {
+            return (string) $value;
+        }
+
+        $string = is_float($value) ? var_export($value, true) : $this->stringValue($value);
+        if (!str_contains($string, '\\')) {
+            return $this->quoteValue($string);
+        }
+        $hex = bin2hex($string);
+
+        return "CONVERT(X'$hex' USING utf8mb4)";
+    }
+
+    private function inferType(mixed $value): ColumnType
+    {
+        return match (true) {
+            is_int($value) => new ColumnType(ColumnTypeFamily::INTEGER, 'INT'),
+            is_float($value) => new ColumnType(ColumnTypeFamily::DOUBLE, 'DOUBLE'),
+            is_bool($value) => new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN'),
+            default => new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR'),
+        };
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+        if (is_resource($value) && get_resource_type($value) === 'stream') {
+            return $this->readStream($value);
+        }
+
+        throw new \RuntimeException('Unsupported value type for CTE shadowing.');
+    }
+
+    /** @param resource $stream */
+    private function readStream($stream): string
+    {
+        $position = ftell($stream);
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        if ($position !== false) {
+            fseek($stream, $position);
+        }
+
+        return $contents === false ? '' : $contents;
+    }
+
+    private function quoteValue(string $value): string
+    {
+        return "'" . str_replace("'", "''", $value) . "'";
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlValueRenderer.php
+++ b/packages/ztd-query-mysql/src/MySqlValueRenderer.php
@@ -49,10 +49,6 @@ final class MySqlValueRenderer implements ValueRenderer
             return "X'" . bin2hex($this->stringValue($value)) . "'";
         }
 
-        if (is_bool($value)) {
-            return $this->quoteValue($value ? '1' : '0');
-        }
-
         if (is_int($value) && !$typed) {
             return (string) $value;
         }
@@ -68,19 +64,15 @@ final class MySqlValueRenderer implements ValueRenderer
 
     private function inferType(mixed $value): ColumnType
     {
-        return match (true) {
-            is_int($value) => new ColumnType(ColumnTypeFamily::INTEGER, 'INT'),
-            is_float($value) => new ColumnType(ColumnTypeFamily::DOUBLE, 'DOUBLE'),
-            is_bool($value) => new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN'),
-            default => new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR'),
-        };
+        if (is_int($value)) {
+            return new ColumnType(ColumnTypeFamily::INTEGER, 'INT');
+        }
+
+        return new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR');
     }
 
     private function stringValue(mixed $value): string
     {
-        if (is_string($value)) {
-            return $value;
-        }
         if ($value instanceof Stringable) {
             return (string) $value;
         }

--- a/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
@@ -16,8 +16,11 @@ use PhpMyAdmin\SqlParser\Statements\InsertStatement;
 use PhpMyAdmin\SqlParser\Statements\SelectStatement as PhpMyAdminSelectStatement;
 use RuntimeException;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\CastRenderer;
+use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Rewrite\SqlTransformer;
+use ZtdQuery\Schema\ColumnType;
 
 /**
  * Transforms INSERT statements into SELECT queries that return the inserted rows.
@@ -27,11 +30,16 @@ final class InsertTransformer implements SqlTransformer
 {
     private MySqlParser $parser;
     private SelectTransformer $selectTransformer;
+    private CastRenderer $castRenderer;
 
-    public function __construct(MySqlParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        MySqlParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CastRenderer $castRenderer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->castRenderer = $castRenderer ?? new MySqlCastRenderer();
     }
 
     /**
@@ -65,20 +73,22 @@ final class InsertTransformer implements SqlTransformer
             throw new UnsupportedSqlException($sql, 'Cannot determine columns');
         }
 
-        $selectSql = $this->buildInsertSelect($statement, $columns);
+        $columnTypes = $tables[$tableName]['columnTypes'] ?? [];
+        $selectSql = $this->buildInsertSelect($statement, $columns, $columnTypes);
 
         return $this->selectTransformer->transform($selectSql, $tables);
     }
 
     /**
      * @param array<int, string> $columns
+     * @param array<string, ColumnType> $columnTypes
      */
-    private function buildInsertSelect(InsertStatement $statement, array $columns): string
+    private function buildInsertSelect(InsertStatement $statement, array $columns, array $columnTypes): string
     {
         if ($statement->values !== null && $statement->values !== []) {
             $rows = [];
             foreach ($statement->values as $valueSet) {
-                $rows[] = $this->buildInsertRowSelect($valueSet, $columns);
+                $rows[] = $this->buildInsertRowSelect($valueSet, $columns, $columnTypes);
             }
 
             return implode(' UNION ALL ', $rows);
@@ -97,8 +107,9 @@ final class InsertTransformer implements SqlTransformer
 
     /**
      * @param array<int, string> $columns
+     * @param array<string, ColumnType> $columnTypes
      */
-    private function buildInsertRowSelect(ArrayObj $valueSet, array $columns): string
+    private function buildInsertRowSelect(ArrayObj $valueSet, array $columns, array $columnTypes): string
     {
         $values = $valueSet->raw !== [] ? $valueSet->raw : $valueSet->values;
         if (count($values) !== count($columns)) {
@@ -108,6 +119,10 @@ final class InsertTransformer implements SqlTransformer
         $selects = [];
         foreach ($columns as $index => $column) {
             $expr = trim($values[$index]);
+            $type = $columnTypes[$column] ?? null;
+            if ($type instanceof ColumnType) {
+                $expr = $this->castRenderer->renderCast($expr, $type);
+            }
             $selects[] = $expr . ' AS `' . $column . '`';
         }
 

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -8,6 +8,7 @@ use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
+use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -22,11 +23,16 @@ final class SelectTransformer implements SqlTransformer
 {
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
+    private ValueRenderer $valueRenderer;
 
-    public function __construct(?CastRenderer $castRenderer = null, ?IdentifierQuoter $quoter = null)
-    {
+    public function __construct(
+        ?CastRenderer $castRenderer = null,
+        ?IdentifierQuoter $quoter = null,
+        ?ValueRenderer $valueRenderer = null,
+    ) {
         $this->castRenderer = $castRenderer ?? new MySqlCastRenderer();
         $this->quoter = $quoter ?? new MySqlIdentifierQuoter();
+        $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\MySql\MySqlValueRenderer($this->castRenderer);
     }
 
     /**
@@ -144,49 +150,16 @@ final class SelectTransformer implements SqlTransformer
 
     private function formatValue(mixed $val, ?ColumnType $type = null): string
     {
-        if (is_null($val)) {
-            return "NULL";
+        if ($type !== null
+            && $val !== null
+            && is_scalar($val)
+            && $type->family === ColumnTypeFamily::STRING
+            && str_starts_with(strtoupper($type->nativeType), 'SET(')
+        ) {
+            $val = $this->normalizeSetValue((string) $val, $type->nativeType);
         }
 
-        if ($type !== null) {
-            return $this->formatWithColumnType($val, $type);
-        }
-
-        if (is_int($val)) {
-            return $this->castRenderer->renderCast(
-                (string) $val,
-                new ColumnType(ColumnTypeFamily::INTEGER, 'INT'),
-            );
-        }
-        if (is_string($val)) {
-            return $this->castRenderer->renderCast(
-                $this->quoteValue($val),
-                new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR'),
-            );
-        }
-        if (is_bool($val)) {
-            return $val ? "TRUE" : "FALSE";
-        }
-        if (is_float($val)) {
-            return (string) $val;
-        }
-        if (is_object($val) && method_exists($val, '__toString')) {
-            return (string) $val;
-        }
-        throw new \RuntimeException('Unsupported value type for CTE shadowing.');
-    }
-
-    private function formatWithColumnType(mixed $val, ColumnType $type): string
-    {
-        $strVal = is_scalar($val) ? (string) $val : ($val === null ? '' : serialize($val));
-
-        if ($type->family === ColumnTypeFamily::STRING && str_starts_with(strtoupper($type->nativeType), 'SET(')) {
-            $strVal = $this->normalizeSetValue($strVal, $type->nativeType);
-        }
-
-        $quotedVal = $this->quoteValue($strVal);
-
-        return $this->castRenderer->renderCast($quotedVal, $type);
+        return $this->valueRenderer->renderValue($val, $type);
     }
 
     private function renderFallbackNullCast(): string
@@ -194,11 +167,6 @@ final class SelectTransformer implements SqlTransformer
         return $this->castRenderer->renderNullCast(
             new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR'),
         );
-    }
-
-    private function quoteValue(string $val): string
-    {
-        return "'" . str_replace("'", "''", $val) . "'";
     }
 
     private function normalizeSetValue(string $value, string $mysqlType): string

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -43,6 +43,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(AlterTableMutation::class)]
 final class MySqlMutationResolverTest extends TestCase
 {

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -51,6 +51,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(AlterTableMutation::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
     protected function createRewriter(ShadowStore $store, TableDefinitionRegistry $registry): SqlRewriter

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
@@ -36,6 +36,7 @@ use ZtdQuery\Session;
 #[UsesClass(ReplaceTransformer::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 final class MySqlSessionFactoryTest extends TestCase
 {
     public function testCreateReturnsSession(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlValueRendererTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlValueRendererTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\MySql\MySqlValueRenderer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCastRenderer::class)]
 final class MySqlValueRendererTest extends TestCase
 {
     public function testTextUsesHexEncodingInsteadOfSqlEscapeMode(): void
@@ -45,6 +47,63 @@ final class MySqlValueRendererTest extends TestCase
         $renderer = new MySqlValueRenderer();
 
         self::assertSame('2.718281828459045', $renderer->renderValue(2.718281828459045));
+    }
+
+    public function testInferredAndDeclaredBooleansRemainDistinct(): void
+    {
+        $renderer = new MySqlValueRenderer();
+
+        self::assertSame('TRUE', $renderer->renderValue(true));
+        self::assertSame(
+            "CAST('1' AS UNSIGNED)",
+            $renderer->renderValue(true, new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN')),
+        );
+    }
+
+    public function testInferredAndDeclaredIntegersRemainDistinct(): void
+    {
+        $renderer = new MySqlValueRenderer();
+
+        self::assertSame('CAST(42 AS SIGNED)', $renderer->renderValue(42));
+        self::assertSame(
+            "CAST('42' AS SIGNED)",
+            $renderer->renderValue(42, new ColumnType(ColumnTypeFamily::INTEGER, 'INT')),
+        );
+    }
+
+    public function testInferredStringableUsesItsSqlRepresentation(): void
+    {
+        $value = new class () implements \Stringable {
+            public function __toString(): string
+            {
+                return 'CURRENT_TIMESTAMP';
+            }
+        };
+
+        self::assertSame('CURRENT_TIMESTAMP', (new MySqlValueRenderer())->renderValue($value));
+    }
+
+    public function testTextEscapesSingleQuotes(): void
+    {
+        self::assertSame(
+            "CAST('O''Reilly' AS CHAR)",
+            (new MySqlValueRenderer())->renderValue("O'Reilly"),
+        );
+    }
+
+    public function testStreamValueIsReadWithoutChangingItsPosition(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+        fwrite($stream, 'stream value');
+        fseek($stream, 3);
+
+        self::assertSame(
+            "CAST('stream value' AS CHAR)",
+            (new MySqlValueRenderer())->renderValue($stream),
+        );
+        self::assertSame(3, ftell($stream));
+        fclose($stream);
     }
 
     public function testRejectsNonScalarValues(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlValueRendererTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlValueRendererTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlValueRenderer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+#[CoversClass(MySqlValueRenderer::class)]
+final class MySqlValueRendererTest extends TestCase
+{
+    public function testTextUsesHexEncodingInsteadOfSqlEscapeMode(): void
+    {
+        $renderer = new MySqlValueRenderer();
+
+        self::assertSame(
+            "CAST(CONVERT(X'706174685c746f5c66696c65' USING utf8mb4) AS CHAR)",
+            $renderer->renderValue('path\\to\\file', new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR(255)')),
+        );
+    }
+
+    public function testBinaryUsesLosslessHexLiteral(): void
+    {
+        $renderer = new MySqlValueRenderer();
+
+        self::assertSame(
+            "CAST(X'0001ff' AS BINARY)",
+            $renderer->renderValue("\x00\x01\xFF", new ColumnType(ColumnTypeFamily::BINARY, 'BLOB')),
+        );
+    }
+
+    public function testNullRetainsDeclaredType(): void
+    {
+        $renderer = new MySqlValueRenderer();
+
+        self::assertSame('NULL', $renderer->renderValue(null, new ColumnType(ColumnTypeFamily::INTEGER, 'INT')));
+    }
+
+    public function testInferredFloatUsesRoundTripRepresentation(): void
+    {
+        $renderer = new MySqlValueRenderer();
+
+        self::assertSame('2.718281828459045', $renderer->renderValue(2.718281828459045));
+    }
+
+    public function testRejectsNonScalarValues(): void
+    {
+        $renderer = new MySqlValueRenderer();
+
+        $this->expectException(\RuntimeException::class);
+        $renderer->renderValue([]);
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 final class DeleteTransformerTest extends TestCase
 {
     public function testBuildDeleteWithJoinAlias(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
@@ -8,19 +8,41 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\Transformer\InsertTransformer;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(InsertTransformer::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 final class InsertTransformerTest extends TestCase
 {
+    public function testUsesInjectedCastRendererAndColumnTypes(): void
+    {
+        $castRenderer = self::createStub(CastRenderer::class);
+        $castRenderer->method('renderCast')->willReturn('CUSTOM_CAST');
+        $transformer = new InsertTransformer(new MySqlParser(), new SelectTransformer(), $castRenderer);
+        $tables = [
+            'users' => [
+                'rows' => [],
+                'columns' => ['id'],
+                'columnTypes' => ['id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INT')],
+            ],
+        ];
+
+        $result = $transformer->transform('INSERT INTO users (id) VALUES (1)', $tables);
+
+        self::assertStringContainsString('SELECT CUSTOM_CAST AS `id`', $result);
+    }
+
     public function testTransformInsertWithValues(): void
     {
         $parser = new MySqlParser();

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
@@ -26,6 +26,7 @@ use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 #[UsesClass(ReplaceTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 final class MySqlTransformerTest extends TestCase
 {
     public function testTransformSelectPassthrough(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
@@ -19,6 +19,7 @@ use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 final class ReplaceTransformerTest extends TestCase
 {
     public function testTransformReplaceWithValues(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\TransformerContractTest;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
+use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
@@ -19,8 +20,25 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[CoversClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testUsesInjectedValueRenderer(): void
+    {
+        $valueRenderer = self::createStub(ValueRenderer::class);
+        $valueRenderer->method('renderValue')->willReturn('CUSTOM_VALUE');
+        $transformer = new SelectTransformer(null, null, $valueRenderer);
+        $tables = [
+            'users' => [
+                'rows' => [['id' => 1]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        self::assertStringContainsString('CUSTOM_VALUE AS `id`', $transformer->transform('SELECT * FROM users', $tables));
+    }
+
     protected function createTransformer(): SqlTransformer
     {
         return new SelectTransformer();

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 final class UpdateTransformerTest extends TestCase
 {
     public function testBuildUpdateSelectUsesAliasAndColumns(): void

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -395,4 +395,28 @@ final class MysqliCteShadowingTest extends TestCase
             $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
         }
     }
+
+    public function testPreparedBackslashesRoundTripWithoutMysqlEscapeCorruption(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'typed_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, value VARCHAR(255))', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $insert = $ztdMysqli->prepare(sprintf('INSERT INTO `%s` (id, value) VALUES (?, ?)', $table));
+            self::assertNotFalse($insert);
+            $id = 1;
+            $value = 'path\\to\\file';
+            self::assertTrue($insert->bind_param('is', $id, $value));
+            self::assertTrue($insert->execute());
+
+            $result = $ztdMysqli->query(sprintf('SELECT value FROM `%s` WHERE id = 1', $table));
+            self::assertNotFalse($result);
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([['value' => $value]], $result->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSqlCteShadowingTest.php
@@ -529,4 +529,54 @@ final class PostgreSqlCteShadowingTest extends TestCase
         }
     }
 
+    public function testPreparedBooleanAndBigIntValuesRetainTheirTypes(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'typed_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec(sprintf('CREATE TABLE %s (id INTEGER PRIMARY KEY, enabled BOOLEAN, quantity BIGINT)', $table));
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+            $insert = $ztdPdo->prepare(sprintf('INSERT INTO %s (id, enabled, quantity) VALUES (?, ?, ?)', $table));
+            self::assertNotFalse($insert);
+            self::assertTrue($insert->execute([1, false, 9223372036854775807]));
+
+            $result = $ztdPdo->query(sprintf('SELECT enabled::int, quantity::text FROM %s', $table));
+            self::assertNotFalse($result);
+            self::assertSame(['enabled' => 0, 'quantity' => '9223372036854775807'], $result->fetch());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
+    public function testArrayAndBinaryValuesRetainNativeTypes(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'typed_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec(sprintf('CREATE TABLE %s (id INTEGER PRIMARY KEY, scores INTEGER[], payload BYTEA)', $table));
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+            $payload = "\x00\x01\xFF";
+
+            $insert = $ztdPdo->prepare(sprintf('INSERT INTO %s (id, scores, payload) VALUES (?, ?::integer[], ?)', $table));
+            self::assertNotFalse($insert);
+            self::assertTrue($insert->bindValue(1, 1, \PDO::PARAM_INT));
+            self::assertTrue($insert->bindValue(2, '{90,85,92}'));
+            self::assertTrue($insert->bindValue(3, $payload, \PDO::PARAM_LOB));
+            self::assertTrue($insert->execute());
+            self::assertSame(1, $ztdPdo->exec(sprintf('INSERT INTO %s (id, scores, payload) VALUES (2, ARRAY[1,2,3], NULL)', $table)));
+
+            $result = $ztdPdo->query(sprintf("SELECT scores::text, encode(payload, 'hex') AS payload FROM %s ORDER BY id", $table));
+            self::assertNotFalse($result);
+            self::assertSame([
+                ['scores' => '{90,85,92}', 'payload' => '0001ff'],
+                ['scores' => '{1,2,3}', 'payload' => null],
+            ], $result->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/SqliteCteShadowingTest.php
@@ -545,4 +545,55 @@ final class SqliteCteShadowingTest extends TestCase
             ['id' => 3, 'select' => 'column-select', 'values' => 'column-values'],
         ], $columnRows->fetchAll());
     }
+
+    public function testBinaryPreparedValueRoundTripsThroughShadowCte(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE events (id INTEGER PRIMARY KEY, payload BLOB)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+        $payload = "\x00\x01\x02\xFF\xFE";
+
+        $insert = $ztdPdo->prepare('INSERT INTO events (id, payload) VALUES (?, ?)');
+        self::assertNotFalse($insert);
+        self::assertTrue($insert->execute([1, $payload]));
+
+        $result = $ztdPdo->query('SELECT payload FROM events WHERE id = 1');
+        self::assertNotFalse($result);
+        self::assertSame($payload, $result->fetchColumn());
+    }
+
+    public function testRealValuesRetainRoundTripPrecision(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE measurements (id INTEGER PRIMARY KEY, value REAL)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+        $ztdPdo->exec('INSERT INTO measurements VALUES (1, 2.718281828459045), (2, 0.30000000000000004)');
+
+        $result = $ztdPdo->query('SELECT value FROM measurements ORDER BY id');
+        self::assertNotFalse($result);
+        self::assertSame([2.718281828459045, 0.30000000000000004], $result->fetchAll(\PDO::FETCH_COLUMN));
+    }
+
+    public function testShadowValuesRetainSqliteStorageClasses(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE values_table (id INTEGER PRIMARY KEY, int_value INTEGER, real_value REAL, text_value TEXT, nullable_value TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+
+        $ztdPdo->exec("INSERT INTO values_table VALUES (1, 42, 3.14, 'hello', NULL)");
+
+        $result = $ztdPdo->query('SELECT typeof(int_value), typeof(real_value), typeof(text_value), typeof(nullable_value) FROM values_table');
+        self::assertNotFalse($result);
+        self::assertSame(['integer', 'real', 'text', 'null'], $result->fetch(\PDO::FETCH_NUM));
+    }
 }

--- a/packages/ztd-query-postgres/src/PgSqlCastRenderer.php
+++ b/packages/ztd-query-postgres/src/PgSqlCastRenderer.php
@@ -68,7 +68,7 @@ final class PgSqlCastRenderer implements CastRenderer
     {
         $baseType = strtoupper((string) preg_replace('/\(.*\)/', '', $nativeType));
 
-        return match (trim($baseType)) {
+        return match ($baseType) {
             'INT2', 'SMALLINT', 'SMALLSERIAL' => 'SMALLINT',
             'INT8', 'BIGINT', 'BIGSERIAL' => 'BIGINT',
             default => 'INTEGER',

--- a/packages/ztd-query-postgres/src/PgSqlCastRenderer.php
+++ b/packages/ztd-query-postgres/src/PgSqlCastRenderer.php
@@ -38,12 +38,17 @@ final class PgSqlCastRenderer implements CastRenderer
 
     private function mapToCastType(ColumnType $type): string
     {
+        $nativeType = trim($type->nativeType);
+        if (str_ends_with($nativeType, '[]')) {
+            return $nativeType;
+        }
+
         if ($type->family === ColumnTypeFamily::UNKNOWN) {
-            return $type->nativeType !== '' ? $type->nativeType : 'TEXT';
+            return $nativeType !== '' ? $nativeType : 'TEXT';
         }
 
         return match ($type->family) {
-            ColumnTypeFamily::INTEGER => 'INTEGER',
+            ColumnTypeFamily::INTEGER => $this->mapIntegerType($nativeType),
             ColumnTypeFamily::FLOAT => 'REAL',
             ColumnTypeFamily::DOUBLE => 'DOUBLE PRECISION',
             ColumnTypeFamily::DECIMAL => $this->extractDecimalType($type->nativeType),
@@ -56,6 +61,17 @@ final class PgSqlCastRenderer implements CastRenderer
             ColumnTypeFamily::TIMESTAMP => 'TIMESTAMP',
             ColumnTypeFamily::BINARY => 'BYTEA',
             ColumnTypeFamily::JSON => 'JSONB',
+        };
+    }
+
+    private function mapIntegerType(string $nativeType): string
+    {
+        $baseType = strtoupper((string) preg_replace('/\(.*\)/', '', $nativeType));
+
+        return match (trim($baseType)) {
+            'INT2', 'SMALLINT', 'SMALLSERIAL' => 'SMALLINT',
+            'INT8', 'BIGINT', 'BIGSERIAL' => 'BIGINT',
+            default => 'INTEGER',
         };
     }
 

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -763,6 +763,7 @@ final class PgSqlParser
         $items = [];
         $current = '';
         $depth = 0;
+        $bracketDepth = 0;
         $len = strlen($str);
         $inSingleQuote = false;
 
@@ -809,7 +810,19 @@ final class PgSqlParser
                 continue;
             }
 
-            if ($char === ',' && $depth === 1) {
+            if ($char === '[') {
+                $bracketDepth++;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === ']' && $bracketDepth > 0) {
+                $bracketDepth--;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === ',' && $depth === 1 && $bracketDepth === 0) {
                 $items[] = trim($current);
                 $current = '';
                 continue;

--- a/packages/ztd-query-postgres/src/PgSqlValueRenderer.php
+++ b/packages/ztd-query-postgres/src/PgSqlValueRenderer.php
@@ -76,19 +76,15 @@ final class PgSqlValueRenderer implements ValueRenderer
 
     private function inferType(mixed $value): ColumnType
     {
-        return match (true) {
-            is_int($value) => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
-            is_float($value) => new ColumnType(ColumnTypeFamily::DOUBLE, 'DOUBLE PRECISION'),
-            is_bool($value) => new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN'),
-            default => new ColumnType(ColumnTypeFamily::TEXT, 'TEXT'),
-        };
+        if (is_int($value)) {
+            return new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER');
+        }
+
+        return new ColumnType(ColumnTypeFamily::TEXT, 'TEXT');
     }
 
     private function stringValue(mixed $value): string
     {
-        if (is_string($value)) {
-            return $value;
-        }
         if ($value instanceof Stringable) {
             return (string) $value;
         }

--- a/packages/ztd-query-postgres/src/PgSqlValueRenderer.php
+++ b/packages/ztd-query-postgres/src/PgSqlValueRenderer.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use Stringable;
+use ZtdQuery\Platform\CastRenderer;
+use ZtdQuery\Platform\ValueRenderer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+/**
+ * Encodes shadow values using PostgreSQL's typed literal semantics.
+ */
+final class PgSqlValueRenderer implements ValueRenderer
+{
+    public function __construct(private readonly CastRenderer $castRenderer = new PgSqlCastRenderer())
+    {
+    }
+
+    public function renderValue(mixed $value, ?ColumnType $type = null): string
+    {
+        if ($value === null) {
+            return 'NULL';
+        }
+
+        if ($type === null && is_bool($value)) {
+            return $value ? 'TRUE' : 'FALSE';
+        }
+
+        if ($type === null && is_float($value)) {
+            return var_export($value, true);
+        }
+
+        if ($type === null && $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        if ($type === null && !is_scalar($value)) {
+            throw new \RuntimeException('Unsupported value type for CTE shadowing.');
+        }
+
+        $resolvedType = $type ?? $this->inferType($value);
+        $expression = $this->renderExpression($value, $resolvedType, $type !== null);
+
+        return $this->castRenderer->renderCast($expression, $resolvedType);
+    }
+
+    private function renderExpression(mixed $value, ColumnType $type, bool $typed): string
+    {
+        if ($type->family === ColumnTypeFamily::BINARY) {
+            $hex = bin2hex($this->stringValue($value));
+
+            return "decode('$hex', 'hex')";
+        }
+
+        if (is_bool($value)) {
+            return $this->quoteValue($value ? '1' : '0');
+        }
+
+        if (is_int($value) && !$typed) {
+            return (string) $value;
+        }
+
+        if (is_float($value)) {
+            return $this->quoteValue(var_export($value, true));
+        }
+
+        if (!is_scalar($value) && !$value instanceof Stringable) {
+            return $this->quoteValue(serialize($value));
+        }
+
+        return $this->quoteValue($this->stringValue($value));
+    }
+
+    private function inferType(mixed $value): ColumnType
+    {
+        return match (true) {
+            is_int($value) => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
+            is_float($value) => new ColumnType(ColumnTypeFamily::DOUBLE, 'DOUBLE PRECISION'),
+            is_bool($value) => new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN'),
+            default => new ColumnType(ColumnTypeFamily::TEXT, 'TEXT'),
+        };
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+        if (is_resource($value) && get_resource_type($value) === 'stream') {
+            return $this->readStream($value);
+        }
+
+        throw new \RuntimeException('Unsupported value type for CTE shadowing.');
+    }
+
+    /** @param resource $stream */
+    private function readStream($stream): string
+    {
+        $position = ftell($stream);
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        if ($position !== false) {
+            fseek($stream, $position);
+        }
+
+        return $contents === false ? '' : $contents;
+    }
+
+    private function quoteValue(string $value): string
+    {
+        return "'" . str_replace("'", "''", $value) . "'";
+    }
+}

--- a/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Postgres\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\CastRenderer;
+use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Rewrite\SqlTransformer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
 
 /**
  * Transforms INSERT statements into SELECT queries that return the inserted rows.
@@ -16,11 +20,16 @@ final class InsertTransformer implements SqlTransformer
 {
     private PgSqlParser $parser;
     private SelectTransformer $selectTransformer;
+    private CastRenderer $castRenderer;
 
-    public function __construct(PgSqlParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        PgSqlParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CastRenderer $castRenderer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->castRenderer = $castRenderer ?? new PgSqlCastRenderer();
     }
 
     /**
@@ -56,6 +65,7 @@ final class InsertTransformer implements SqlTransformer
         }
 
         $selectParts = [];
+        $columnTypes = $tables[$tableName]['columnTypes'] ?? [];
         foreach ($valueRows as $values) {
             if (count($values) !== count($columns)) {
                 throw new UnsupportedSqlException($sql, 'Insert values count does not match column count');
@@ -64,6 +74,10 @@ final class InsertTransformer implements SqlTransformer
             $selects = [];
             foreach ($columns as $index => $column) {
                 $expr = trim($values[$index]);
+                $type = $columnTypes[$column] ?? null;
+                if ($type instanceof ColumnType) {
+                    $expr = $this->castInsertExpression($expr, $type);
+                }
                 $selects[] = $expr . ' AS "' . $column . '"';
             }
             $selectParts[] = 'SELECT ' . implode(', ', $selects);
@@ -72,5 +86,14 @@ final class InsertTransformer implements SqlTransformer
         $selectSql = implode(' UNION ALL ', $selectParts);
 
         return $this->selectTransformer->transform($selectSql, $tables);
+    }
+
+    private function castInsertExpression(string $expression, ColumnType $type): string
+    {
+        if ($type->family === ColumnTypeFamily::BOOLEAN && $expression === '?') {
+            return "CAST(COALESCE(NULLIF(CAST(? AS TEXT), ''), 'false') AS BOOLEAN)";
+        }
+
+        return $this->castRenderer->renderCast($expression, $type);
     }
 }

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -8,6 +8,7 @@ use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
+use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -26,11 +27,16 @@ final class SelectTransformer implements SqlTransformer
 {
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
+    private ValueRenderer $valueRenderer;
 
-    public function __construct(?CastRenderer $castRenderer = null, ?IdentifierQuoter $quoter = null)
-    {
+    public function __construct(
+        ?CastRenderer $castRenderer = null,
+        ?IdentifierQuoter $quoter = null,
+        ?ValueRenderer $valueRenderer = null,
+    ) {
         $this->castRenderer = $castRenderer ?? new PgSqlCastRenderer();
         $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
+        $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Postgres\PgSqlValueRenderer($this->castRenderer);
     }
 
     /**
@@ -179,44 +185,7 @@ final class SelectTransformer implements SqlTransformer
 
     private function formatValue(mixed $val, ?ColumnType $colType = null): string
     {
-        if (is_null($val)) {
-            return 'NULL';
-        }
-
-        if ($colType !== null) {
-            if (is_string($val)) {
-                $quotedVal = $this->quoteValue($val);
-            } elseif (is_int($val) || is_float($val) || is_bool($val)) {
-                $quotedVal = $this->quoteValue((string) $val);
-            } else {
-                $quotedVal = $this->quoteValue(serialize($val));
-            }
-
-            return $this->castRenderer->renderCast($quotedVal, $colType);
-        }
-
-        if (is_int($val)) {
-            return $this->castRenderer->renderCast(
-                (string) $val,
-                new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
-            );
-        }
-        if (is_string($val)) {
-            return $this->castRenderer->renderCast(
-                $this->quoteValue($val),
-                new ColumnType(ColumnTypeFamily::TEXT, 'TEXT'),
-            );
-        }
-        if (is_bool($val)) {
-            return $val ? 'TRUE' : 'FALSE';
-        }
-        if (is_float($val)) {
-            return (string) $val;
-        }
-        if (is_object($val) && method_exists($val, '__toString')) {
-            return (string) $val;
-        }
-        throw new \RuntimeException('Unsupported value type for CTE shadowing.');
+        return $this->valueRenderer->renderValue($val, $colType);
     }
 
     private function renderFallbackNullCast(): string
@@ -226,8 +195,4 @@ final class SelectTransformer implements SqlTransformer
         );
     }
 
-    private function quoteValue(string $val): string
-    {
-        return "'" . str_replace("'", "''", $val) . "'";
-    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCastRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCastRendererTest.php
@@ -47,6 +47,26 @@ final class PgSqlCastRendererTest extends CastRendererContractTest
         self::assertSame("CAST('42' AS INTEGER)", $renderer->renderCast("'42'", $type));
     }
 
+    public function testRenderCastBigIntPreservesWidth(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame(
+            'CAST(9223372036854775807 AS BIGINT)',
+            $renderer->renderCast('9223372036854775807', new ColumnType(ColumnTypeFamily::INTEGER, 'BIGINT')),
+        );
+    }
+
+    public function testRenderCastPreservesArrayType(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame(
+            "CAST('{1,2}' AS INT4[])",
+            $renderer->renderCast("'{1,2}'", new ColumnType(ColumnTypeFamily::INTEGER, 'INT4[]')),
+        );
+    }
+
     public function testRenderNullCastInteger(): void
     {
         $renderer = new PgSqlCastRenderer();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCastRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCastRendererTest.php
@@ -67,6 +67,58 @@ final class PgSqlCastRendererTest extends CastRendererContractTest
         );
     }
 
+    public function testRenderCastTrimsArrayType(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame(
+            "CAST('{1,2}' AS INT4[])",
+            $renderer->renderCast("'{1,2}'", new ColumnType(ColumnTypeFamily::INTEGER, ' INT4[] ')),
+        );
+    }
+
+    public function testRenderCastPreservesInt2Alias(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame('CAST(1 AS SMALLINT)', $renderer->renderCast('1', new ColumnType(ColumnTypeFamily::INTEGER, 'int2')));
+    }
+
+    public function testRenderCastPreservesSmallIntAlias(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame('CAST(1 AS SMALLINT)', $renderer->renderCast('1', new ColumnType(ColumnTypeFamily::INTEGER, 'smallint')));
+    }
+
+    public function testRenderCastPreservesSmallSerialAlias(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame('CAST(1 AS SMALLINT)', $renderer->renderCast('1', new ColumnType(ColumnTypeFamily::INTEGER, 'smallserial')));
+    }
+
+    public function testRenderCastPreservesInt8Alias(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame('CAST(1 AS BIGINT)', $renderer->renderCast('1', new ColumnType(ColumnTypeFamily::INTEGER, 'int8')));
+    }
+
+    public function testRenderCastPreservesBigIntAlias(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame('CAST(1 AS BIGINT)', $renderer->renderCast('1', new ColumnType(ColumnTypeFamily::INTEGER, 'bigint')));
+    }
+
+    public function testRenderCastPreservesBigSerialAlias(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+
+        self::assertSame('CAST(1 AS BIGINT)', $renderer->renderCast('1', new ColumnType(ColumnTypeFamily::INTEGER, 'bigserial')));
+    }
+
     public function testRenderNullCastInteger(): void
     {
         $renderer = new PgSqlCastRenderer();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -3531,4 +3531,14 @@ SELECT * FROM users'));
         self::assertNull($parser->extractInsertSelectSql($sql));
         self::assertSame([['1']], $parser->extractInsertValues($sql));
     }
+
+    public function testInsertValuesDoesNotUnderflowArrayBracketDepth(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertSame(
+            [['1]', '2']],
+            $parser->extractInsertValues('INSERT INTO target (a, b) VALUES (1], 2)'),
+        );
+    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -3382,6 +3382,16 @@ SELECT * FROM users'));
         self::assertSame('5', $rows[0][1]);
     }
 
+    public function testExtractInsertValuesKeepsArrayConstructorTogether(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertSame(
+            [['1', 'ARRAY[90,85,92]', 'NULL']],
+            $parser->extractInsertValues('INSERT INTO scores (id, values, payload) VALUES (1, ARRAY[90,85,92], NULL)'),
+        );
+    }
+
     public function testHasInsertSelectWithSubqueryInValues(): void
     {
         $parser = new PgSqlParser();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -50,6 +50,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
     protected function createRewriter(ShadowStore $store, TableDefinitionRegistry $registry): SqlRewriter

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -36,6 +36,7 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(PgSqlTransformer::class)]
 #[UsesClass(PgSqlSchemaReflector::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(InsertTransformer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
@@ -27,6 +27,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 final class PgSqlTransformerTest extends TestCase
 {

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlValueRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlValueRendererTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlValueRenderer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+#[CoversClass(PgSqlValueRenderer::class)]
+final class PgSqlValueRendererTest extends TestCase
+{
+    public function testFalseUsesBooleanLiteral(): void
+    {
+        $renderer = new PgSqlValueRenderer();
+
+        self::assertSame(
+            "CAST('0' AS BOOLEAN)",
+            $renderer->renderValue(false, new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN')),
+        );
+    }
+
+    public function testBigIntRetainsNativeWidth(): void
+    {
+        $renderer = new PgSqlValueRenderer();
+
+        self::assertSame(
+            "CAST('9223372036854775807' AS BIGINT)",
+            $renderer->renderValue(9223372036854775807, new ColumnType(ColumnTypeFamily::INTEGER, 'BIGINT')),
+        );
+    }
+
+    public function testArrayRetainsNativeArrayType(): void
+    {
+        $renderer = new PgSqlValueRenderer();
+
+        self::assertSame(
+            "CAST('{1,2,3}' AS INT4[])",
+            $renderer->renderValue('{1,2,3}', new ColumnType(ColumnTypeFamily::INTEGER, 'INT4[]')),
+        );
+    }
+
+    public function testBinaryUsesDecodeExpression(): void
+    {
+        $renderer = new PgSqlValueRenderer();
+
+        self::assertSame(
+            "CAST(decode('0001ff', 'hex') AS BYTEA)",
+            $renderer->renderValue("\x00\x01\xFF", new ColumnType(ColumnTypeFamily::BINARY, 'BYTEA')),
+        );
+    }
+
+    public function testStringQuotesApostrophes(): void
+    {
+        $renderer = new PgSqlValueRenderer();
+
+        self::assertSame("CAST('O''Reilly' AS TEXT)", $renderer->renderValue("O'Reilly"));
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlValueRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlValueRendererTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlValueRenderer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(PgSqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCastRenderer::class)]
 final class PgSqlValueRendererTest extends TestCase
 {
     public function testFalseUsesBooleanLiteral(): void
@@ -58,5 +60,81 @@ final class PgSqlValueRendererTest extends TestCase
         $renderer = new PgSqlValueRenderer();
 
         self::assertSame("CAST('O''Reilly' AS TEXT)", $renderer->renderValue("O'Reilly"));
+    }
+
+    public function testInferredScalarTypesUseNativeLiterals(): void
+    {
+        $renderer = new PgSqlValueRenderer();
+
+        self::assertSame('TRUE', $renderer->renderValue(true));
+        self::assertSame('2.718281828459045', $renderer->renderValue(2.718281828459045));
+        self::assertSame('CAST(42 AS INTEGER)', $renderer->renderValue(42));
+    }
+
+    public function testDeclaredFloatUsesQuotedRoundTripRepresentation(): void
+    {
+        $renderer = new PgSqlValueRenderer();
+
+        self::assertSame(
+            "CAST('2.718281828459045' AS DOUBLE PRECISION)",
+            $renderer->renderValue(2.718281828459045, new ColumnType(ColumnTypeFamily::DOUBLE, 'DOUBLE PRECISION')),
+        );
+    }
+
+    public function testInferredAndDeclaredStringableRemainDistinct(): void
+    {
+        $value = new class () implements \Stringable {
+            public function __toString(): string
+            {
+                return 'CURRENT_TIMESTAMP';
+            }
+        };
+        $renderer = new PgSqlValueRenderer();
+
+        self::assertSame('CURRENT_TIMESTAMP', $renderer->renderValue($value));
+        self::assertSame(
+            "CAST('CURRENT_TIMESTAMP' AS TEXT)",
+            $renderer->renderValue($value, new ColumnType(ColumnTypeFamily::TEXT, 'TEXT')),
+        );
+    }
+
+    public function testUntypedArrayIsRejected(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        (new PgSqlValueRenderer())->renderValue(['value']);
+    }
+
+    public function testDeclaredNonScalarUsesSerializedRepresentation(): void
+    {
+        self::assertSame(
+            "CAST('a:1:{i:0;s:5:\"value\";}' AS JSONB)",
+            (new PgSqlValueRenderer())->renderValue(['value'], new ColumnType(ColumnTypeFamily::JSON, 'JSONB')),
+        );
+    }
+
+    public function testBinaryStreamIsReadWithoutChangingItsPosition(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+        fwrite($stream, "\x00\x01\xFF");
+        fseek($stream, 1);
+
+        self::assertSame(
+            "CAST(decode('0001ff', 'hex') AS BYTEA)",
+            (new PgSqlValueRenderer())->renderValue($stream, new ColumnType(ColumnTypeFamily::BINARY, 'BYTEA')),
+        );
+        self::assertSame(1, ftell($stream));
+        fclose($stream);
+    }
+
+    public function testBinaryRejectsNonStringableNonResource(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        (new PgSqlValueRenderer())->renderValue(
+            ['value'],
+            new ColumnType(ColumnTypeFamily::BINARY, 'BYTEA'),
+        );
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 final class DeleteTransformerTest extends TestCase
 {

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -186,7 +186,7 @@ final class InsertTransformerTest extends TestCase
         ];
 
         $result = $transformer->transform($sql, $tables);
-        self::assertStringContainsString('1 AS "id"', $result);
+        self::assertStringContainsString('CAST(1 AS INTEGER) AS "id"', $result);
         self::assertStringNotContainsString(' 1  AS', $result);
     }
 

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\Transformer\InsertTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
@@ -21,9 +22,61 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 final class InsertTransformerTest extends TestCase
 {
+    public function testUsesInjectedCastRendererForTypedValue(): void
+    {
+        $castRenderer = self::createStub(CastRenderer::class);
+        $castRenderer->method('renderCast')->willReturn('CUSTOM_CAST');
+        $transformer = new InsertTransformer(new PgSqlParser(), new SelectTransformer(), $castRenderer);
+        $tables = [
+            'users' => [
+                'rows' => [],
+                'columns' => ['id'],
+                'columnTypes' => ['id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER')],
+            ],
+        ];
+
+        self::assertStringContainsString(
+            'SELECT CUSTOM_CAST AS "id"',
+            $transformer->transform('INSERT INTO users (id) VALUES (1)', $tables),
+        );
+    }
+
+    public function testBooleanPlaceholderUsesNullSafeCastOnlyForBooleanPlaceholder(): void
+    {
+        $transformer = new InsertTransformer(new PgSqlParser(), new SelectTransformer());
+        $booleanTables = [
+            'flags' => [
+                'rows' => [],
+                'columns' => ['enabled'],
+                'columnTypes' => ['enabled' => new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN')],
+            ],
+        ];
+        $integerTables = [
+            'numbers' => [
+                'rows' => [],
+                'columns' => ['value'],
+                'columnTypes' => ['value' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER')],
+            ],
+        ];
+
+        self::assertStringContainsString(
+            "CAST(COALESCE(NULLIF(CAST(? AS TEXT), ''), 'false') AS BOOLEAN)",
+            $transformer->transform('INSERT INTO flags (enabled) VALUES (?)', $booleanTables),
+        );
+        self::assertStringContainsString(
+            'CAST(TRUE AS BOOLEAN)',
+            $transformer->transform('INSERT INTO flags (enabled) VALUES (TRUE)', $booleanTables),
+        );
+        self::assertStringContainsString(
+            'CAST(? AS INTEGER)',
+            $transformer->transform('INSERT INTO numbers (value) VALUES (?)', $integerTables),
+        );
+    }
+
     public function testInsertValuesWithExplicitColumns(): void
     {
         $transformer = new InsertTransformer(new PgSqlParser(), new SelectTransformer());

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Transformer;
 
 use Tests\Contract\TransformerContractTest;
 use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
+use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -16,9 +17,26 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 
 #[CoversClass(SelectTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testUsesInjectedValueRenderer(): void
+    {
+        $valueRenderer = self::createStub(ValueRenderer::class);
+        $valueRenderer->method('renderValue')->willReturn('CUSTOM_VALUE');
+        $transformer = new SelectTransformer(null, null, $valueRenderer);
+        $tables = [
+            'users' => [
+                'rows' => [['id' => 1]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        self::assertStringContainsString('CUSTOM_VALUE', $transformer->transform('SELECT * FROM users', $tables));
+    }
+
     protected function createTransformer(): SqlTransformer
     {
         return new SelectTransformer();

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 final class UpdateTransformerTest extends TestCase
 {

--- a/packages/ztd-query-sqlite/src/SqliteValueRenderer.php
+++ b/packages/ztd-query-sqlite/src/SqliteValueRenderer.php
@@ -76,19 +76,15 @@ final class SqliteValueRenderer implements ValueRenderer
 
     private function inferType(mixed $value): ColumnType
     {
-        return match (true) {
-            is_int($value) => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
-            is_float($value) => new ColumnType(ColumnTypeFamily::DOUBLE, 'REAL'),
-            is_bool($value) => new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN'),
-            default => new ColumnType(ColumnTypeFamily::TEXT, 'TEXT'),
-        };
+        if (is_int($value)) {
+            return new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER');
+        }
+
+        return new ColumnType(ColumnTypeFamily::TEXT, 'TEXT');
     }
 
     private function stringValue(mixed $value): string
     {
-        if (is_string($value)) {
-            return $value;
-        }
         if ($value instanceof Stringable) {
             return (string) $value;
         }

--- a/packages/ztd-query-sqlite/src/SqliteValueRenderer.php
+++ b/packages/ztd-query-sqlite/src/SqliteValueRenderer.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use Stringable;
+use ZtdQuery\Platform\CastRenderer;
+use ZtdQuery\Platform\ValueRenderer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+/**
+ * Encodes shadow values while preserving SQLite storage classes.
+ */
+final class SqliteValueRenderer implements ValueRenderer
+{
+    public function __construct(private readonly CastRenderer $castRenderer = new SqliteCastRenderer())
+    {
+    }
+
+    public function renderValue(mixed $value, ?ColumnType $type = null): string
+    {
+        if ($value === null) {
+            return 'NULL';
+        }
+
+        if ($type === null && is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if ($type === null && is_float($value)) {
+            return var_export($value, true);
+        }
+
+        if ($type === null && $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        if ($type === null && !is_scalar($value)) {
+            throw new \RuntimeException('Unsupported value type for CTE shadowing.');
+        }
+
+        $resolvedType = $type ?? $this->inferType($value);
+        $expression = $this->renderExpression($value, $resolvedType, $type !== null);
+
+        return $this->castRenderer->renderCast($expression, $resolvedType);
+    }
+
+    private function renderExpression(mixed $value, ColumnType $type, bool $typed): string
+    {
+        if ($type->family === ColumnTypeFamily::BINARY) {
+            return "X'" . bin2hex($this->stringValue($value)) . "'";
+        }
+
+        if (is_bool($value)) {
+            return $this->quoteValue($value ? '1' : '0');
+        }
+
+        if (is_int($value) && !$typed) {
+            return (string) $value;
+        }
+
+        if (is_float($value)) {
+            return $this->quoteValue(var_export($value, true));
+        }
+
+        if (!is_scalar($value) && !$value instanceof Stringable) {
+            return $this->quoteValue(serialize($value));
+        }
+
+        $string = $this->stringValue($value);
+
+        return $this->quoteValue($string);
+    }
+
+    private function inferType(mixed $value): ColumnType
+    {
+        return match (true) {
+            is_int($value) => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
+            is_float($value) => new ColumnType(ColumnTypeFamily::DOUBLE, 'REAL'),
+            is_bool($value) => new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN'),
+            default => new ColumnType(ColumnTypeFamily::TEXT, 'TEXT'),
+        };
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+        if (is_resource($value) && get_resource_type($value) === 'stream') {
+            return $this->readStream($value);
+        }
+
+        throw new \RuntimeException('Unsupported value type for CTE shadowing.');
+    }
+
+    /** @param resource $stream */
+    private function readStream($stream): string
+    {
+        $position = ftell($stream);
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        if ($position !== false) {
+            fseek($stream, $position);
+        }
+
+        return $contents === false ? '' : $contents;
+    }
+
+    private function quoteValue(string $value): string
+    {
+        return "'" . str_replace("'", "''", $value) . "'";
+    }
+}

--- a/packages/ztd-query-sqlite/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/InsertTransformer.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\CastRenderer;
+use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Rewrite\SqlTransformer;
+use ZtdQuery\Schema\ColumnType;
 
 /**
  * Transforms INSERT/REPLACE statements into SELECT queries that return the inserted rows.
@@ -23,11 +26,16 @@ final class InsertTransformer implements SqlTransformer
 {
     private SqliteParser $parser;
     private SelectTransformer $selectTransformer;
+    private CastRenderer $castRenderer;
 
-    public function __construct(SqliteParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        SqliteParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CastRenderer $castRenderer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->castRenderer = $castRenderer ?? new SqliteCastRenderer();
     }
 
     /**
@@ -53,15 +61,17 @@ final class InsertTransformer implements SqlTransformer
             throw new UnsupportedSqlException($sql, 'Cannot determine columns');
         }
 
-        $selectSql = $this->buildInsertSelect($sql, $columns);
+        $columnTypes = $tables[$tableName]['columnTypes'] ?? [];
+        $selectSql = $this->buildInsertSelect($sql, $columns, $columnTypes);
 
         return $this->selectTransformer->transform($selectSql, $tables);
     }
 
     /**
      * @param array<int, string> $columns
+     * @param array<string, ColumnType> $columnTypes
      */
-    private function buildInsertSelect(string $sql, array $columns): string
+    private function buildInsertSelect(string $sql, array $columns, array $columnTypes): string
     {
         if ($this->parser->hasInsertSelect($sql)) {
             $selectSql = $this->parser->extractInsertSelect($sql);
@@ -76,7 +86,7 @@ final class InsertTransformer implements SqlTransformer
         if ($valueSets !== []) {
             $rows = [];
             foreach ($valueSets as $values) {
-                $rows[] = $this->buildInsertRowSelect($values, $columns);
+                $rows[] = $this->buildInsertRowSelect($values, $columns, $columnTypes);
             }
 
             return implode(' UNION ALL ', $rows);
@@ -88,8 +98,9 @@ final class InsertTransformer implements SqlTransformer
     /**
      * @param array<int, string> $values
      * @param array<int, string> $columns
+     * @param array<string, ColumnType> $columnTypes
      */
-    private function buildInsertRowSelect(array $values, array $columns): string
+    private function buildInsertRowSelect(array $values, array $columns, array $columnTypes): string
     {
         if (count($values) !== count($columns)) {
             throw new \RuntimeException('Insert values count does not match column count.');
@@ -98,6 +109,10 @@ final class InsertTransformer implements SqlTransformer
         $selects = [];
         foreach ($columns as $index => $column) {
             $expr = trim($values[$index]);
+            $type = $columnTypes[$column] ?? null;
+            if ($type instanceof ColumnType) {
+                $expr = $this->castRenderer->renderCast($expr, $type);
+            }
             $selects[] = $expr . ' AS "' . $column . '"';
         }
 

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -9,6 +9,7 @@ use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
+use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -24,12 +25,17 @@ final class SelectTransformer implements SqlTransformer
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
     private SqliteParser $parser;
+    private ValueRenderer $valueRenderer;
 
-    public function __construct(?CastRenderer $castRenderer = null, ?IdentifierQuoter $quoter = null)
-    {
+    public function __construct(
+        ?CastRenderer $castRenderer = null,
+        ?IdentifierQuoter $quoter = null,
+        ?ValueRenderer $valueRenderer = null,
+    ) {
         $this->castRenderer = $castRenderer ?? new SqliteCastRenderer();
         $this->quoter = $quoter ?? new SqliteIdentifierQuoter();
         $this->parser = new SqliteParser();
+        $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Sqlite\SqliteValueRenderer($this->castRenderer);
     }
 
     /**
@@ -148,44 +154,7 @@ final class SelectTransformer implements SqlTransformer
 
     private function formatValue(mixed $val, ?ColumnType $type = null): string
     {
-        if (is_null($val)) {
-            return 'NULL';
-        }
-
-        if ($type !== null) {
-            if (is_string($val)) {
-                $quotedVal = $this->quoteValue($val);
-            } elseif (is_int($val) || is_float($val) || is_bool($val)) {
-                $quotedVal = $this->quoteValue((string) $val);
-            } else {
-                $quotedVal = $this->quoteValue(serialize($val));
-            }
-
-            return $this->castRenderer->renderCast($quotedVal, $type);
-        }
-
-        if (is_int($val)) {
-            return $this->castRenderer->renderCast(
-                (string) $val,
-                new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
-            );
-        }
-        if (is_string($val)) {
-            return $this->castRenderer->renderCast(
-                $this->quoteValue($val),
-                new ColumnType(ColumnTypeFamily::TEXT, 'TEXT'),
-            );
-        }
-        if (is_bool($val)) {
-            return $val ? '1' : '0';
-        }
-        if (is_float($val)) {
-            return (string) $val;
-        }
-        if (is_object($val) && method_exists($val, '__toString')) {
-            return (string) $val;
-        }
-        throw new \RuntimeException('Unsupported value type for CTE shadowing.');
+        return $this->valueRenderer->renderValue($val, $type);
     }
 
     private function renderFallbackNullCast(): string
@@ -195,8 +164,4 @@ final class SelectTransformer implements SqlTransformer
         );
     }
 
-    private function quoteValue(string $val): string
-    {
-        return "'" . str_replace("'", "''", $val) . "'";
-    }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -50,6 +50,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 final class SqliteRewriterTest extends RewriterContractTest
 {
     protected function createRewriter(ShadowStore $store, TableDefinitionRegistry $registry): SqlRewriter

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(SqliteSessionFactory::class)]
 #[UsesClass(SqliteCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteMutationResolver::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteValueRendererTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteValueRendererTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteValueRenderer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(SqliteValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCastRenderer::class)]
 final class SqliteValueRendererTest extends TestCase
 {
     public function testIntegerStringUsesNumericExpression(): void
@@ -55,5 +57,89 @@ final class SqliteValueRendererTest extends TestCase
         $renderer = new SqliteValueRenderer();
 
         self::assertSame("CAST('O''Reilly' AS TEXT)", $renderer->renderValue("O'Reilly"));
+    }
+
+    public function testInferredScalarTypesUseNativeLiterals(): void
+    {
+        $renderer = new SqliteValueRenderer();
+
+        self::assertSame('1', $renderer->renderValue(true));
+        self::assertSame('2.718281828459045', $renderer->renderValue(2.718281828459045));
+        self::assertSame('CAST(42 AS INTEGER)', $renderer->renderValue(42));
+    }
+
+    public function testDeclaredBooleanAndIntegerUseTypedText(): void
+    {
+        $renderer = new SqliteValueRenderer();
+
+        self::assertSame(
+            "CAST('1' AS INTEGER)",
+            $renderer->renderValue(true, new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN')),
+        );
+        self::assertSame(
+            "CAST('0' AS INTEGER)",
+            $renderer->renderValue(false, new ColumnType(ColumnTypeFamily::BOOLEAN, 'BOOLEAN')),
+        );
+        self::assertSame(
+            "CAST('42' AS INTEGER)",
+            $renderer->renderValue(42, new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER')),
+        );
+    }
+
+    public function testInferredAndDeclaredStringableRemainDistinct(): void
+    {
+        $value = new class () implements \Stringable {
+            public function __toString(): string
+            {
+                return 'CURRENT_TIMESTAMP';
+            }
+        };
+        $renderer = new SqliteValueRenderer();
+
+        self::assertSame('CURRENT_TIMESTAMP', $renderer->renderValue($value));
+        self::assertSame(
+            "CAST('CURRENT_TIMESTAMP' AS TEXT)",
+            $renderer->renderValue($value, new ColumnType(ColumnTypeFamily::TEXT, 'TEXT')),
+        );
+    }
+
+    public function testUntypedArrayIsRejected(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        (new SqliteValueRenderer())->renderValue(['value']);
+    }
+
+    public function testDeclaredNonScalarUsesSerializedRepresentation(): void
+    {
+        self::assertSame(
+            "CAST('a:1:{i:0;s:5:\"value\";}' AS TEXT)",
+            (new SqliteValueRenderer())->renderValue(['value'], new ColumnType(ColumnTypeFamily::JSON, 'JSON')),
+        );
+    }
+
+    public function testBinaryStreamIsReadWithoutChangingItsPosition(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+        fwrite($stream, "\x00\x01\xFF");
+        fseek($stream, 1);
+
+        self::assertSame(
+            "CAST(X'0001ff' AS BLOB)",
+            (new SqliteValueRenderer())->renderValue($stream, new ColumnType(ColumnTypeFamily::BINARY, 'BLOB')),
+        );
+        self::assertSame(1, ftell($stream));
+        fclose($stream);
+    }
+
+    public function testBinaryRejectsNonStringableNonResource(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        (new SqliteValueRenderer())->renderValue(
+            ['value'],
+            new ColumnType(ColumnTypeFamily::BINARY, 'BLOB'),
+        );
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteValueRendererTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteValueRendererTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteValueRenderer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+#[CoversClass(SqliteValueRenderer::class)]
+final class SqliteValueRendererTest extends TestCase
+{
+    public function testIntegerStringUsesNumericExpression(): void
+    {
+        $renderer = new SqliteValueRenderer();
+
+        self::assertSame(
+            "CAST('42' AS INTEGER)",
+            $renderer->renderValue('42', new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER')),
+        );
+    }
+
+    public function testFloatUsesRoundTripRepresentation(): void
+    {
+        $renderer = new SqliteValueRenderer();
+
+        self::assertSame(
+            "CAST('2.718281828459045' AS REAL)",
+            $renderer->renderValue(2.718281828459045, new ColumnType(ColumnTypeFamily::FLOAT, 'REAL')),
+        );
+    }
+
+    public function testBinaryUsesLosslessHexLiteral(): void
+    {
+        $renderer = new SqliteValueRenderer();
+
+        self::assertSame(
+            "CAST(X'0001ff' AS BLOB)",
+            $renderer->renderValue("\x00\x01\xFF", new ColumnType(ColumnTypeFamily::BINARY, 'BLOB')),
+        );
+    }
+
+    public function testNullRetainsDeclaredType(): void
+    {
+        $renderer = new SqliteValueRenderer();
+
+        self::assertSame('NULL', $renderer->renderValue(null, new ColumnType(ColumnTypeFamily::TEXT, 'TEXT')));
+    }
+
+    public function testTextRemainsText(): void
+    {
+        $renderer = new SqliteValueRenderer();
+
+        self::assertSame("CAST('O''Reilly' AS TEXT)", $renderer->renderValue("O'Reilly"));
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 final class DeleteTransformerTest extends TestCase
 {

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\Transformer\InsertTransformer;
@@ -14,15 +15,37 @@ use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(InsertTransformer::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 final class InsertTransformerTest extends TestCase
 {
+    public function testUsesInjectedCastRendererAndColumnTypes(): void
+    {
+        $castRenderer = self::createStub(CastRenderer::class);
+        $castRenderer->method('renderCast')->willReturn('CUSTOM_CAST');
+        $transformer = new InsertTransformer(new SqliteParser(), new SelectTransformer(), $castRenderer);
+        $tables = [
+            'users' => [
+                'rows' => [],
+                'columns' => ['id'],
+                'columnTypes' => ['id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER')],
+            ],
+        ];
+
+        self::assertStringContainsString(
+            'SELECT CUSTOM_CAST AS "id"',
+            $transformer->transform('INSERT INTO users (id) VALUES (1)', $tables),
+        );
+    }
+
     public function testTransformInsertValues(): void
     {
         $parser = new SqliteParser();

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\TransformerContractTest;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
+use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
 use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
@@ -20,11 +21,28 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(SelectTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testUsesInjectedValueRenderer(): void
+    {
+        $valueRenderer = self::createStub(ValueRenderer::class);
+        $valueRenderer->method('renderValue')->willReturn('CUSTOM_VALUE');
+        $transformer = new SelectTransformer(null, null, $valueRenderer);
+        $tables = [
+            'users' => [
+                'rows' => [['id' => 1]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        self::assertStringContainsString('CUSTOM_VALUE', $transformer->transform('SELECT * FROM users', $tables));
+    }
+
     protected function createTransformer(): SqlTransformer
     {
         return new SelectTransformer();

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 final class SqliteTransformerTest extends TestCase
 {

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 final class UpdateTransformerTest extends TestCase
 {


### PR DESCRIPTION
## Summary

- centralize PHP-to-SQL shadow value encoding behind a dialect-specific typed renderer
- encode MySQL backslashes independently of SQL escape mode
- preserve PostgreSQL boolean, integer width, array, and binary types
- preserve SQLite BLOB bytes, REAL round-trip precision, and storage classes
- cast INSERT value projections using the reflected target column type

## Recurrence prevention

Value serialization is now one typed boundary per dialect instead of duplicated scalar/string branches in each SELECT transformer. Unit tests cover every encoding category and adapter integration compares real database behavior for prepared and literal inputs.

## Validation

- core: 294 unit tests; formatter and PHPStan clean
- MySQL: 894 unit tests; formatter and PHPStan clean
- PostgreSQL: 1,304 unit tests; formatter and PHPStan clean
- SQLite: 1,184 unit tests; formatter and PHPStan clean
- MySQLi prepared backslash integration: passing
- PostgreSQL boolean/BIGINT/array/BYTEA integration: passing
- SQLite BLOB/REAL/typeof integration: passing
- PDO/MySQLi adapter formatter and PHPStan: clean

Stacked on #212.

Fixes #5
Fixes #6
Fixes #33
Fixes #151
Fixes #155
Fixes #19
Fixes #177