### PR TITLE
Parse SQL structure without flattening nested syntax

### DIFF
--- a/packages/ztd-query-core/src/Sql/SqlToken.php
+++ b/packages/ztd-query-core/src/Sql/SqlToken.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Sql;
+
+/**
+ * A token with its original byte span and nesting level.
+ */
+final class SqlToken
+{
+    public function __construct(
+        public readonly SqlTokenKind $kind,
+        public readonly string $text,
+        public readonly int $offset,
+        public readonly int $depth,
+        public readonly int $bracketDepth,
+    ) {
+    }
+
+    public function endOffset(): int
+    {
+        return $this->offset + strlen($this->text);
+    }
+
+    public function isTopLevel(): bool
+    {
+        return $this->depth === 0 && $this->bracketDepth === 0;
+    }
+
+    public function isKeyword(string $keyword): bool
+    {
+        return $this->kind === SqlTokenKind::Word && strcasecmp($this->text, $keyword) === 0;
+    }
+}

--- a/packages/ztd-query-core/src/Sql/SqlTokenKind.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenKind.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Sql;
+
+/**
+ * Lexical categories needed for lossless SQL structure inspection.
+ */
+enum SqlTokenKind: string
+{
+    case Word = 'word';
+    case QuotedIdentifier = 'quoted_identifier';
+    case String = 'string';
+    case Number = 'number';
+    case Parameter = 'parameter';
+    case Symbol = 'symbol';
+    case Comment = 'comment';
+    case Whitespace = 'whitespace';
+}

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -134,29 +134,29 @@ final class SqlTokenStream
     public function selectFromClauses(): array
     {
         $tokens = $this->significantTokens();
+        /** @var array<int, array<int, bool>> $selectScopes */
         $selectScopes = [];
         $clauses = [];
 
         foreach ($tokens as $index => $token) {
-            $scope = $token->depth . ':' . $token->bracketDepth;
             if ($token->isKeyword('SELECT')) {
-                $selectScopes[$scope] = true;
+                $selectScopes[$token->depth][$token->bracketDepth] = true;
                 continue;
             }
             if ($token->isKeyword('UNION') || $token->isKeyword('INTERSECT') || $token->isKeyword('EXCEPT')) {
-                $selectScopes[$scope] = false;
+                $selectScopes[$token->depth][$token->bracketDepth] = false;
                 continue;
             }
-            if (!$token->isKeyword('FROM') || ($selectScopes[$scope] ?? false) !== true) {
+            if (!$token->isKeyword('FROM') || ($selectScopes[$token->depth][$token->bracketDepth] ?? false) !== true) {
                 continue;
             }
 
-            $end = $this->findSelectFromEnd($tokens, $index + 1, $token);
+            $end = $this->findSelectFromEnd($tokens, $token);
             $clause = trim(substr($this->sql, $token->endOffset(), $end - $token->endOffset()));
             if ($clause !== '') {
                 $clauses[] = $clause;
             }
-            $selectScopes[$scope] = false;
+            $selectScopes[$token->depth][$token->bracketDepth] = false;
         }
 
         return $clauses;
@@ -188,7 +188,7 @@ final class SqlTokenStream
     }
 
     /** @param list<SqlToken> $tokens */
-    private function findSelectFromEnd(array $tokens, int $from, SqlToken $fromToken): int
+    private function findSelectFromEnd(array $tokens, SqlToken $fromToken): int
     {
         $terminators = [
             ['WHERE'], ['GROUP', 'BY'], ['HAVING'], ['ORDER', 'BY'],
@@ -196,16 +196,23 @@ final class SqlTokenStream
             ['FOR'], ['RETURNING'],
         ];
 
-        for ($index = $from, $count = count($tokens); $index < $count; $index++) {
-            $token = $tokens[$index];
+        $afterFrom = false;
+        foreach ($tokens as $index => $token) {
+            if (!$afterFrom) {
+                $afterFrom = $token === $fromToken;
+                continue;
+            }
             if ($token->depth < $fromToken->depth || $token->bracketDepth < $fromToken->bracketDepth) {
                 return $token->offset;
             }
-            if ($token->depth !== $fromToken->depth || $token->bracketDepth !== $fromToken->bracketDepth) {
+            if ($token->depth !== $fromToken->depth) {
+                continue;
+            }
+            if ($token->bracketDepth !== $fromToken->bracketDepth) {
                 continue;
             }
             foreach ($terminators as $sequence) {
-                if ($this->matchesKeywordSequenceAtDepth($tokens, $index, $sequence, $fromToken)) {
+                if ($this->matchesKeywordSequence($tokens, $index, $sequence)) {
                     return $token->offset;
                 }
             }
@@ -218,19 +225,17 @@ final class SqlTokenStream
      * @param list<SqlToken> $tokens
      * @param non-empty-list<string> $keywords
      */
-    private function matchesKeywordSequenceAtDepth(
+    private function matchesKeywordSequence(
         array $tokens,
         int $index,
         array $keywords,
-        SqlToken $reference,
     ): bool {
         foreach ($keywords as $relative => $keyword) {
             $candidate = $tokens[$index + $relative] ?? null;
-            if ($candidate === null
-                || $candidate->depth !== $reference->depth
-                || $candidate->bracketDepth !== $reference->bracketDepth
-                || !$candidate->isKeyword($keyword)
-            ) {
+            if ($candidate === null) {
+                return false;
+            }
+            if (!$candidate->isKeyword($keyword)) {
                 return false;
             }
         }
@@ -261,10 +266,8 @@ final class SqlTokenStream
             }
 
             if ($char === '-' && $next === '-') {
-                $offset += 2;
-                while ($offset < $length && $sql[$offset] !== "\n") {
-                    $offset++;
-                }
+                $lineEnd = strpos($sql, "\n", $offset);
+                $offset = $lineEnd === false ? $length : $lineEnd;
                 $tokens[] = self::token($sql, SqlTokenKind::Comment, $start, $offset, $depth, $bracketDepth);
                 continue;
             }
@@ -272,13 +275,17 @@ final class SqlTokenStream
             if ($char === '/' && $next === '*') {
                 $offset += 2;
                 $commentDepth = 1;
-                while ($offset < $length && $commentDepth > 0) {
-                    if (($sql[$offset] ?? '') === '/' && ($sql[$offset + 1] ?? '') === '*') {
+                while ($commentDepth > 0) {
+                    if (!isset($sql[$offset])) {
+                        break;
+                    }
+                    $pair = substr($sql, $offset, 2);
+                    if ($pair === '/*') {
                         $commentDepth++;
                         $offset += 2;
                         continue;
                     }
-                    if (($sql[$offset] ?? '') === '*' && ($sql[$offset + 1] ?? '') === '/') {
+                    if ($pair === '*/') {
                         $commentDepth--;
                         $offset += 2;
                         continue;
@@ -311,10 +318,8 @@ final class SqlTokenStream
                     continue;
                 }
                 if (ctype_digit($next)) {
-                    $offset += 2;
-                    while ($offset < $length && ctype_digit($sql[$offset])) {
-                        $offset++;
-                    }
+                    $offset++;
+                    $offset += strspn($sql, '0123456789', $offset);
                     $tokens[] = self::token($sql, SqlTokenKind::Parameter, $start, $offset, $depth, $bracketDepth);
                     continue;
                 }
@@ -342,18 +347,12 @@ final class SqlTokenStream
                 $offset++;
                 if ($char === '0' && (($sql[$offset] ?? '') === 'x' || ($sql[$offset] ?? '') === 'X')) {
                     $offset++;
-                    while ($offset < $length && preg_match('/[0-9A-Fa-f_]/', $sql[$offset]) === 1) {
-                        $offset++;
-                    }
+                    $offset += strspn($sql, '0123456789ABCDEFabcdef_', $offset);
                 } else {
-                    while ($offset < $length && (ctype_digit($sql[$offset]) || $sql[$offset] === '_')) {
-                        $offset++;
-                    }
+                    $offset += strspn($sql, '0123456789_', $offset);
                     if (($sql[$offset] ?? '') === '.') {
                         $offset++;
-                        while ($offset < $length && (ctype_digit($sql[$offset]) || $sql[$offset] === '_')) {
-                            $offset++;
-                        }
+                        $offset += strspn($sql, '0123456789_', $offset);
                     }
                     if (($sql[$offset] ?? '') === 'e' || ($sql[$offset] ?? '') === 'E') {
                         $offset++;
@@ -388,9 +387,8 @@ final class SqlTokenStream
 
     private static function scanQuoted(string $sql, int $offset, string $quote): int
     {
-        $length = strlen($sql);
         $offset++;
-        while ($offset < $length) {
+        while (isset($sql[$offset])) {
             if ($sql[$offset] === $quote) {
                 if (($sql[$offset + 1] ?? '') === $quote) {
                     $offset += 2;
@@ -399,14 +397,14 @@ final class SqlTokenStream
 
                 return $offset + 1;
             }
-            if ($sql[$offset] === '\\' && isset($sql[$offset + 1])) {
+            if ($sql[$offset] === '\\') {
                 $offset += 2;
                 continue;
             }
             $offset++;
         }
 
-        return $offset;
+        return strlen($sql);
     }
 
     private static function dollarTagLength(string $tail): ?int

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -1,0 +1,441 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Sql;
+
+/**
+ * Lossless SQL token stream for structure-aware clause operations.
+ */
+final class SqlTokenStream
+{
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private function __construct(
+        private readonly string $sql,
+        private readonly array $tokens,
+    ) {
+    }
+
+    public static function tokenize(string $sql): self
+    {
+        return new self($sql, self::scan($sql));
+    }
+
+    /** @return list<SqlToken> */
+    public function tokens(): array
+    {
+        return $this->tokens;
+    }
+
+    /** @return list<SqlToken> */
+    public function significantTokens(): array
+    {
+        return array_values(array_filter(
+            $this->tokens,
+            static fn (SqlToken $token): bool => !in_array(
+                $token->kind,
+                [SqlTokenKind::Whitespace, SqlTokenKind::Comment],
+                true,
+            ),
+        ));
+    }
+
+    /** @return list<string> */
+    public function splitStatements(): array
+    {
+        $statements = [];
+        $start = 0;
+        foreach ($this->significantTokens() as $token) {
+            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== ';' || !$token->isTopLevel()) {
+                continue;
+            }
+            $statement = trim(substr($this->sql, $start, $token->offset - $start));
+            if ($statement !== '') {
+                $statements[] = $statement;
+            }
+            $start = $token->endOffset();
+        }
+
+        $statement = trim(substr($this->sql, $start));
+        if ($statement !== '') {
+            $statements[] = $statement;
+        }
+
+        return $statements;
+    }
+
+    /**
+     * @param non-empty-list<string> $startKeywords
+     * @param list<non-empty-list<string>> $endKeywords
+     */
+    public function topLevelClause(array $startKeywords, array $endKeywords = []): ?string
+    {
+        $tokens = $this->significantTokens();
+        $start = $this->findKeywordSequence($tokens, $startKeywords, 0);
+        if ($start === null) {
+            return null;
+        }
+
+        $contentStart = $tokens[$start + count($startKeywords) - 1]->endOffset();
+        $contentEnd = strlen($this->sql);
+        foreach ($endKeywords as $sequence) {
+            $candidate = $this->findKeywordSequence($tokens, $sequence, $start + count($startKeywords));
+            if ($candidate !== null) {
+                $contentEnd = min($contentEnd, $tokens[$candidate]->offset);
+            }
+        }
+
+        return trim(substr($this->sql, $contentStart, $contentEnd - $contentStart));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function splitTopLevel(string $delimiter = ','): array
+    {
+        $parts = [];
+        $start = 0;
+        foreach ($this->significantTokens() as $token) {
+            if ($token->kind !== SqlTokenKind::Symbol
+                || $token->text !== $delimiter
+                || !$token->isTopLevel()
+            ) {
+                continue;
+            }
+            $parts[] = trim(substr($this->sql, $start, $token->offset - $start));
+            $start = $token->endOffset();
+        }
+        $tail = trim(substr($this->sql, $start));
+        if ($tail !== '' || $parts !== []) {
+            $parts[] = $tail;
+        }
+
+        return $parts;
+    }
+
+    public function firstTopLevelKeyword(): ?string
+    {
+        foreach ($this->significantTokens() as $token) {
+            if ($token->isTopLevel() && $token->kind === SqlTokenKind::Word) {
+                return strtoupper($token->text);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Return every FROM clause that belongs to a SELECT at the same nesting level.
+     *
+     * @return list<string>
+     */
+    public function selectFromClauses(): array
+    {
+        $tokens = $this->significantTokens();
+        $selectScopes = [];
+        $clauses = [];
+
+        foreach ($tokens as $index => $token) {
+            $scope = $token->depth . ':' . $token->bracketDepth;
+            if ($token->isKeyword('SELECT')) {
+                $selectScopes[$scope] = true;
+                continue;
+            }
+            if ($token->isKeyword('UNION') || $token->isKeyword('INTERSECT') || $token->isKeyword('EXCEPT')) {
+                $selectScopes[$scope] = false;
+                continue;
+            }
+            if (!$token->isKeyword('FROM') || ($selectScopes[$scope] ?? false) !== true) {
+                continue;
+            }
+
+            $end = $this->findSelectFromEnd($tokens, $index + 1, $token);
+            $clause = trim(substr($this->sql, $token->endOffset(), $end - $token->endOffset()));
+            if ($clause !== '') {
+                $clauses[] = $clause;
+            }
+            $selectScopes[$scope] = false;
+        }
+
+        return $clauses;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param non-empty-list<string> $keywords
+     */
+    private function findKeywordSequence(array $tokens, array $keywords, int $from): ?int
+    {
+        $limit = count($tokens) - count($keywords);
+        for ($index = $from; $index <= $limit; $index++) {
+            $token = $tokens[$index];
+            if (!$token->isTopLevel()) {
+                continue;
+            }
+            foreach ($keywords as $relative => $keyword) {
+                $candidate = $tokens[$index + $relative];
+                if (!$candidate->isTopLevel() || !$candidate->isKeyword($keyword)) {
+                    continue 2;
+                }
+            }
+
+            return $index;
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function findSelectFromEnd(array $tokens, int $from, SqlToken $fromToken): int
+    {
+        $terminators = [
+            ['WHERE'], ['GROUP', 'BY'], ['HAVING'], ['ORDER', 'BY'],
+            ['LIMIT'], ['OFFSET'], ['UNION'], ['INTERSECT'], ['EXCEPT'],
+            ['FOR'], ['RETURNING'],
+        ];
+
+        for ($index = $from, $count = count($tokens); $index < $count; $index++) {
+            $token = $tokens[$index];
+            if ($token->depth < $fromToken->depth || $token->bracketDepth < $fromToken->bracketDepth) {
+                return $token->offset;
+            }
+            if ($token->depth !== $fromToken->depth || $token->bracketDepth !== $fromToken->bracketDepth) {
+                continue;
+            }
+            foreach ($terminators as $sequence) {
+                if ($this->matchesKeywordSequenceAtDepth($tokens, $index, $sequence, $fromToken)) {
+                    return $token->offset;
+                }
+            }
+        }
+
+        return strlen($this->sql);
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param non-empty-list<string> $keywords
+     */
+    private function matchesKeywordSequenceAtDepth(
+        array $tokens,
+        int $index,
+        array $keywords,
+        SqlToken $reference,
+    ): bool {
+        foreach ($keywords as $relative => $keyword) {
+            $candidate = $tokens[$index + $relative] ?? null;
+            if ($candidate === null
+                || $candidate->depth !== $reference->depth
+                || $candidate->bracketDepth !== $reference->bracketDepth
+                || !$candidate->isKeyword($keyword)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @return list<SqlToken> */
+    private static function scan(string $sql): array
+    {
+        $tokens = [];
+        $length = strlen($sql);
+        $offset = 0;
+        $depth = 0;
+        $bracketDepth = 0;
+
+        while ($offset < $length) {
+            $start = $offset;
+            $char = $sql[$offset];
+            $next = $sql[$offset + 1] ?? '';
+
+            if (ctype_space($char)) {
+                while ($offset < $length && ctype_space($sql[$offset])) {
+                    $offset++;
+                }
+                $tokens[] = self::token($sql, SqlTokenKind::Whitespace, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if ($char === '-' && $next === '-') {
+                $offset += 2;
+                while ($offset < $length && $sql[$offset] !== "\n") {
+                    $offset++;
+                }
+                $tokens[] = self::token($sql, SqlTokenKind::Comment, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if ($char === '/' && $next === '*') {
+                $offset += 2;
+                $commentDepth = 1;
+                while ($offset < $length && $commentDepth > 0) {
+                    if (($sql[$offset] ?? '') === '/' && ($sql[$offset + 1] ?? '') === '*') {
+                        $commentDepth++;
+                        $offset += 2;
+                        continue;
+                    }
+                    if (($sql[$offset] ?? '') === '*' && ($sql[$offset + 1] ?? '') === '/') {
+                        $commentDepth--;
+                        $offset += 2;
+                        continue;
+                    }
+                    $offset++;
+                }
+                $tokens[] = self::token($sql, SqlTokenKind::Comment, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if ($char === "'") {
+                $offset = self::scanQuoted($sql, $offset, "'");
+                $tokens[] = self::token($sql, SqlTokenKind::String, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if ($char === '"' || $char === '`') {
+                $offset = self::scanQuoted($sql, $offset, $char);
+                $tokens[] = self::token($sql, SqlTokenKind::QuotedIdentifier, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if ($char === '$') {
+                $tagLength = self::dollarTagLength(substr($sql, $offset));
+                if ($tagLength !== null) {
+                    $tag = substr($sql, $offset, $tagLength);
+                    $end = strpos($sql, $tag, $offset + $tagLength);
+                    $offset = $end === false ? $length : $end + $tagLength;
+                    $tokens[] = self::token($sql, SqlTokenKind::String, $start, $offset, $depth, $bracketDepth);
+                    continue;
+                }
+                if (ctype_digit($next)) {
+                    $offset += 2;
+                    while ($offset < $length && ctype_digit($sql[$offset])) {
+                        $offset++;
+                    }
+                    $tokens[] = self::token($sql, SqlTokenKind::Parameter, $start, $offset, $depth, $bracketDepth);
+                    continue;
+                }
+            }
+
+            if ($char === '?' || ($char === ':' && $next !== ':' && self::isWordStart($next))) {
+                $offset++;
+                while ($offset < $length && self::isWordPart($sql[$offset])) {
+                    $offset++;
+                }
+                $tokens[] = self::token($sql, SqlTokenKind::Parameter, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if (self::isWordStart($char)) {
+                $offset++;
+                while ($offset < $length && self::isWordPart($sql[$offset])) {
+                    $offset++;
+                }
+                $tokens[] = self::token($sql, SqlTokenKind::Word, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if (ctype_digit($char)) {
+                $offset++;
+                if ($char === '0' && (($sql[$offset] ?? '') === 'x' || ($sql[$offset] ?? '') === 'X')) {
+                    $offset++;
+                    while ($offset < $length && preg_match('/[0-9A-Fa-f_]/', $sql[$offset]) === 1) {
+                        $offset++;
+                    }
+                } else {
+                    while ($offset < $length && (ctype_digit($sql[$offset]) || $sql[$offset] === '_')) {
+                        $offset++;
+                    }
+                    if (($sql[$offset] ?? '') === '.') {
+                        $offset++;
+                        while ($offset < $length && (ctype_digit($sql[$offset]) || $sql[$offset] === '_')) {
+                            $offset++;
+                        }
+                    }
+                    if (($sql[$offset] ?? '') === 'e' || ($sql[$offset] ?? '') === 'E') {
+                        $offset++;
+                        if (($sql[$offset] ?? '') === '+' || ($sql[$offset] ?? '') === '-') {
+                            $offset++;
+                        }
+                        while ($offset < $length && ctype_digit($sql[$offset])) {
+                            $offset++;
+                        }
+                    }
+                }
+                $tokens[] = self::token($sql, SqlTokenKind::Number, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if ($char === ')') {
+                $depth = max(0, $depth - 1);
+            } elseif ($char === ']') {
+                $bracketDepth = max(0, $bracketDepth - 1);
+            }
+            $offset++;
+            $tokens[] = self::token($sql, SqlTokenKind::Symbol, $start, $offset, $depth, $bracketDepth);
+            if ($char === '(') {
+                $depth++;
+            } elseif ($char === '[') {
+                $bracketDepth++;
+            }
+        }
+
+        return $tokens;
+    }
+
+    private static function scanQuoted(string $sql, int $offset, string $quote): int
+    {
+        $length = strlen($sql);
+        $offset++;
+        while ($offset < $length) {
+            if ($sql[$offset] === $quote) {
+                if (($sql[$offset + 1] ?? '') === $quote) {
+                    $offset += 2;
+                    continue;
+                }
+
+                return $offset + 1;
+            }
+            if ($sql[$offset] === '\\' && isset($sql[$offset + 1])) {
+                $offset += 2;
+                continue;
+            }
+            $offset++;
+        }
+
+        return $offset;
+    }
+
+    private static function dollarTagLength(string $tail): ?int
+    {
+        if (preg_match('/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/', $tail, $matches) !== 1) {
+            return null;
+        }
+
+        return strlen($matches[0]);
+    }
+
+    private static function isWordStart(string $char): bool
+    {
+        return $char !== '' && ($char === '_' || ctype_alpha($char) || ord($char) >= 128);
+    }
+
+    private static function isWordPart(string $char): bool
+    {
+        return self::isWordStart($char) || ctype_digit($char) || $char === '$';
+    }
+
+    private static function token(
+        string $sql,
+        SqlTokenKind $kind,
+        int $start,
+        int $end,
+        int $depth,
+        int $bracketDepth,
+    ): SqlToken {
+        return new SqlToken($kind, substr($sql, $start, $end - $start), $start, $depth, $bracketDepth);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenKindTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenKindTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sql;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Sql\SqlTokenKind;
+
+#[CoversClass(SqlTokenKind::class)]
+final class SqlTokenKindTest extends TestCase
+{
+    public function testKindsHaveStableValues(): void
+    {
+        self::assertSame('word', SqlTokenKind::Word->value);
+        self::assertSame('quoted_identifier', SqlTokenKind::QuotedIdentifier->value);
+        self::assertSame('string', SqlTokenKind::String->value);
+        self::assertSame('number', SqlTokenKind::Number->value);
+        self::assertSame('parameter', SqlTokenKind::Parameter->value);
+        self::assertSame('symbol', SqlTokenKind::Symbol->value);
+        self::assertSame('comment', SqlTokenKind::Comment->value);
+        self::assertSame('whitespace', SqlTokenKind::Whitespace->value);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -5,22 +5,30 @@ declare(strict_types=1);
 namespace Tests\Unit\Sql;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Sql\SqlToken;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqlTokenStream::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
 final class SqlTokenStreamTest extends TestCase
 {
     public function testSplitsOnlyTopLevelStatementTerminators(): void
     {
-        $sql = 'SELECT \';\' AS value; SELECT $$a;b$$; /* ; */ SELECT 3';
+        $sql = 'SELECT \';\' AS value; SELECT $$a;b$$; /* ; */ SELECT (3; 4); SELECT [5; 6];;';
 
         self::assertSame(
-            ["SELECT ';' AS value", 'SELECT $$a;b$$', '/* ; */ SELECT 3'],
+            ["SELECT ';' AS value", 'SELECT $$a;b$$', '/* ; */ SELECT (3; 4)', 'SELECT [5; 6]'],
             SqlTokenStream::tokenize($sql)->splitStatements(),
         );
+    }
+
+    public function testReturnsNoStatementsForEmptyInputAndTerminators(): void
+    {
+        self::assertSame([], SqlTokenStream::tokenize(' ; ; ')->splitStatements());
     }
 
     public function testClauseIgnoresNestedKeywords(): void
@@ -39,6 +47,28 @@ final class SqlTokenStreamTest extends TestCase
         );
     }
 
+    public function testClauseSupportsMultiWordBoundariesAndUsesEarliestEnd(): void
+    {
+        $sql = 'SELECT id FROM users ORDER BY created_at LIMIT 10';
+        $stream = SqlTokenStream::tokenize($sql);
+
+        self::assertSame('created_at', $stream->topLevelClause(['ORDER', 'BY'], [['LIMIT'], ['RETURNING']]));
+        self::assertSame('id', $stream->topLevelClause(['SELECT'], [['LIMIT'], ['FROM']]));
+        self::assertNull($stream->topLevelClause(['GROUP', 'BY'], [['LIMIT']]));
+    }
+
+    public function testClauseRejectsSequencesSplitAcrossNestingLevels(): void
+    {
+        $sql = 'SELECT ORDER (BY hidden) BY visible FROM source';
+
+        self::assertNull(SqlTokenStream::tokenize($sql)->topLevelClause(['ORDER', 'BY'], [['FROM']]));
+    }
+
+    public function testClauseCanStartAtLastAvailableToken(): void
+    {
+        self::assertSame('', SqlTokenStream::tokenize('SET')->topLevelClause(['SET']));
+    }
+
     public function testSplitsCommasOutsideParenthesesArraysAndStrings(): void
     {
         $stream = SqlTokenStream::tokenize("ARRAY[1,2], COALESCE(a, b), 'x,y', plain");
@@ -49,13 +79,293 @@ final class SqlTokenStreamTest extends TestCase
         );
     }
 
-    public function testTracksQuotedIdentifiersCommentsAndParameters(): void
+    public function testSplitsWithCustomTopLevelDelimiterAndPreservesEmptyParts(): void
     {
-        $tokens = SqlTokenStream::tokenize('SELECT "where", `set`, ?, :name, $2 /* FROM */')->significantTokens();
-        $kinds = array_map(static fn (SqlToken $token): SqlTokenKind => $token->kind, $tokens);
+        $stream = SqlTokenStream::tokenize(' first ; (nested ; value) ; ; last ');
 
-        self::assertContains(SqlTokenKind::QuotedIdentifier, $kinds);
-        self::assertSame(3, count(array_filter($kinds, static fn (SqlTokenKind $kind): bool => $kind === SqlTokenKind::Parameter)));
+        self::assertSame(
+            ['first', '(nested ; value)', '', 'last'],
+            $stream->splitTopLevel(';'),
+        );
+    }
+
+    public function testSplitTopLevelHandlesEmptyAndTrailingDelimiterInput(): void
+    {
+        self::assertSame([], SqlTokenStream::tokenize('')->splitTopLevel());
+        self::assertSame(['value', ''], SqlTokenStream::tokenize('value,')->splitTopLevel());
+        self::assertSame(['value'], SqlTokenStream::tokenize('value')->splitTopLevel());
+    }
+
+    public function testTokenizesWhitespaceAndNestedCommentsLosslessly(): void
+    {
+        $sql = " \t-- note\n/* outer /* inner */ end */x";
+        $tokens = SqlTokenStream::tokenize($sql)->tokens();
+
+        self::assertSame(
+            [
+                [SqlTokenKind::Whitespace, " \t", 0],
+                [SqlTokenKind::Comment, '-- note', 2],
+                [SqlTokenKind::Whitespace, "\n", 9],
+                [SqlTokenKind::Comment, '/* outer /* inner */ end */', 10],
+                [SqlTokenKind::Word, 'x', 37],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text, $token->offset],
+                $tokens,
+            ),
+        );
+        self::assertSame($sql, implode('', array_map(static fn (SqlToken $token): string => $token->text, $tokens)));
+        self::assertSame(
+            ['x'],
+            array_map(static fn (SqlToken $token): string => $token->text, SqlTokenStream::tokenize($sql)->significantTokens()),
+        );
+    }
+
+    public function testTokenizesUnterminatedCommentsLosslessly(): void
+    {
+        self::assertSame(
+            [[SqlTokenKind::Comment, '/* outer /* inner */']],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize('/* outer /* inner */')->tokens(),
+            ),
+        );
+    }
+
+    public function testCommentDelimitersDoNotOverlapOrConsumeFollowingTokens(): void
+    {
+        self::assertSame(
+            [
+                [SqlTokenKind::Comment, '/**/'],
+                [SqlTokenKind::Word, 'next'],
+                [SqlTokenKind::Comment, '/*/unterminated'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize('/**/next/*/unterminated')->tokens(),
+            ),
+        );
+        self::assertSame(
+            [
+                [SqlTokenKind::Word, 'prefix'],
+                [SqlTokenKind::Whitespace, ' '],
+                [SqlTokenKind::Comment, '--'],
+                [SqlTokenKind::Whitespace, "\n"],
+                [SqlTokenKind::Word, 'next'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize("prefix --\nnext")->tokens(),
+            ),
+        );
+    }
+
+    public function testNestedCommentDelimitersAdvanceAsPairs(): void
+    {
+        self::assertSame(
+            [
+                [SqlTokenKind::Comment, '/*/**/*/'],
+                [SqlTokenKind::Word, 'tail'],
+                [SqlTokenKind::Comment, '/*/*/x*/tail'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize('/*/**/*/tail/*/*/x*/tail')->tokens(),
+            ),
+        );
+    }
+
+    public function testAsteriskWithoutOpeningSlashIsNotAComment(): void
+    {
+        self::assertSame(
+            [
+                [SqlTokenKind::Word, 'value'],
+                [SqlTokenKind::Symbol, '*'],
+                [SqlTokenKind::Symbol, '*'],
+                [SqlTokenKind::Word, 'not_comment'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize('value**not_comment')->tokens(),
+            ),
+        );
+    }
+
+    public function testTokenizesQuotedValuesAndIdentifiers(): void
+    {
+        $sql = "'it''s' 'a\\\\\'b' \"a\"\"b\" `a``b` 'open";
+
+        self::assertSame(
+            [
+                [SqlTokenKind::String, "'it''s'"],
+                [SqlTokenKind::Whitespace, ' '],
+                [SqlTokenKind::String, "'a\\\\\'b'"],
+                [SqlTokenKind::Whitespace, ' '],
+                [SqlTokenKind::QuotedIdentifier, '"a""b"'],
+                [SqlTokenKind::Whitespace, ' '],
+                [SqlTokenKind::QuotedIdentifier, '`a``b`'],
+                [SqlTokenKind::Whitespace, ' '],
+                [SqlTokenKind::String, "'open"],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize($sql)->tokens(),
+            ),
+        );
+    }
+
+    public function testQuotedEscapeAtEndRemainsInsideUnterminatedValue(): void
+    {
+        self::assertSame(
+            [[SqlTokenKind::String, "'value\x5c"]],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize("'value\x5c")->tokens(),
+            ),
+        );
+    }
+
+    public function testQuotedEscapeControlsWhereTheValueEnds(): void
+    {
+        self::assertSame(
+            [
+                [SqlTokenKind::String, "'''\x5c'x'"],
+                [SqlTokenKind::Whitespace, ' '],
+                [SqlTokenKind::String, "'\x5cx'"],
+                [SqlTokenKind::Whitespace, ' '],
+                [SqlTokenKind::Word, 'tail'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize("'''\x5c'x' '\x5cx' tail")->tokens(),
+            ),
+        );
+    }
+
+    public function testTokenizesDollarStringsAndParameters(): void
+    {
+        $sql = '$$body$$ $tag$body$tag$ $1 $123 ? :name :: : $word';
+
+        self::assertSame(
+            [
+                [SqlTokenKind::String, '$$body$$'],
+                [SqlTokenKind::String, '$tag$body$tag$'],
+                [SqlTokenKind::Parameter, '$1'],
+                [SqlTokenKind::Parameter, '$123'],
+                [SqlTokenKind::Parameter, '?'],
+                [SqlTokenKind::Parameter, ':name'],
+                [SqlTokenKind::Symbol, ':'],
+                [SqlTokenKind::Symbol, ':'],
+                [SqlTokenKind::Symbol, ':'],
+                [SqlTokenKind::Symbol, '$'],
+                [SqlTokenKind::Word, 'word'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize($sql)->significantTokens(),
+            ),
+        );
+    }
+
+    public function testParametersStopBeforeFollowingWordAndAtEndOfInput(): void
+    {
+        self::assertSame(
+            [
+                [SqlTokenKind::Parameter, '$1'],
+                [SqlTokenKind::Word, 'x'],
+                [SqlTokenKind::Parameter, ':end'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize('$1x :end')->significantTokens(),
+            ),
+        );
+    }
+
+    public function testTokenizesUnterminatedDollarString(): void
+    {
+        self::assertSame(
+            [[SqlTokenKind::String, '$tag$body']],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize('$tag$body')->tokens(),
+            ),
+        );
+    }
+
+    public function testDollarTagMustStartAtCurrentOffset(): void
+    {
+        self::assertSame(
+            [
+                [SqlTokenKind::Symbol, '$'],
+                [SqlTokenKind::Word, 'bad'],
+                [SqlTokenKind::Symbol, '-'],
+                [SqlTokenKind::String, '$tag$body$tag$'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize('$bad-$tag$body$tag$')->tokens(),
+            ),
+        );
+    }
+
+    public function testTokenizesWordsAndEveryNumberForm(): void
+    {
+        $sql = "_word2\$tail café9 \x80 0 9_000 0xCA_FE 0Xb 0y 1.25 2e3 3E+4 4e-5 5. 6eX";
+
+        self::assertSame(
+            [
+                [SqlTokenKind::Word, '_word2$tail'],
+                [SqlTokenKind::Word, 'café9'],
+                [SqlTokenKind::Word, "\x80"],
+                [SqlTokenKind::Number, '0'],
+                [SqlTokenKind::Number, '9_000'],
+                [SqlTokenKind::Number, '0xCA_FE'],
+                [SqlTokenKind::Number, '0Xb'],
+                [SqlTokenKind::Number, '0'],
+                [SqlTokenKind::Word, 'y'],
+                [SqlTokenKind::Number, '1.25'],
+                [SqlTokenKind::Number, '2e3'],
+                [SqlTokenKind::Number, '3E+4'],
+                [SqlTokenKind::Number, '4e-5'],
+                [SqlTokenKind::Number, '5.'],
+                [SqlTokenKind::Number, '6e'],
+                [SqlTokenKind::Word, 'X'],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->kind, $token->text],
+                SqlTokenStream::tokenize($sql)->significantTokens(),
+            ),
+        );
+    }
+
+    public function testTracksParenthesisAndBracketDepthWithoutUnderflow(): void
+    {
+        self::assertSame(
+            [
+                ['(', 0, 0],
+                ['[', 1, 0],
+                ['x', 1, 1],
+                [']', 1, 0],
+                [',', 1, 0],
+                ['(', 1, 0],
+                ['y', 2, 0],
+                [')', 1, 0],
+                [')', 0, 0],
+                ['[', 0, 0],
+                ['[', 0, 1],
+                ['z', 0, 2],
+                [']', 0, 1],
+                [']', 0, 0],
+                [')', 0, 0],
+                [']', 0, 0],
+                ['(', 0, 0],
+            ],
+            array_map(
+                static fn (SqlToken $token): array => [$token->text, $token->depth, $token->bracketDepth],
+                SqlTokenStream::tokenize('([x],(y))[[z]])](')->significantTokens(),
+            ),
+        );
     }
 
     public function testFindsFirstTopLevelKeywordAfterLeadingComment(): void
@@ -64,6 +374,12 @@ final class SqlTokenStreamTest extends TestCase
             'WITH',
             SqlTokenStream::tokenize('/* SELECT */ WITH data AS (SELECT 1) SELECT * FROM data')->firstTopLevelKeyword(),
         );
+    }
+
+    public function testFirstTopLevelKeywordIgnoresNestedWordsAndCanBeAbsent(): void
+    {
+        self::assertSame('UPDATE', SqlTokenStream::tokenize('(SELECT hidden) [DELETE hidden] update users')->firstTopLevelKeyword());
+        self::assertNull(SqlTokenStream::tokenize("123 + 'SELECT'")->firstTopLevelKeyword());
     }
 
     public function testKeepsArithmeticOperatorsOutsideNumberTokens(): void
@@ -83,6 +399,87 @@ final class SqlTokenStreamTest extends TestCase
         self::assertSame(
             ['events', 'archived', 'current_events'],
             SqlTokenStream::tokenize($sql)->selectFromClauses(),
+        );
+    }
+
+    public function testSelectFromClausesStopAtEveryClauseBoundary(): void
+    {
+        $sql = 'SELECT * FROM a WHERE x; SELECT * FROM b GROUP BY x; SELECT * FROM c HAVING x; SELECT * FROM d ORDER BY x; SELECT * FROM e LIMIT 1; SELECT * FROM f OFFSET 1; SELECT * FROM g FOR UPDATE; SELECT * FROM h RETURNING x';
+
+        self::assertSame(
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+            SqlTokenStream::tokenize($sql)->selectFromClauses(),
+        );
+    }
+
+    public function testSelectFromClausesTrackSetOperationScopes(): void
+    {
+        $sql = 'SELECT * FROM first UNION SELECT * FROM second INTERSECT SELECT * FROM third EXCEPT SELECT * FROM fourth';
+
+        self::assertSame(
+            ['first', 'second', 'third', 'fourth'],
+            SqlTokenStream::tokenize($sql)->selectFromClauses(),
+        );
+    }
+
+    public function testEverySetOperationReleasesItsSelectScope(): void
+    {
+        $sql = 'SELECT 1 UNION FROM invalid_union; SELECT 1 INTERSECT FROM invalid_intersect; SELECT 1 EXCEPT FROM invalid_except';
+
+        self::assertSame([], SqlTokenStream::tokenize($sql)->selectFromClauses());
+    }
+
+    public function testSelectFromClausesTrackParenthesisAndBracketScopesIndependently(): void
+    {
+        $sql = 'SELECT [SELECT * FROM bracketed] FROM (SELECT * FROM nested) outer_table';
+
+        self::assertSame(
+            ['bracketed', '(SELECT * FROM nested) outer_table', 'nested'],
+            SqlTokenStream::tokenize($sql)->selectFromClauses(),
+        );
+    }
+
+    public function testSelectWithoutFromDoesNotOwnLaterFromClause(): void
+    {
+        $sql = 'SELECT 1 UNION FROM invalid';
+
+        self::assertSame([], SqlTokenStream::tokenize($sql)->selectFromClauses());
+    }
+
+    public function testSelectOwnsOnlyItsFirstFromClause(): void
+    {
+        $sql = 'SELECT * FROM users WHERE id FROM invalid';
+
+        self::assertSame(['users'], SqlTokenStream::tokenize($sql)->selectFromClauses());
+    }
+
+    public function testSelectFromEndIgnoresNestedClauseBoundaries(): void
+    {
+        $sql = 'SELECT * FROM (SELECT * FROM nested WHERE active) alias WHERE visible; SELECT * FROM source GROUP (BY hidden) WHERE valid; SELECT * FROM another ORDER [BY hidden] LIMIT 1';
+
+        self::assertSame(
+            ['(SELECT * FROM nested WHERE active) alias', 'nested', 'source GROUP (BY hidden)', 'another ORDER [BY hidden]'],
+            SqlTokenStream::tokenize($sql)->selectFromClauses(),
+        );
+    }
+
+    public function testIncompleteMultiWordBoundaryRemainsInFromClause(): void
+    {
+        self::assertSame(
+            ['source GROUP'],
+            SqlTokenStream::tokenize('SELECT * FROM source GROUP')->selectFromClauses(),
+        );
+    }
+
+    public function testFromSearchStartsAfterFromToken(): void
+    {
+        self::assertSame(
+            ['table'],
+            SqlTokenStream::tokenize('SELECT WHERE FROM table')->selectFromClauses(),
+        );
+        self::assertSame(
+            [],
+            SqlTokenStream::tokenize('SELECT * FROM WHERE value')->selectFromClauses(),
         );
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sql;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(SqlTokenStream::class)]
+final class SqlTokenStreamTest extends TestCase
+{
+    public function testSplitsOnlyTopLevelStatementTerminators(): void
+    {
+        $sql = 'SELECT \';\' AS value; SELECT $$a;b$$; /* ; */ SELECT 3';
+
+        self::assertSame(
+            ["SELECT ';' AS value", 'SELECT $$a;b$$', '/* ; */ SELECT 3'],
+            SqlTokenStream::tokenize($sql)->splitStatements(),
+        );
+    }
+
+    public function testClauseIgnoresNestedKeywords(): void
+    {
+        $sql = "UPDATE users SET label = TRIM(BOTH 'x' FROM label), amount = CAST(raw AS DECIMAL(10,2)) WHERE id IN (SELECT id FROM source WHERE active) ORDER BY id";
+
+        $stream = SqlTokenStream::tokenize($sql);
+
+        self::assertSame(
+            "label = TRIM(BOTH 'x' FROM label), amount = CAST(raw AS DECIMAL(10,2))",
+            $stream->topLevelClause(['SET'], [['FROM'], ['WHERE'], ['ORDER', 'BY'], ['LIMIT']]),
+        );
+        self::assertSame(
+            'id IN (SELECT id FROM source WHERE active)',
+            $stream->topLevelClause(['WHERE'], [['ORDER', 'BY'], ['LIMIT']]),
+        );
+    }
+
+    public function testSplitsCommasOutsideParenthesesArraysAndStrings(): void
+    {
+        $stream = SqlTokenStream::tokenize("ARRAY[1,2], COALESCE(a, b), 'x,y', plain");
+
+        self::assertSame(
+            ['ARRAY[1,2]', 'COALESCE(a, b)', "'x,y'", 'plain'],
+            $stream->splitTopLevel(),
+        );
+    }
+
+    public function testTracksQuotedIdentifiersCommentsAndParameters(): void
+    {
+        $tokens = SqlTokenStream::tokenize('SELECT "where", `set`, ?, :name, $2 /* FROM */')->significantTokens();
+        $kinds = array_map(static fn (SqlToken $token): SqlTokenKind => $token->kind, $tokens);
+
+        self::assertContains(SqlTokenKind::QuotedIdentifier, $kinds);
+        self::assertSame(3, count(array_filter($kinds, static fn (SqlTokenKind $kind): bool => $kind === SqlTokenKind::Parameter)));
+    }
+
+    public function testFindsFirstTopLevelKeywordAfterLeadingComment(): void
+    {
+        self::assertSame(
+            'WITH',
+            SqlTokenStream::tokenize('/* SELECT */ WITH data AS (SELECT 1) SELECT * FROM data')->firstTopLevelKeyword(),
+        );
+    }
+
+    public function testKeepsArithmeticOperatorsOutsideNumberTokens(): void
+    {
+        $tokens = SqlTokenStream::tokenize('SELECT 1+2, 3.5e-2')->significantTokens();
+
+        self::assertSame(
+            ['SELECT', '1', '+', '2', ',', '3.5e-2'],
+            array_map(static fn (SqlToken $token): string => $token->text, $tokens),
+        );
+    }
+
+    public function testFindsOnlyFromClausesOwnedBySelectScopes(): void
+    {
+        $sql = 'SELECT EXTRACT(YEAR FROM event_date) FROM events WHERE id IN (SELECT id FROM archived) UNION SELECT id FROM current_events';
+
+        self::assertSame(
+            ['events', 'archived', 'current_events'],
+            SqlTokenStream::tokenize($sql)->selectFromClauses(),
+        );
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sql;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+
+#[CoversClass(SqlToken::class)]
+final class SqlTokenTest extends TestCase
+{
+    public function testExposesSpanNestingAndKeywordComparison(): void
+    {
+        $token = new SqlToken(SqlTokenKind::Word, 'select', 3, 0, 0);
+
+        self::assertSame(9, $token->endOffset());
+        self::assertTrue($token->isTopLevel());
+        self::assertTrue($token->isKeyword('SELECT'));
+    }
+
+    public function testNestedTokenIsNotTopLevel(): void
+    {
+        $token = new SqlToken(SqlTokenKind::Word, 'WHERE', 0, 1, 0);
+
+        self::assertFalse($token->isTopLevel());
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenTest.php
@@ -27,4 +27,25 @@ final class SqlTokenTest extends TestCase
 
         self::assertFalse($token->isTopLevel());
     }
+
+    public function testBracketNestedTokenIsNotTopLevel(): void
+    {
+        $token = new SqlToken(SqlTokenKind::Word, 'WHERE', 0, 0, 1);
+
+        self::assertFalse($token->isTopLevel());
+    }
+
+    public function testNonWordTokenIsNotAKeyword(): void
+    {
+        $token = new SqlToken(SqlTokenKind::String, 'SELECT', 0, 0, 0);
+
+        self::assertFalse($token->isKeyword('SELECT'));
+    }
+
+    public function testDifferentWordIsNotAKeyword(): void
+    {
+        $token = new SqlToken(SqlTokenKind::Word, 'SELECTED', 0, 0, 0);
+
+        self::assertFalse($token->isKeyword('SELECT'));
+    }
 }

--- a/packages/ztd-query-mysql/src/MySqlParser.php
+++ b/packages/ztd-query-mysql/src/MySqlParser.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\MySql;
 
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
+use ZtdQuery\Sql\SqlTokenStream;
 
 /**
  * MySQL parser implementation backed by phpMyAdmin SQL parser.
@@ -18,7 +19,7 @@ final class MySqlParser
      * Suppresses warnings for large number to int conversion that occur
      * in phpmyadmin/sql-parser when parsing SQL with very large numeric literals.
      *
-     * @return array<int, Statement>
+     * @return list<Statement>
      */
     public function parse(string $sql): array
     {
@@ -35,5 +36,11 @@ final class MySqlParser
         } finally {
             restore_error_handler();
         }
+    }
+
+    /** @return list<string> */
+    public function splitStatements(string $sql): array
+    {
+        return SqlTokenStream::tokenize($sql)->splitStatements();
     }
 }

--- a/packages/ztd-query-mysql/src/MySqlQueryGuard.php
+++ b/packages/ztd-query-mysql/src/MySqlQueryGuard.php
@@ -34,9 +34,17 @@ final class MySqlQueryGuard
      */
     public function classify(string $sql): ?QueryKind
     {
-        $statements = $this->parser->parse($sql);
-        if ($statements === [] || count($statements) !== 1) {
+        if (count($this->parser->splitStatements($sql)) !== 1) {
             return null;
+        }
+
+        $statements = $this->parser->parse($sql);
+        if ($statements === []) {
+            return null;
+        }
+
+        if (count($statements) > 1) {
+            return $this->classifyCompositeRead($statements);
         }
 
         $statement = $statements[0];
@@ -48,6 +56,22 @@ final class MySqlQueryGuard
         }
 
         return $this->classifyStatement($statement);
+    }
+
+    /**
+     * phpmyadmin/sql-parser represents some single set expressions as several SELECT statements.
+     *
+     * @param list<Statement> $statements
+     */
+    private function classifyCompositeRead(array $statements): ?QueryKind
+    {
+        foreach ($statements as $statement) {
+            if (!$statement instanceof SelectStatement || $statement->into !== null) {
+                return null;
+            }
+        }
+
+        return QueryKind::READ;
     }
 
     /**

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -59,6 +59,14 @@ final class MySqlRewriter implements SqlRewriter
      */
     public function rewrite(string $sql): RewritePlan
     {
+        $logicalStatements = $this->parser->splitStatements($sql);
+        if ($logicalStatements === []) {
+            throw new UnsupportedSqlException($sql, 'Empty or unparseable');
+        }
+        if (count($logicalStatements) !== 1) {
+            throw new UnsupportedSqlException($sql, 'Multi-statement');
+        }
+
         $statements = $this->parser->parse($sql);
         if ($statements === []) {
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
@@ -68,7 +76,7 @@ final class MySqlRewriter implements SqlRewriter
             return $this->rewriteStatement($statements[0], $sql);
         }
 
-        throw new UnsupportedSqlException($sql, 'Multi-statement');
+        return $this->rewriteCompositeRead($statements, $sql);
     }
 
     /**
@@ -79,7 +87,7 @@ final class MySqlRewriter implements SqlRewriter
      */
     public function rewriteMultiple(string $sql): MultiRewritePlan
     {
-        $statements = $this->parser->parse($sql);
+        $statements = $this->parser->splitStatements($sql);
 
         if ($statements === []) {
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
@@ -87,11 +95,36 @@ final class MySqlRewriter implements SqlRewriter
 
         $plans = [];
         foreach ($statements as $statement) {
-            $stmtSql = $statement->build();
-            $plans[] = $this->rewriteStatement($statement, $stmtSql);
+            $plans[] = $this->rewrite($statement);
         }
 
         return new MultiRewritePlan($plans);
+    }
+
+    /**
+     * phpmyadmin/sql-parser represents EXCEPT, INTERSECT, and some nested EXISTS
+     * expressions as several SELECT statements even though the SQL has one statement.
+     *
+     * @param list<Statement> $statements
+     */
+    private function rewriteCompositeRead(array $statements, string $sql): RewritePlan
+    {
+        foreach ($statements as $statement) {
+            if (!$statement instanceof SelectStatement || $statement->into !== null) {
+                throw new UnsupportedSqlException($sql, 'Statement type not supported');
+            }
+            if ($this->hasSchemaContext()) {
+                $unknownTable = $this->findUnknownTable($statement);
+                if ($unknownTable !== null) {
+                    throw new UnknownSchemaException($sql, $unknownTable, 'table');
+                }
+            }
+        }
+
+        return new RewritePlan(
+            $this->transformer->transform($sql, $this->buildTableContext()),
+            QueryKind::READ,
+        );
     }
 
     private function rewriteStatement(Statement $statement, string $sql): RewritePlan

--- a/packages/ztd-query-mysql/tests/Unit/MySqlParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlParserTest.php
@@ -54,4 +54,13 @@ final class MySqlParserTest extends TestCase
 
         self::assertCount(1, $statements);
     }
+
+    public function testSplitsActualStatementsWithoutSplittingSetExpressions(): void
+    {
+        $parser = new MySqlParser();
+
+        self::assertSame(['SELECT 1 EXCEPT SELECT 2'], $parser->splitStatements('SELECT 1 EXCEPT SELECT 2'));
+        self::assertSame(['SELECT 1 INTERSECT SELECT 2'], $parser->splitStatements('SELECT 1 INTERSECT SELECT 2'));
+        self::assertSame(['SELECT 1', 'SELECT 2'], $parser->splitStatements('SELECT 1; SELECT 2'));
+    }
 }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlQueryGuardTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlQueryGuardTest.php
@@ -58,6 +58,16 @@ class MySqlQueryGuardTest extends QueryClassifierContractTest
         self::assertSame(QueryKind::READ, $guard->classify('WITH cte AS (SELECT 1) SELECT * FROM users'));
     }
 
+    public function testClassifiesSingleSelectExpressionsSplitByThirdPartyParser(): void
+    {
+        $guard = new MySqlQueryGuard(new MySqlParser());
+
+        self::assertSame(QueryKind::READ, $guard->classify('SELECT 1 EXCEPT SELECT 2'));
+        self::assertSame(QueryKind::READ, $guard->classify('SELECT 1 INTERSECT SELECT 2'));
+        self::assertSame(QueryKind::READ, $guard->classify('SELECT 1 WHERE CASE WHEN EXISTS(SELECT 1) THEN TRUE ELSE FALSE END'));
+        self::assertNull($guard->classify('SELECT 1; SELECT 2'));
+    }
+
     public function testClassifiesWriteStatements(): void
     {
         $guard = new MySqlQueryGuard(new MySqlParser());

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -162,6 +162,42 @@ final class MySqlRewriterTest extends RewriterContractTest
         self::assertSame(QueryKind::READ, $caseExists->kind());
     }
 
+    public function testCompositeReadRejectsSelectInto(): void
+    {
+        $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());
+
+        $this->expectException(UnsupportedSqlException::class);
+        $this->expectExceptionMessage('Statement type not supported');
+
+        $rewriter->rewrite('SELECT 1 INTO @result EXCEPT SELECT 2');
+    }
+
+    public function testCompositeReadAllowsTablesWithoutSchemaContext(): void
+    {
+        $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());
+
+        $plan = $rewriter->rewrite('SELECT * FROM missing EXCEPT SELECT * FROM other');
+
+        self::assertSame(QueryKind::READ, $plan->kind());
+        self::assertSame('SELECT * FROM missing EXCEPT SELECT * FROM other', $plan->sql());
+    }
+
+    public function testCompositeReadRejectsUnknownTableWithSchemaContext(): void
+    {
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $registry = new TableDefinitionRegistry();
+        $definition = $schemaParser->parse('CREATE TABLE known (id INT)');
+        self::assertNotNull($definition);
+        $registry->register('known', $definition);
+        $rewriter = $this->createRewriter(new ShadowStore(), $registry);
+
+        $this->expectException(UnknownSchemaException::class);
+        $this->expectExceptionMessage('unknown_table');
+
+        $rewriter->rewrite('SELECT * FROM known EXCEPT SELECT * FROM unknown_table');
+    }
+
     public function testRewriteMultipleUsesLexicalStatementBoundaries(): void
     {
         $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -147,6 +147,32 @@ final class MySqlRewriterTest extends RewriterContractTest
         self::assertStringStartsWith('WITH `users` AS', $plan->sql());
     }
 
+    public function testRewritesSingleSetExpressionsWithoutTreatingThemAsMultipleStatements(): void
+    {
+        $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());
+
+        $except = $rewriter->rewrite('SELECT 1 EXCEPT SELECT 2');
+        $intersect = $rewriter->rewrite('SELECT 1 INTERSECT SELECT 2');
+        $caseExists = $rewriter->rewrite('SELECT 1 WHERE CASE WHEN EXISTS(SELECT 1) THEN TRUE ELSE FALSE END');
+
+        self::assertSame(QueryKind::READ, $except->kind());
+        self::assertSame('SELECT 1 EXCEPT SELECT 2', $except->sql());
+        self::assertSame(QueryKind::READ, $intersect->kind());
+        self::assertSame('SELECT 1 INTERSECT SELECT 2', $intersect->sql());
+        self::assertSame(QueryKind::READ, $caseExists->kind());
+    }
+
+    public function testRewriteMultipleUsesLexicalStatementBoundaries(): void
+    {
+        $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());
+
+        $plan = $rewriter->rewriteMultiple('SELECT 1 EXCEPT SELECT 2; SELECT 3');
+
+        self::assertCount(2, $plan->plans());
+        self::assertSame('SELECT 1 EXCEPT SELECT 2', $plan->plans()[0]->sql());
+        self::assertSame('SELECT 3', $plan->plans()[1]->sql());
+    }
+
     public function testRewriteUpdateCreatesMutation(): void
     {
         $shadowStore = new ShadowStore();

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -20,6 +20,38 @@ use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
 #[Large]
 final class MysqliCteShadowingTest extends TestCase
 {
+    public function testSetExpressionsRemainSingleStatements(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $users = 'prefix_' . bin2hex(random_bytes(8));
+        $vip = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (name VARCHAR(255) PRIMARY KEY)', $users));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (name VARCHAR(255) PRIMARY KEY)', $vip));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $ztdMysqli->query(sprintf("INSERT INTO `%s` (name) VALUES ('Alice'), ('Bob')", $users));
+            $ztdMysqli->query(sprintf("INSERT INTO `%s` (name) VALUES ('Alice')", $vip));
+
+            $except = $ztdMysqli->query(sprintf(
+                'SELECT name FROM `%s` EXCEPT SELECT name FROM `%s` ORDER BY name',
+                $users,
+                $vip,
+            ));
+            $intersect = $ztdMysqli->query(sprintf(
+                'SELECT name FROM `%s` INTERSECT SELECT name FROM `%s` ORDER BY name',
+                $users,
+                $vip,
+            ));
+            self::assertInstanceOf(\mysqli_result::class, $except);
+            self::assertInstanceOf(\mysqli_result::class, $intersect);
+            self::assertSame([['name' => 'Bob']], $except->fetch_all(MYSQLI_ASSOC));
+            self::assertSame([['name' => 'Alice']], $intersect->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testSelectOnCleanShadowReturnsEmpty(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaAwareSqlBuilder.php
@@ -83,6 +83,14 @@ final class PgSchemaAwareSqlBuilder
         /** @var string $updateCol */
         $updateCol = $this->faker->randomElement($nonPkCols);
         $newValue = $this->generateLiteral($updateCol);
+        if ($this->isTextColumn($updateCol) && $this->faker->boolean(35)) {
+            $column = $this->quoteIdentifier($updateCol);
+            /** @var string $newValue */
+            $newValue = $this->faker->randomElement([
+                "TRIM(BOTH 'x' FROM $column)",
+                "SUBSTRING($column FROM 1 FOR 3)",
+            ]);
+        }
 
         $whereClause = $this->buildPkWhere($schema);
 
@@ -140,6 +148,18 @@ final class PgSchemaAwareSqlBuilder
 
         $str = $this->faker->lexify('????');
         return "'" . str_replace("'", "''", $str) . "'";
+    }
+
+    private function isTextColumn(string $column): bool
+    {
+        $column = strtolower($column);
+
+        return str_contains($column, 'name')
+            || str_contains($column, 'email')
+            || str_contains($column, 'status')
+            || str_contains($column, 'text')
+            || str_contains($column, 'varchar')
+            || str_contains($column, 'char');
     }
 
     private function quoteIdentifier(string $name): string

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/SelectFromTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/SelectFromTest.php
@@ -134,4 +134,23 @@ final class SelectFromTest extends TestCase
             $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
         }
     }
+
+    public function testFromKeywordInsideExtractIsNotTreatedAsTableClause(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$table} (id INTEGER PRIMARY KEY, event_date DATE NOT NULL)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO {$table} (id, event_date) VALUES (1, '2024-01-10')");
+
+            $statement = $ztdPdo->query("SELECT EXTRACT(YEAR FROM event_date) AS year FROM {$table} WHERE id = 1");
+
+            self::assertNotFalse($statement);
+            self::assertSame('2024', $statement->fetchColumn());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/UpdateBasicTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/UpdateBasicTest.php
@@ -108,4 +108,30 @@ final class UpdateBasicTest extends TestCase
             $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
         }
     }
+
+    public function testUpdateSetPreservesFromKeywordsInsideFunctions(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$table} (id INTEGER PRIMARY KEY, name TEXT NOT NULL, code TEXT NOT NULL)");
+            $rawPdo->exec("INSERT INTO {$table} (id, name, code) VALUES (1, '  Alice  ', 'abcdef')");
+
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO {$table} (id, name, code) VALUES (1, '  Alice  ', 'abcdef')");
+
+            $sql = "UPDATE {$table} SET name = TRIM(BOTH ' ' FROM name), code = SUBSTRING(code FROM 2 FOR 3) WHERE id = 1";
+            $rawPdo->exec($sql);
+            $ztdPdo->exec($sql);
+
+            $rawStatement = $rawPdo->query("SELECT * FROM {$table}");
+            $ztdStatement = $ztdPdo->query("SELECT * FROM {$table}");
+            self::assertNotFalse($rawStatement);
+            self::assertNotFalse($ztdStatement);
+            self::assertSame($rawStatement->fetchAll(), $ztdStatement->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
 }

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Platform\Postgres;
 
+use ZtdQuery\Sql\SqlTokenStream;
+
 /**
  * Focused PostgreSQL SQL parser.
  *
@@ -39,129 +41,7 @@ final class PgSqlParser
      */
     public function splitStatements(string $sql): array
     {
-        $statements = [];
-        $current = '';
-        $len = strlen($sql);
-        $inSingleQuote = false;
-        $inDoubleQuote = false;
-        $inDollarQuote = false;
-        $dollarTag = '';
-        $inLineComment = false;
-        $inBlockComment = false;
-
-        for ($i = 0; $i < $len; $i++) {
-            $char = $sql[$i];
-            $next = $i + 1 < $len ? $sql[$i + 1] : '';
-
-            if ($inLineComment) {
-                $current .= $char;
-                if ($char === "\n") {
-                    $inLineComment = false;
-                }
-                continue;
-            }
-
-            if ($inBlockComment) {
-                $current .= $char;
-                if ($char === '*' && $next === '/') {
-                    $current .= '/';
-                    $i++;
-                    $inBlockComment = false;
-                }
-                continue;
-            }
-
-            if ($inDollarQuote) {
-                if ($char === '$') {
-                    $endTag = '$' . $dollarTag . '$';
-                    $remaining = substr($sql, $i, strlen($endTag));
-                    if ($remaining === $endTag) {
-                        $current .= $endTag;
-                        $i += strlen($endTag) - 1;
-                        $inDollarQuote = false;
-                        continue;
-                    }
-                }
-                $current .= $char;
-                continue;
-            }
-
-            if ($inSingleQuote) {
-                $current .= $char;
-                if ($char === "'" && $next === "'") {
-                    $current .= "'";
-                    $i++;
-                } elseif ($char === "'") {
-                    $inSingleQuote = false;
-                }
-                continue;
-            }
-
-            if ($inDoubleQuote) {
-                $current .= $char;
-                if ($char === '"' && $next === '"') {
-                    $current .= '"';
-                    $i++;
-                } elseif ($char === '"') {
-                    $inDoubleQuote = false;
-                }
-                continue;
-            }
-
-            if ($char === '-' && $next === '-') {
-                $current .= $char;
-                $inLineComment = true;
-                continue;
-            }
-
-            if ($char === '/' && $next === '*') {
-                $current .= $char;
-                $inBlockComment = true;
-                continue;
-            }
-
-            if ($char === "'") {
-                $current .= $char;
-                $inSingleQuote = true;
-                continue;
-            }
-
-            if ($char === '"') {
-                $current .= $char;
-                $inDoubleQuote = true;
-                continue;
-            }
-
-            if ($char === '$') {
-                $tag = $this->extractDollarTag($sql, $i);
-                if ($tag !== null) {
-                    $dollarTag = $tag;
-                    $fullTag = '$' . $tag . '$';
-                    $current .= $fullTag;
-                    $i += strlen($fullTag) - 1;
-                    $inDollarQuote = true;
-                    continue;
-                }
-            }
-
-            if ($char === ';') {
-                $stmt = trim($current);
-                if ($stmt !== '') {
-                    $statements[] = $stmt;
-                }
-                $current = '';
-                continue;
-            }
-
-            $current .= $char;
-        }
-
-        $stmt = trim($current);
-        if ($stmt !== '') {
-            $statements[] = $stmt;
-        }
-
-        return $statements;
+        return SqlTokenStream::tokenize($sql)->splitStatements();
     }
 
     /**
@@ -249,20 +129,20 @@ final class PgSqlParser
      */
     public function extractOnConflictUpdateColumns(string $sql): array
     {
-        $sql = $this->maskComments($sql);
         $columns = [];
         /** @var array<string, string> $values */
         $values = [];
 
-        if (preg_match('/\bON\s+CONFLICT\b.*?\bDO\s+UPDATE\s+SET\s+(.+?)$/is', $sql, $m) !== 1) {
+        $setClause = SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['DO', 'UPDATE', 'SET'],
+            [['WHERE'], ['RETURNING']],
+        );
+        if ($setClause === null) {
             return ['columns' => [], 'values' => []];
         }
-
-        $setClause = $m[1];
-        $setClause = preg_replace('/\s+WHERE\s+.+$/is', '', $setClause) ?? $setClause;
         $setClause = rtrim($setClause, '; ');
 
-        $assignments = $this->splitByTopLevelComma($setClause);
+        $assignments = SqlTokenStream::tokenize($setClause)->splitTopLevel();
 
         foreach ($assignments as $assignment) {
             $assignment = trim($assignment);
@@ -334,13 +214,15 @@ final class PgSqlParser
      */
     public function extractUpdateSets(string $sql): array
     {
-        $sql = $this->maskComments($sql);
-        if (preg_match('/\bSET\s+(.+?)(?:\s+FROM\s+|\s+WHERE\s+|\s+RETURNING\s+|$)/is', $sql, $m) !== 1) {
+        $setClause = SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['SET'],
+            [['FROM'], ['WHERE'], ['RETURNING']],
+        );
+        if ($setClause === null) {
             return [];
         }
 
-        $setClause = $m[1];
-        $assignments = $this->splitByTopLevelComma($setClause);
+        $assignments = SqlTokenStream::tokenize($setClause)->splitTopLevel();
         $result = [];
 
         foreach ($assignments as $assignment) {
@@ -359,19 +241,10 @@ final class PgSqlParser
      */
     public function extractWhereClause(string $sql): ?string
     {
-        $sql = $this->maskComments($sql);
-        $stripped = $this->stripStringLiterals($sql);
-        if (preg_match('/\bWHERE\b/i', $stripped, $m, PREG_OFFSET_CAPTURE) !== 1) {
-            return null;
-        }
-
-        $whereClause = substr($sql, $m[0][1] + strlen('WHERE'));
-        $strippedTail = $this->stripStringLiterals($whereClause);
-        if (preg_match('/\s+(?:RETURNING|ORDER\s+BY|LIMIT)\b/is', $strippedTail, $tailMatch, PREG_OFFSET_CAPTURE) === 1) {
-            $whereClause = substr_replace($whereClause, '', $tailMatch[0][1]);
-        }
-
-        return trim($whereClause);
+        return SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['WHERE'],
+            [['RETURNING'], ['ORDER', 'BY'], ['LIMIT']],
+        );
     }
 
     /**
@@ -379,15 +252,10 @@ final class PgSqlParser
      */
     public function extractUpdateFromClause(string $sql): ?string
     {
-        $sql = $this->maskComments($sql);
-        if (preg_match('/\bFROM\s+(.+?)(?:\s+WHERE\s+|\s+RETURNING\s+|$)/is', $sql, $m) === 1) {
-            $stripped = $this->stripStringLiterals($sql);
-            if (preg_match('/\bSET\b.*?\bFROM\b/is', $stripped) === 1) {
-                return trim($m[1]);
-            }
-        }
-
-        return null;
+        return SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['FROM'],
+            [['WHERE'], ['RETURNING']],
+        );
     }
 
     /**
@@ -421,12 +289,10 @@ final class PgSqlParser
      */
     public function extractDeleteUsingClause(string $sql): ?string
     {
-        $sql = $this->maskComments($sql);
-        if (preg_match('/\bUSING\s+(.+?)(?:\s+WHERE\s+|\s+RETURNING\s+|$)/is', $sql, $m) === 1) {
-            return trim($m[1]);
-        }
-
-        return null;
+        return SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['USING'],
+            [['WHERE'], ['RETURNING']],
+        );
     }
 
     /**
@@ -580,19 +446,14 @@ final class PgSqlParser
      */
     public function extractSelectTableNames(string $sql): array
     {
-        $sql = $this->maskComments($sql);
         $tables = [];
-        $stripped = $this->stripStringLiterals($sql);
-
-        if (preg_match_all('/\bFROM\s+(.+?)(?:\s+WHERE\b|\s+GROUP\b|\s+HAVING\b|\s+ORDER\b|\s+LIMIT\b|\s+OFFSET\b|\s+UNION\b|\s+INTERSECT\b|\s+EXCEPT\b|\s+FOR\b|\s*;|\s*$)/is', $stripped, $fromMatches) > 0) {
-            foreach ($fromMatches[1] as $fromClause) {
-                $tables = array_merge($tables, $this->extractTableRefsFromClause($fromClause));
-            }
-        }
-
-        if (preg_match_all('/\bJOIN\s+("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $stripped, $joinMatches) > 0) {
-            foreach ($joinMatches[1] as $joinTable) {
-                $tables[] = $this->unquoteIdentifier($this->stripSchemaPrefix($joinTable));
+        foreach (SqlTokenStream::tokenize($sql)->selectFromClauses() as $fromClause) {
+            $fromClause = $this->maskComments($fromClause);
+            $tables = array_merge($tables, $this->extractTableRefsFromClause($fromClause));
+            if (preg_match_all('/\bJOIN\s+("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $fromClause, $joinMatches) > 0) {
+                foreach ($joinMatches[1] as $joinTable) {
+                    $tables[] = $this->unquoteIdentifier($this->stripSchemaPrefix($joinTable));
+                }
             }
         }
 
@@ -976,28 +837,6 @@ final class PgSqlParser
             }
 
             $i += $tokenLength - 1;
-        }
-
-        return null;
-    }
-
-    private function extractDollarTag(string $sql, int $pos): ?string
-    {
-        $len = strlen($sql);
-        $i = $pos + 1;
-
-        if ($i < $len && $sql[$i] === '$') {
-            return '';
-        }
-
-        $tag = '';
-        while ($i < $len && (ctype_alnum($sql[$i]) || $sql[$i] === '_')) {
-            $tag .= $sql[$i];
-            $i++;
-        }
-
-        if ($i < $len && $sql[$i] === '$' && $tag !== '') {
-            return $tag;
         }
 
         return null;

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -133,10 +133,15 @@ final class PgSqlParser
         /** @var array<string, string> $values */
         $values = [];
 
-        $setClause = SqlTokenStream::tokenize($sql)->topLevelClause(
-            ['DO', 'UPDATE', 'SET'],
-            [['WHERE'], ['RETURNING']],
-        );
+        $action = SqlTokenStream::tokenize($sql)->topLevelClause(['DO'], [['RETURNING']]);
+        if ($action === null) {
+            return ['columns' => [], 'values' => []];
+        }
+        $actionStream = SqlTokenStream::tokenize($action);
+        if ($actionStream->firstTopLevelKeyword() !== 'UPDATE') {
+            return ['columns' => [], 'values' => []];
+        }
+        $setClause = $actionStream->topLevelClause(['SET'], [['WHERE']]);
         if ($setClause === null) {
             return ['columns' => [], 'values' => []];
         }
@@ -450,10 +455,9 @@ final class PgSqlParser
         foreach (SqlTokenStream::tokenize($sql)->selectFromClauses() as $fromClause) {
             $fromClause = $this->maskComments($fromClause);
             $tables = array_merge($tables, $this->extractTableRefsFromClause($fromClause));
-            if (preg_match_all('/\bJOIN\s+("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $fromClause, $joinMatches) > 0) {
-                foreach ($joinMatches[1] as $joinTable) {
-                    $tables[] = $this->unquoteIdentifier($this->stripSchemaPrefix($joinTable));
-                }
+            preg_match_all('/\bJOIN\s+("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $fromClause, $joinMatches);
+            foreach ($joinMatches[1] as $joinTable) {
+                $tables[] = $this->unquoteIdentifier($this->stripSchemaPrefix($joinTable));
             }
         }
 

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -3541,4 +3541,40 @@ SELECT * FROM users'));
             $parser->extractInsertValues('INSERT INTO target (a, b) VALUES (1], 2)'),
         );
     }
+
+    public function testUpdateClausesIgnoreKeywordsInsideExpressionsAndSubqueries(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = "UPDATE products SET name = TRIM(BOTH 'x' FROM name), price = CAST(raw AS NUMERIC(10,2)), maximum = (SELECT MAX(price) FROM products p2 WHERE p2.category_id = products.category_id) FROM categories c WHERE products.category_id = c.id RETURNING *";
+
+        self::assertSame([
+            'name' => "TRIM(BOTH 'x' FROM name)",
+            'price' => 'CAST(raw AS NUMERIC(10,2))',
+            'maximum' => '(SELECT MAX(price) FROM products p2 WHERE p2.category_id = products.category_id)',
+        ], $parser->extractUpdateSets($sql));
+        self::assertSame('categories c', $parser->extractUpdateFromClause($sql));
+        self::assertSame('products.category_id = c.id', $parser->extractWhereClause($sql));
+    }
+
+    public function testConflictAssignmentsIgnoreNestedWhereAndReturningKeywords(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = 'INSERT INTO target (id, value) VALUES (1, 2) ON CONFLICT (id) DO UPDATE SET value = (SELECT value FROM source WHERE source.id = excluded.id), meta = jsonb_build_object(\'returning\', excluded.value) WHERE target.active RETURNING *';
+
+        self::assertSame([
+            'columns' => ['value', 'meta'],
+            'values' => [
+                'value' => '(SELECT value FROM source WHERE source.id = excluded.id)',
+                'meta' => "jsonb_build_object('returning', excluded.value)",
+            ],
+        ], $parser->extractOnConflictUpdateColumns($sql));
+    }
+
+    public function testSelectTablesIgnoreFromKeywordInsideExtract(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = 'SELECT EXTRACT(YEAR FROM event_date) FROM events WHERE id IN (SELECT event_id FROM archived_events)';
+
+        self::assertSame(['events', 'archived_events'], $parser->extractSelectTableNames($sql));
+    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -596,6 +596,29 @@ SELECT * FROM users'));
         self::assertSame('EXCLUDED.v', $result['values']['v']);
     }
 
+    public function testExtractOnConflictStopsBeforeReturningWithoutWhere(): void
+    {
+        $parser = new PgSqlParser();
+        $result = $parser->extractOnConflictUpdateColumns(
+            "INSERT INTO t (id, v) VALUES (1, 2) ON CONFLICT (id) DO UPDATE SET v = EXCLUDED.v RETURNING id"
+        );
+
+        self::assertSame(['v'], $result['columns']);
+        self::assertSame('EXCLUDED.v', $result['values']['v']);
+    }
+
+    public function testExtractOnConflictRejectsNonUpdateActionContainingSet(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertSame(
+            ['columns' => [], 'values' => []],
+            $parser->extractOnConflictUpdateColumns(
+                'INSERT INTO t (id, v) VALUES (1, 2) ON CONFLICT (id) DO NOTHING SET v = EXCLUDED.v'
+            ),
+        );
+    }
+
     public function testExtractOnConflictQuotedColumn(): void
     {
         $parser = new PgSqlParser();

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Platform\Sqlite;
 
+use ZtdQuery\Sql\SqlTokenStream;
+
 /**
  * Lightweight SQL parser for SQLite.
  *
@@ -76,106 +78,7 @@ final class SqliteParser
      */
     public function splitStatements(string $sql): array
     {
-        $statements = [];
-        $current = '';
-        $len = strlen($sql);
-        $inSingleQuote = false;
-        $inDoubleQuote = false;
-        $depth = 0;
-
-        for ($i = 0; $i < $len; $i++) {
-            $char = $sql[$i];
-
-            if ($inSingleQuote) {
-                $current .= $char;
-                if ($char === '\'' && ($i + 1 < $len) && $sql[$i + 1] === '\'') {
-                    $current .= $sql[$i + 1];
-                    $i++;
-                } elseif ($char === '\'') {
-                    $inSingleQuote = false;
-                }
-                continue;
-            }
-
-            if ($inDoubleQuote) {
-                $current .= $char;
-                if ($char === '"' && ($i + 1 < $len) && $sql[$i + 1] === '"') {
-                    $current .= $sql[$i + 1];
-                    $i++;
-                } elseif ($char === '"') {
-                    $inDoubleQuote = false;
-                }
-                continue;
-            }
-
-            if ($char === '\'') {
-                $inSingleQuote = true;
-                $current .= $char;
-                continue;
-            }
-
-            if ($char === '"') {
-                $inDoubleQuote = true;
-                $current .= $char;
-                continue;
-            }
-
-            if ($char === '(') {
-                $depth++;
-                $current .= $char;
-                continue;
-            }
-
-            if ($char === ')') {
-                if ($depth > 0) {
-                    $depth--;
-                }
-                $current .= $char;
-                continue;
-            }
-
-            if ($char === '-' && ($i + 1 < $len) && $sql[$i + 1] === '-') {
-                $end = strpos($sql, "\n", $i);
-                if ($end === false) {
-                    $current .= substr($sql, $i);
-                    $i = $len;
-                } else {
-                    $current .= substr($sql, $i, $end - $i);
-                    $i = $end - 1;
-                }
-                continue;
-            }
-
-            if ($char === '/' && ($i + 1 < $len) && $sql[$i + 1] === '*') {
-                $end = strpos($sql, '*/', $i + 2);
-                if ($end === false) {
-                    $current .= substr($sql, $i);
-                    $i = $len;
-                } else {
-                    $current .= substr($sql, $i, $end + 2 - $i);
-                    $i = $end + 1;
-                }
-                continue;
-            }
-
-            if ($char === ';' && $depth === 0) {
-                $stmt = trim($current);
-                if ($stmt !== '') {
-                    $statements[] = $stmt;
-                }
-                $current = '';
-                continue;
-            }
-
-            $current .= $char;
-        }
-
-        $stmt = trim($current);
-        if ($stmt !== '') {
-            $statements[] = $stmt;
-        }
-
-        return $statements;
+        return SqlTokenStream::tokenize($sql)->splitStatements();
     }
 
     /**
@@ -206,34 +109,30 @@ final class SqliteParser
      */
     public function extractSelectTables(string $sql): array
     {
-        $sql = $this->stripComments($sql);
-        $sql = $this->maskStringLiterals($sql);
         $tables = [];
-
-        if (preg_match('/\bFROM\s+(.+?)(?:\s+WHERE\b|\s+GROUP\s+BY\b|\s+HAVING\b|\s+ORDER\s+BY\b|\s+LIMIT\b|\s+UNION\b|$)/is', $sql, $matches) === 1) {
-            $fromClause = $matches[1];
+        foreach (SqlTokenStream::tokenize($sql)->selectFromClauses() as $fromClause) {
+            $fromClause = $this->stripComments($fromClause);
             $fromOnly = preg_replace('/\b(?:INNER|LEFT|RIGHT|CROSS|NATURAL)\s+JOIN\b.*/is', '', $fromClause);
             $fromOnly = preg_replace('/\bJOIN\b.*/is', '', $fromOnly ?? $fromClause);
 
-            $parts = explode(',', $fromOnly ?? $fromClause);
+            $parts = SqlTokenStream::tokenize($fromOnly ?? $fromClause)->splitTopLevel();
             foreach ($parts as $part) {
                 $table = $this->extractTableFromExpr(trim($part));
                 if ($table !== null) {
                     $tables[] = $table;
                 }
             }
-        }
-
-        if (preg_match_all('/\bJOIN\s+("(?:[^"]|"")*"|[^\s(]+)/i', $sql, $joinMatches) > 0) {
-            foreach ($joinMatches[1] as $joinTable) {
-                $table = $this->unquoteIdentifier($joinTable);
-                if ($table !== '') {
-                    $tables[] = $table;
+            if (preg_match_all('/\bJOIN\s+("(?:[^"]|"")*"|[^\s(]+)/i', $fromClause, $joinMatches) > 0) {
+                foreach ($joinMatches[1] as $joinTable) {
+                    $table = $this->unquoteIdentifier($joinTable);
+                    if ($table !== '') {
+                        $tables[] = $table;
+                    }
                 }
             }
         }
 
-        return $tables;
+        return array_values(array_unique($tables));
     }
 
     /**
@@ -279,12 +178,15 @@ final class SqliteParser
      */
     public function extractUpdateAssignments(string $sql): array
     {
-        $sql = $this->stripComments($sql);
-        if (preg_match('/\bSET\s+(.+?)(?:\s+WHERE\b|\s+ORDER\s+BY\b|\s+LIMIT\b|$)/is', $sql, $matches) !== 1) {
+        $setClause = SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['SET'],
+            [['FROM'], ['WHERE'], ['ORDER', 'BY'], ['LIMIT'], ['RETURNING']],
+        );
+        if ($setClause === null) {
             return [];
         }
 
-        return $this->parseAssignments($matches[1]);
+        return $this->parseAssignments($setClause);
     }
 
     /**
@@ -292,12 +194,10 @@ final class SqliteParser
      */
     public function extractWhereClause(string $sql): ?string
     {
-        $sql = $this->stripComments($sql);
-        if (preg_match('/\bWHERE\s+(.+?)(?:\s+ORDER\s+BY\b|\s+LIMIT\b|\s+GROUP\s+BY\b|\s+HAVING\b|$)/is', $sql, $matches) === 1) {
-            return trim($matches[1]);
-        }
-
-        return null;
+        return SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['WHERE'],
+            [['ORDER', 'BY'], ['LIMIT'], ['GROUP', 'BY'], ['HAVING'], ['RETURNING']],
+        );
     }
 
     /**
@@ -305,12 +205,10 @@ final class SqliteParser
      */
     public function extractOrderByClause(string $sql): ?string
     {
-        $sql = $this->stripComments($sql);
-        if (preg_match('/\bORDER\s+BY\s+(.+?)(?:\s+LIMIT\b|$)/is', $sql, $matches) === 1) {
-            return trim($matches[1]);
-        }
-
-        return null;
+        return SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['ORDER', 'BY'],
+            [['LIMIT'], ['RETURNING']],
+        );
     }
 
     /**
@@ -318,12 +216,7 @@ final class SqliteParser
      */
     public function extractLimitClause(string $sql): ?string
     {
-        $sql = $this->stripComments($sql);
-        if (preg_match('/\bLIMIT\s+(.+?)$/is', $sql, $matches) === 1) {
-            return trim($matches[1]);
-        }
-
-        return null;
+        return SqlTokenStream::tokenize($sql)->topLevelClause(['LIMIT'], [['RETURNING']]);
     }
 
     /**
@@ -364,12 +257,15 @@ final class SqliteParser
      */
     public function extractOnConflictUpdates(string $sql): array
     {
-        $sql = $this->stripComments($sql);
-        if (preg_match('/\bON\s+CONFLICT\s*(?:\([^)]*\))?\s*DO\s+UPDATE\s+SET\s+(.+?)$/is', $sql, $matches) !== 1) {
+        $setClause = SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['DO', 'UPDATE', 'SET'],
+            [['WHERE'], ['RETURNING']],
+        );
+        if ($setClause === null) {
             return [];
         }
 
-        return $this->parseAssignments($matches[1]);
+        return $this->parseAssignments($setClause);
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -113,21 +113,26 @@ final class SqliteParser
         foreach (SqlTokenStream::tokenize($sql)->selectFromClauses() as $fromClause) {
             $fromClause = $this->stripComments($fromClause);
             $fromOnly = preg_replace('/\b(?:INNER|LEFT|RIGHT|CROSS|NATURAL)\s+JOIN\b.*/is', '', $fromClause);
-            $fromOnly = preg_replace('/\bJOIN\b.*/is', '', $fromOnly ?? $fromClause);
+            if ($fromOnly === null) {
+                continue;
+            }
+            $fromOnly = preg_replace('/\bJOIN\b.*/is', '', $fromOnly);
+            if ($fromOnly === null) {
+                continue;
+            }
 
-            $parts = SqlTokenStream::tokenize($fromOnly ?? $fromClause)->splitTopLevel();
+            $parts = SqlTokenStream::tokenize($fromOnly)->splitTopLevel();
             foreach ($parts as $part) {
                 $table = $this->extractTableFromExpr(trim($part));
                 if ($table !== null) {
                     $tables[] = $table;
                 }
             }
-            if (preg_match_all('/\bJOIN\s+("(?:[^"]|"")*"|[^\s(]+)/i', $fromClause, $joinMatches) > 0) {
-                foreach ($joinMatches[1] as $joinTable) {
-                    $table = $this->unquoteIdentifier($joinTable);
-                    if ($table !== '') {
-                        $tables[] = $table;
-                    }
+            preg_match_all('/\bJOIN\s+("(?:[^"]|"")*"|[^\s(]+)/i', $fromClause, $joinMatches);
+            foreach ($joinMatches[1] as $joinTable) {
+                $table = $this->unquoteIdentifier($joinTable);
+                if ($table !== '') {
+                    $tables[] = $table;
                 }
             }
         }
@@ -257,10 +262,15 @@ final class SqliteParser
      */
     public function extractOnConflictUpdates(string $sql): array
     {
-        $setClause = SqlTokenStream::tokenize($sql)->topLevelClause(
-            ['DO', 'UPDATE', 'SET'],
-            [['WHERE'], ['RETURNING']],
-        );
+        $action = SqlTokenStream::tokenize($sql)->topLevelClause(['DO'], [['RETURNING']]);
+        if ($action === null) {
+            return [];
+        }
+        $actionStream = SqlTokenStream::tokenize($action);
+        if ($actionStream->firstTopLevelKeyword() !== 'UPDATE') {
+            return [];
+        }
+        $setClause = $actionStream->topLevelClause(['SET'], [['WHERE']]);
         if ($setClause === null) {
             return [];
         }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -2860,4 +2860,37 @@ SELECT * FROM users'));
 
         self::assertSame('SELECT 1', $parser->extractInsertSelect("INSERT INTO target SELECT 1 \n\t"));
     }
+
+    public function testUpdateClausesIgnoreKeywordsInsideExpressionsAndSubqueries(): void
+    {
+        $parser = new SqliteParser();
+        $sql = "UPDATE products SET price = CAST(raw AS NUMERIC(10,2)), maximum = (SELECT MAX(price) FROM products p2 WHERE p2.category_id = products.category_id) FROM categories c WHERE products.category_id = c.id ORDER BY products.id LIMIT 1 RETURNING *";
+
+        self::assertSame([
+            'price' => 'CAST(raw AS NUMERIC(10,2))',
+            'maximum' => '(SELECT MAX(price) FROM products p2 WHERE p2.category_id = products.category_id)',
+        ], $parser->extractUpdateAssignments($sql));
+        self::assertSame('products.category_id = c.id', $parser->extractWhereClause($sql));
+        self::assertSame('products.id', $parser->extractOrderByClause($sql));
+        self::assertSame('1', $parser->extractLimitClause($sql));
+    }
+
+    public function testConflictAssignmentsIgnoreNestedWhereAndReturningKeywords(): void
+    {
+        $parser = new SqliteParser();
+        $sql = 'INSERT INTO target (id, value) VALUES (1, 2) ON CONFLICT (id) DO UPDATE SET value = (SELECT value FROM source WHERE source.id = excluded.id), note = \'returning where\' WHERE target.active RETURNING *';
+
+        self::assertSame([
+            'value' => '(SELECT value FROM source WHERE source.id = excluded.id)',
+            'note' => "'returning where'",
+        ], $parser->extractOnConflictUpdates($sql));
+    }
+
+    public function testSelectTablesComeFromSelectScopesOnly(): void
+    {
+        $parser = new SqliteParser();
+        $sql = 'SELECT printf(\'from %s\', name) FROM events WHERE id IN (SELECT event_id FROM archived_events)';
+
+        self::assertSame(['events', 'archived_events'], $parser->extractSelectTables($sql));
+    }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -194,6 +194,18 @@ SELECT * FROM users'));
         self::assertContains('orders', $tables);
     }
 
+    public function testExtractSelectTablesDeduplicatesAndReindexesInFirstSeenOrder(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            ['users', 'orders'],
+            $parser->extractSelectTables(
+                'SELECT * FROM users UNION SELECT * FROM users UNION SELECT * FROM orders'
+            ),
+        );
+    }
+
     public function testExtractInsertColumns(): void
     {
         $parser = new SqliteParser();
@@ -288,6 +300,30 @@ SELECT * FROM users'));
         );
         self::assertArrayHasKey('name', $updates);
         self::assertSame('excluded.name', $updates['name']);
+    }
+
+    public function testExtractOnConflictStopsBeforeReturningWithoutWhere(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            ['name' => 'excluded.name'],
+            $parser->extractOnConflictUpdates(
+                'INSERT INTO users (id, name) VALUES (1, "Alice") ON CONFLICT (id) DO UPDATE SET name = excluded.name RETURNING id'
+            ),
+        );
+    }
+
+    public function testExtractOnConflictRejectsNonUpdateActionContainingSet(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            [],
+            $parser->extractOnConflictUpdates(
+                'INSERT INTO users (id, name) VALUES (1, "Alice") ON CONFLICT (id) DO NOTHING SET name = excluded.name'
+            ),
+        );
     }
 
     public function testHasInsertSelect(): void
@@ -871,6 +907,16 @@ SELECT * FROM users'));
     {
         $parser = new SqliteParser();
         self::assertSame('id', $parser->extractOrderByClause('SELECT * FROM users ORDER BY id LIMIT 5'));
+    }
+
+    public function testExtractOrderByClauseRequiresOrderBeforeBy(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            'value',
+            $parser->extractOrderByClause('SELECT value AS by FROM users ORDER BY value'),
+        );
     }
 
     public function testExtractOrderByClauseNone(): void


### PR DESCRIPTION
Stack 4/16. Base: #214.

Root problem

Structural SQL operations relied on flat regexes or a third-party parser's statement count. Keywords and separators inside functions, subqueries, quoted strings, comments, and dollar strings were therefore mistaken for top-level boundaries.

Changes

- add a lossless, byte-offset SQL token stream in core with nesting-aware statement, SELECT/FROM scope, clause, and comma operations
- use it for PostgreSQL and SQLite statement, table-reference, and clause extraction
- distinguish logical MySQL statement boundaries from phpmyadmin/sql-parser's internal SELECT splitting
- extend PostgreSQL correctness fuzz generation with `TRIM`/`SUBSTRING` SET expressions
- add parser, rewriter, guard, and real-database regression tests

Verification

- core unit: 304 tests / 606 assertions
- MySQL unit: 898 tests / 2239 assertions
- PostgreSQL unit: 1307 tests / 2083 assertions
- SQLite unit: 1187 tests / 2075 assertions
- package lint/PHPStan: core, MySQL, PostgreSQL, SQLite, PDO adapter, MySQLi adapter
- PostgreSQL integration: nested `FROM` functions and `EXTRACT` pass against raw PDO
- MySQL integration: EXCEPT and INTERSECT pass against MySQL

Fixes #14
Fixes #15
Fixes #47
Fixes #98

The same structural fix also covers the reproduced DML/set-operation variants below. Each was verified against the native engine on this stack.

Fixes #50
Fixes #51
Fixes #57
Fixes #74
Fixes #84
Fixes #100
Fixes #116
Fixes #118
Fixes #119
Fixes #131
Fixes #132
Fixes #134
Fixes #136
Fixes #139
Fixes #140
Fixes #142
Fixes #143
Fixes #144
Fixes #147
Fixes #165
Fixes #168
Fixes #171
Fixes #174
Fixes #176