### PR TITLE
Restore MySQL ENUM rank semantics

### DIFF
--- a/packages/ztd-query-mysql/src/MySqlTypeSemantics.php
+++ b/packages/ztd-query-mysql/src/MySqlTypeSemantics.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+/**
+ * Restores native operators that cannot be represented by a CTE column cast.
+ */
+final class MySqlTypeSemantics
+{
+    /**
+     * @param array<string, array{
+     *     rows: array<int, array<string, mixed>>,
+     *     columns: array<int, string>,
+     *     columnTypes: array<string, ColumnType>
+     * }> $tables
+     */
+    public function rewrite(string $sql, array $tables): string
+    {
+        [$qualified, $unqualified] = $this->enumColumns($tables);
+        if ($qualified === [] && $unqualified === []) {
+            return $sql;
+        }
+
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $edits = $this->comparisonEdits($sql, $tokens, $qualified, $unqualified);
+        foreach ($this->orderByEdits($sql, $tokens, $qualified, $unqualified) as $key => $edit) {
+            $edits[$key] = $edit;
+        }
+
+        uasort($edits, static fn (array $left, array $right): int => $right['start'] <=> $left['start']);
+        foreach ($edits as $edit) {
+            $sql = substr($sql, 0, $edit['start']) . $edit['replacement'] . substr($sql, $edit['end']);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * @param array<string, array{
+     *     rows: array<int, array<string, mixed>>,
+     *     columns: array<int, string>,
+     *     columnTypes: array<string, ColumnType>
+     * }> $tables
+     * @return array{array<string, list<string>>, array<string, list<string>|null>}
+     */
+    private function enumColumns(array $tables): array
+    {
+        $qualified = [];
+        $unqualified = [];
+        foreach ($tables as $table => $context) {
+            foreach ($context['columnTypes'] as $column => $type) {
+                $members = $this->enumMembers($type->nativeType);
+                if ($members === []) {
+                    continue;
+                }
+                $qualified[strtolower("$table.$column")] = $members;
+                $key = strtolower($column);
+                if (!array_key_exists($key, $unqualified)) {
+                    $unqualified[$key] = $members;
+                } elseif ($unqualified[$key] !== $members) {
+                    $unqualified[$key] = null;
+                }
+            }
+        }
+
+        return [$qualified, $unqualified];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param array<string, list<string>> $qualified
+     * @param array<string, list<string>|null> $unqualified
+     * @return array<string, array{start: int, end: int, replacement: string}>
+     */
+    private function comparisonEdits(string $sql, array $tokens, array $qualified, array $unqualified): array
+    {
+        $edits = [];
+        for ($index = 0, $count = count($tokens); $index < $count; $index++) {
+            $column = $this->columnAt($sql, $tokens, $index, $qualified, $unqualified);
+            if ($column === null) {
+                continue;
+            }
+            $operatorIndex = $index + $column['length'];
+            $operator = $this->orderedOperatorAt($tokens, $operatorIndex);
+            if ($operator === null) {
+                continue;
+            }
+            $value = $tokens[$operatorIndex + $operator['length']] ?? null;
+            if ($value === null || $value->kind !== SqlTokenKind::String) {
+                continue;
+            }
+
+            $this->addRankEdit($edits, $column['token'], $column['members']);
+            $this->addRankEdit($edits, $value, $column['members']);
+            $index = $operatorIndex + $operator['length'];
+        }
+
+        return $edits;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param array<string, list<string>> $qualified
+     * @param array<string, list<string>|null> $unqualified
+     * @return array<string, array{start: int, end: int, replacement: string}>
+     */
+    private function orderByEdits(string $sql, array $tokens, array $qualified, array $unqualified): array
+    {
+        $edits = [];
+        for ($index = 0, $count = count($tokens); $index < $count - 1; $index++) {
+            if (!$tokens[$index]->isKeyword('ORDER') || !$tokens[$index + 1]->isKeyword('BY')) {
+                continue;
+            }
+            $depth = $tokens[$index]->depth;
+            $bracketDepth = $tokens[$index]->bracketDepth;
+            for ($item = $index + 2; $item < $count; $item++) {
+                $token = $tokens[$item];
+                if ($token->depth < $depth || $token->bracketDepth < $bracketDepth) {
+                    break;
+                }
+                if ($token->depth !== $depth || $token->bracketDepth !== $bracketDepth) {
+                    continue;
+                }
+                if ($token->isKeyword('LIMIT') || $token->isKeyword('FOR') || $token->isKeyword('LOCK')) {
+                    break;
+                }
+                $column = $this->columnAt($sql, $tokens, $item, $qualified, $unqualified);
+                if ($column === null) {
+                    continue;
+                }
+                $after = $tokens[$item + $column['length']] ?? null;
+                if ($after !== null
+                    && $after->depth === $depth
+                    && $after->bracketDepth === $bracketDepth
+                    && !$after->isKeyword('ASC')
+                    && !$after->isKeyword('DESC')
+                    && !($after->kind === SqlTokenKind::Symbol && $after->text === ',')
+                    && !$after->isKeyword('LIMIT')
+                    && !$after->isKeyword('FOR')
+                    && !$after->isKeyword('LOCK')
+                ) {
+                    continue;
+                }
+                $this->addRankEdit($edits, $column['token'], $column['members']);
+                $item += $column['length'] - 1;
+            }
+        }
+
+        return $edits;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param array<string, list<string>> $qualified
+     * @param array<string, list<string>|null> $unqualified
+     * @return array{token: SqlToken, length: int, members: list<string>}|null
+     */
+    private function columnAt(string $sql, array $tokens, int $index, array $qualified, array $unqualified): ?array
+    {
+        $first = $tokens[$index] ?? null;
+        if ($first === null || !$this->isIdentifier($first)) {
+            return null;
+        }
+
+        $length = 1;
+        $column = $this->unquoteIdentifier($first->text);
+        $qualifiedKey = null;
+        if (($tokens[$index + 1] ?? null)?->text === '.' && isset($tokens[$index + 2]) && $this->isIdentifier($tokens[$index + 2])) {
+            $length = 3;
+            $column = $this->unquoteIdentifier($tokens[$index + 2]->text);
+            $qualifiedKey = strtolower($this->unquoteIdentifier($first->text) . '.' . $column);
+        }
+
+        $members = $qualifiedKey !== null ? ($qualified[$qualifiedKey] ?? null) : null;
+        $members ??= $unqualified[strtolower($column)] ?? null;
+        if ($members === null) {
+            return null;
+        }
+
+        $last = $tokens[$index + $length - 1];
+
+        return [
+            'token' => new SqlToken(
+                SqlTokenKind::Word,
+                substr($sql, $first->offset, $last->endOffset() - $first->offset),
+                $first->offset,
+                $first->depth,
+                $first->bracketDepth,
+            ),
+            'length' => $length,
+            'members' => $members,
+        ];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{length: int}|null
+     */
+    private function orderedOperatorAt(array $tokens, int $index): ?array
+    {
+        $first = $tokens[$index] ?? null;
+        if ($first === null || $first->kind !== SqlTokenKind::Symbol || ($first->text !== '<' && $first->text !== '>')) {
+            return null;
+        }
+        $second = $tokens[$index + 1] ?? null;
+
+        return ['length' => $second?->text === '=' ? 2 : 1];
+    }
+
+    /**
+     * @param array<string, array{start: int, end: int, replacement: string}> $edits
+     * @param list<string> $members
+     */
+    private function addRankEdit(array &$edits, SqlToken $token, array $members): void
+    {
+        $memberSql = array_map(
+            static fn (string $member): string => "'" . str_replace("'", "''", $member) . "'",
+            $members,
+        );
+        $key = $token->offset . ':' . $token->endOffset();
+        $edits[$key] = [
+            'start' => $token->offset,
+            'end' => $token->endOffset(),
+            'replacement' => 'FIELD(' . $token->text . ', ' . implode(', ', $memberSql) . ')',
+        ];
+    }
+
+    /** @return list<string> */
+    private function enumMembers(string $nativeType): array
+    {
+        $open = strpos($nativeType, '(');
+        if ($open === false || strtoupper(trim(substr($nativeType, 0, $open))) !== 'ENUM' || !str_ends_with(trim($nativeType), ')')) {
+            return [];
+        }
+        $inner = substr(trim($nativeType), $open + 1, -1);
+        $members = [];
+        foreach (SqlTokenStream::tokenize($inner)->splitTopLevel() as $literal) {
+            $literal = trim($literal);
+            if (strlen($literal) < 2) {
+                return [];
+            }
+            $quote = $literal[0];
+            if (($quote !== "'" && $quote !== '"') || $literal[strlen($literal) - 1] !== $quote) {
+                return [];
+            }
+            $value = substr($literal, 1, -1);
+            $members[] = str_replace([$quote . $quote, '\\' . $quote, '\\\\'], [$quote, $quote, '\\'], $value);
+        }
+
+        return $members;
+    }
+
+    private function isIdentifier(SqlToken $token): bool
+    {
+        return $token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier;
+    }
+
+    private function unquoteIdentifier(string $identifier): string
+    {
+        if ((str_starts_with($identifier, '`') && str_ends_with($identifier, '`'))
+            || (str_starts_with($identifier, '"') && str_ends_with($identifier, '"'))
+        ) {
+            return substr($identifier, 1, -1);
+        }
+
+        return $identifier;
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlTypeSemantics.php
+++ b/packages/ztd-query-mysql/src/MySqlTypeSemantics.php
@@ -24,10 +24,6 @@ final class MySqlTypeSemantics
     public function rewrite(string $sql, array $tables): string
     {
         [$qualified, $unqualified] = $this->enumColumns($tables);
-        if ($qualified === [] && $unqualified === []) {
-            return $sql;
-        }
-
         $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
         $edits = $this->comparisonEdits($sql, $tokens, $qualified, $unqualified);
         foreach ($this->orderByEdits($sql, $tokens, $qualified, $unqualified) as $key => $edit) {
@@ -77,12 +73,12 @@ final class MySqlTypeSemantics
      * @param list<SqlToken> $tokens
      * @param array<string, list<string>> $qualified
      * @param array<string, list<string>|null> $unqualified
-     * @return array<string, array{start: int, end: int, replacement: string}>
+     * @return array<int, array{start: int, end: int, replacement: string}>
      */
     private function comparisonEdits(string $sql, array $tokens, array $qualified, array $unqualified): array
     {
         $edits = [];
-        for ($index = 0, $count = count($tokens); $index < $count; $index++) {
+        foreach ($tokens as $index => $token) {
             $column = $this->columnAt($sql, $tokens, $index, $qualified, $unqualified);
             if ($column === null) {
                 continue;
@@ -99,7 +95,6 @@ final class MySqlTypeSemantics
 
             $this->addRankEdit($edits, $column['token'], $column['members']);
             $this->addRankEdit($edits, $value, $column['members']);
-            $index = $operatorIndex + $operator['length'];
         }
 
         return $edits;
@@ -109,21 +104,26 @@ final class MySqlTypeSemantics
      * @param list<SqlToken> $tokens
      * @param array<string, list<string>> $qualified
      * @param array<string, list<string>|null> $unqualified
-     * @return array<string, array{start: int, end: int, replacement: string}>
+     * @return array<int, array{start: int, end: int, replacement: string}>
      */
     private function orderByEdits(string $sql, array $tokens, array $qualified, array $unqualified): array
     {
         $edits = [];
-        for ($index = 0, $count = count($tokens); $index < $count - 1; $index++) {
-            if (!$tokens[$index]->isKeyword('ORDER') || !$tokens[$index + 1]->isKeyword('BY')) {
+        foreach ($tokens as $index => $order) {
+            if (!$order->isKeyword('ORDER')) {
                 continue;
             }
-            $depth = $tokens[$index]->depth;
-            $bracketDepth = $tokens[$index]->bracketDepth;
-            for ($item = $index + 2; $item < $count; $item++) {
-                $token = $tokens[$item];
-                if ($token->depth < $depth || $token->bracketDepth < $bracketDepth) {
-                    break;
+            $by = $tokens[$index + 1] ?? null;
+            if ($by === null || !$by->isKeyword('BY')) {
+                continue;
+            }
+            $depth = $order->depth;
+            $bracketDepth = $order->bracketDepth;
+            $afterBy = false;
+            foreach ($tokens as $item => $token) {
+                if (!$afterBy) {
+                    $afterBy = $token === $by;
+                    continue;
                 }
                 if ($token->depth !== $depth || $token->bracketDepth !== $bracketDepth) {
                     continue;
@@ -149,7 +149,6 @@ final class MySqlTypeSemantics
                     continue;
                 }
                 $this->addRankEdit($edits, $column['token'], $column['members']);
-                $item += $column['length'] - 1;
             }
         }
 
@@ -164,22 +163,25 @@ final class MySqlTypeSemantics
      */
     private function columnAt(string $sql, array $tokens, int $index, array $qualified, array $unqualified): ?array
     {
-        $first = $tokens[$index] ?? null;
-        if ($first === null || !$this->isIdentifier($first)) {
+        $first = $tokens[$index];
+        if (($tokens[$index - 1] ?? null)?->text === '.') {
             return null;
         }
 
         $length = 1;
-        $column = $this->unquoteIdentifier($first->text);
+        $column = $this->identifierName($first);
         $qualifiedKey = null;
-        if (($tokens[$index + 1] ?? null)?->text === '.' && isset($tokens[$index + 2]) && $this->isIdentifier($tokens[$index + 2])) {
+        $dot = $tokens[$index + 1] ?? null;
+        $qualifiedColumn = $tokens[$index + 2] ?? null;
+        if ($dot?->text === '.' && $qualifiedColumn !== null && $this->isIdentifier($qualifiedColumn)) {
             $length = 3;
-            $column = $this->unquoteIdentifier($tokens[$index + 2]->text);
-            $qualifiedKey = strtolower($this->unquoteIdentifier($first->text) . '.' . $column);
+            $column = $this->identifierName($qualifiedColumn);
+            $qualifiedKey = strtolower($this->identifierName($first) . '.' . $column);
         }
 
-        $members = $qualifiedKey !== null ? ($qualified[$qualifiedKey] ?? null) : null;
-        $members ??= $unqualified[strtolower($column)] ?? null;
+        $members = $qualifiedKey === null
+            ? ($unqualified[strtolower($column)] ?? null)
+            : ($qualified[$qualifiedKey] ?? null);
         if ($members === null) {
             return null;
         }
@@ -215,17 +217,16 @@ final class MySqlTypeSemantics
     }
 
     /**
-     * @param array<string, array{start: int, end: int, replacement: string}> $edits
+     * @param array<int, array{start: int, end: int, replacement: string}> $edits
      * @param list<string> $members
      */
     private function addRankEdit(array &$edits, SqlToken $token, array $members): void
     {
         $memberSql = array_map(
-            static fn (string $member): string => "'" . str_replace("'", "''", $member) . "'",
+            static fn (string $member): string => "'" . str_replace(['\\', "'"], ['\\\\', "''"], $member) . "'",
             $members,
         );
-        $key = $token->offset . ':' . $token->endOffset();
-        $edits[$key] = [
+        $edits[$token->offset] = [
             'start' => $token->offset,
             'end' => $token->endOffset(),
             'replacement' => 'FIELD(' . $token->text . ', ' . implode(', ', $memberSql) . ')',
@@ -236,18 +237,23 @@ final class MySqlTypeSemantics
     private function enumMembers(string $nativeType): array
     {
         $open = strpos($nativeType, '(');
-        if ($open === false || strtoupper(trim(substr($nativeType, 0, $open))) !== 'ENUM' || !str_ends_with(trim($nativeType), ')')) {
+        if ($open === false) {
+            return [];
+        }
+        if (strtoupper(trim(substr($nativeType, 0, $open))) !== 'ENUM') {
             return [];
         }
         $inner = substr(trim($nativeType), $open + 1, -1);
         $members = [];
         foreach (SqlTokenStream::tokenize($inner)->splitTopLevel() as $literal) {
-            $literal = trim($literal);
             if (strlen($literal) < 2) {
                 return [];
             }
             $quote = $literal[0];
-            if (($quote !== "'" && $quote !== '"') || $literal[strlen($literal) - 1] !== $quote) {
+            if ($quote !== "'" && $quote !== '"') {
+                return [];
+            }
+            if ($literal[strlen($literal) - 1] !== $quote) {
                 return [];
             }
             $value = substr($literal, 1, -1);
@@ -259,17 +265,13 @@ final class MySqlTypeSemantics
 
     private function isIdentifier(SqlToken $token): bool
     {
-        return $token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier;
+        return in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true);
     }
 
-    private function unquoteIdentifier(string $identifier): string
+    private function identifierName(SqlToken $token): string
     {
-        if ((str_starts_with($identifier, '`') && str_ends_with($identifier, '`'))
-            || (str_starts_with($identifier, '"') && str_ends_with($identifier, '"'))
-        ) {
-            return substr($identifier, 1, -1);
-        }
-
-        return $identifier;
+        return $token->kind === SqlTokenKind::QuotedIdentifier
+            ? substr($token->text, 1, -1)
+            : $token->text;
     }
 }

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -31,12 +31,11 @@ final class SelectTransformer implements SqlTransformer
         ?CastRenderer $castRenderer = null,
         ?IdentifierQuoter $quoter = null,
         ?ValueRenderer $valueRenderer = null,
-        ?MySqlTypeSemantics $typeSemantics = null,
     ) {
         $this->castRenderer = $castRenderer ?? new MySqlCastRenderer();
         $this->quoter = $quoter ?? new MySqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\MySql\MySqlValueRenderer($this->castRenderer);
-        $this->typeSemantics = $typeSemantics ?? new MySqlTypeSemantics();
+        $this->typeSemantics = new MySqlTypeSemantics();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\MySql\Transformer;
 
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
+use ZtdQuery\Platform\MySql\MySqlTypeSemantics;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
@@ -24,15 +25,18 @@ final class SelectTransformer implements SqlTransformer
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
+    private MySqlTypeSemantics $typeSemantics;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
         ?IdentifierQuoter $quoter = null,
         ?ValueRenderer $valueRenderer = null,
+        ?MySqlTypeSemantics $typeSemantics = null,
     ) {
         $this->castRenderer = $castRenderer ?? new MySqlCastRenderer();
         $this->quoter = $quoter ?? new MySqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\MySql\MySqlValueRenderer($this->castRenderer);
+        $this->typeSemantics = $typeSemantics ?? new MySqlTypeSemantics();
     }
 
     /**
@@ -40,6 +44,7 @@ final class SelectTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
+        $sql = $this->typeSemantics->rewrite($sql, $tables);
         $sql = $this->rewriteSetOrderBy($sql, $tables);
 
         $ctes = [];

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -44,6 +44,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(AlterTableMutation::class)]
 final class MySqlMutationResolverTest extends TestCase
 {

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -52,6 +52,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
     protected function createRewriter(ShadowStore $store, TableDefinitionRegistry $registry): SqlRewriter

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
@@ -37,6 +37,7 @@ use ZtdQuery\Session;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 final class MySqlSessionFactoryTest extends TestCase
 {
     public function testCreateReturnsSession(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlTypeSemanticsTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlTypeSemanticsTest.php
@@ -13,6 +13,22 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[CoversClass(MySqlTypeSemantics::class)]
 final class MySqlTypeSemanticsTest extends TestCase
 {
+    public function testLeavesSqlUntouchedWithoutEnumColumns(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['name'],
+                'columnTypes' => ['name' => new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR(255)')],
+            ],
+        ];
+        $sql = "SELECT * FROM items WHERE name > 'a' ORDER BY name";
+
+        self::assertSame($sql, $semantics->rewrite($sql, $tables));
+        self::assertSame($sql, $semantics->rewrite($sql, []));
+    }
+
     public function testRewritesEnumOrderingAndOrderedComparisonsToRanks(): void
     {
         $semantics = new MySqlTypeSemantics();
@@ -63,5 +79,301 @@ final class MySqlTypeSemanticsTest extends TestCase
         $sql = "SELECT * FROM items WHERE name > 'a' ORDER BY COALESCE(size, 'small')";
 
         self::assertSame($sql, $semantics->rewrite($sql, $tables));
+    }
+
+    public function testFindsEnumAfterNonEnumColumnsAndNonOrderedOccurrences(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'Items' => [
+                'rows' => [],
+                'columns' => ['Name', 'Size'],
+                'columnTypes' => [
+                    'Name' => new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR(255)'),
+                    'Size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')"),
+                ],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT Size FROM Items WHERE Name > 'a' AND FIELD(SIZE, 'small', 'large') > FIELD('small', 'small', 'large')",
+            $semantics->rewrite("SELECT Size FROM Items WHERE Name > 'a' AND SIZE > 'small'", $tables),
+        );
+    }
+
+    public function testRewritesEveryOrderedComparisonAndRejectsOtherOperands(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items WHERE FIELD(size, 'small', 'large') < FIELD('large', 'small', 'large') OR FIELD(size, 'small', 'large') >= FIELD('small', 'small', 'large') OR size = 'small' OR size <> 'large' OR size > 1 OR size >",
+            $semantics->rewrite("SELECT * FROM items WHERE size < 'large' OR size >= 'small' OR size = 'small' OR size <> 'large' OR size > 1 OR size >", $tables),
+        );
+    }
+
+    public function testComparisonScanContinuesAfterInvalidRightOperand(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items WHERE size > 1 OR FIELD(size, 'small', 'large') > FIELD('small', 'small', 'large')",
+            $semantics->rewrite("SELECT * FROM items WHERE size > 1 OR size > 'small'", $tables),
+        );
+    }
+
+    public function testQualifiedColumnsDoNotFallBackToAmbiguousOrUnrelatedTables(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'Items' => [
+                'rows' => [],
+                'columns' => ['Size'],
+                'columnTypes' => ['Size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')")],
+            ],
+            'Other' => [
+                'rows' => [],
+                'columns' => ['Size'],
+                'columnTypes' => ['Size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('low','high')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM Items JOIN Other WHERE FIELD(ITEMS.SIZE, 'small', 'large') > FIELD('small', 'small', 'large') AND FIELD(other.size, 'low', 'high') < FIELD('high', 'low', 'high') AND missing.size > 'small' AND size > 'small'",
+            $semantics->rewrite("SELECT * FROM Items JOIN Other WHERE ITEMS.SIZE > 'small' AND other.size < 'high' AND missing.size > 'small' AND size > 'small'", $tables),
+        );
+    }
+
+    public function testMatchingEnumsAcrossTablesAllowUnqualifiedColumn(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $type = new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')");
+        $tables = [
+            'first' => ['rows' => [], 'columns' => ['size'], 'columnTypes' => ['size' => $type]],
+            'second' => ['rows' => [], 'columns' => ['size'], 'columnTypes' => ['size' => $type]],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM first JOIN second WHERE FIELD(size, 'small', 'large') > FIELD('small', 'small', 'large')",
+            $semantics->rewrite("SELECT * FROM first JOIN second WHERE size > 'small'", $tables),
+        );
+    }
+
+    public function testOrderByRewritesOnlyStandaloneEnumItems(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size', 'name'],
+                'columnTypes' => [
+                    'size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')"),
+                    'name' => new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR(255)'),
+                ],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items ORDER BY FIELD(size, 'small', 'large'), name, FIELD(items.size, 'small', 'large') ASC LIMIT size",
+            $semantics->rewrite('SELECT * FROM items ORDER BY size, name, items.size ASC LIMIT size', $tables),
+        );
+        self::assertSame(
+            "SELECT * FROM items ORDER BY size + 1, FIELD(size, 'small', 'large') DESC",
+            $semantics->rewrite('SELECT * FROM items ORDER BY size + 1, size DESC', $tables),
+        );
+    }
+
+    public function testOrderByStopsAtEveryFollowingClause(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items ORDER BY FIELD(size, 'small', 'large') LIMIT size",
+            $semantics->rewrite('SELECT * FROM items ORDER BY size LIMIT size', $tables),
+        );
+        self::assertSame(
+            "SELECT * FROM items ORDER BY FIELD(size, 'small', 'large') FOR UPDATE, size",
+            $semantics->rewrite('SELECT * FROM items ORDER BY size FOR UPDATE, size', $tables),
+        );
+        self::assertSame(
+            "SELECT * FROM items ORDER BY FIELD(size, 'small', 'large') LOCK IN SHARE MODE, size",
+            $semantics->rewrite('SELECT * FROM items ORDER BY size LOCK IN SHARE MODE, size', $tables),
+        );
+    }
+
+    public function testOrderByContinuesAfterNestedExpressions(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items ORDER BY COALESCE(size, 'small'), FIELD(size, 'small', 'large') DESC",
+            $semantics->rewrite("SELECT * FROM items ORDER BY COALESCE(size, 'small'), size DESC", $tables),
+        );
+        self::assertSame(
+            "SELECT * FROM items WHERE id IN (SELECT id FROM items ORDER BY FIELD(size, 'small', 'large')) ORDER BY FIELD(size, 'small', 'large')",
+            $semantics->rewrite('SELECT * FROM items WHERE id IN (SELECT id FROM items ORDER BY size) ORDER BY size', $tables),
+        );
+    }
+
+    public function testOrderByScanStartsAfterByAndContinuesAfterUnrelatedOrderWord(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size', 'name'],
+                'columnTypes' => [
+                    'size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')"),
+                    'name' => new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR(255)'),
+                ],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT size, name FROM items ORDER BY FIELD(size, 'small', 'large')",
+            $semantics->rewrite('SELECT size, name FROM items ORDER BY size', $tables),
+        );
+        self::assertSame(
+            "SELECT ORDER FROM items ORDER BY FIELD(size, 'small', 'large')",
+            $semantics->rewrite('SELECT ORDER FROM items ORDER BY size', $tables),
+        );
+    }
+
+    public function testByWithoutOrderAndIncompleteOrderRemainUntouched(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')")],
+            ],
+        ];
+
+        self::assertSame('SELECT size AS by FROM items', $semantics->rewrite('SELECT size AS by FROM items', $tables));
+        self::assertSame('SELECT * FROM items ORDER', $semantics->rewrite('SELECT * FROM items ORDER', $tables));
+        self::assertSame('SELECT * FROM items AS BY size', $semantics->rewrite('SELECT * FROM items AS BY size', $tables));
+    }
+
+    public function testParsesCaseWhitespaceAndBothEnumQuoteStyles(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, ' enum ( \'small\' , "large" ) ')],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items WHERE FIELD(size, 'small', 'large') > FIELD('small', 'small', 'large')",
+            $semantics->rewrite("SELECT * FROM items WHERE size > 'small'", $tables),
+        );
+    }
+
+    public function testEscapesEnumMembersInGeneratedFieldExpressions(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('it''s','back\\\\slash')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items ORDER BY FIELD(size, 'it''s', 'back\\\\slash')",
+            $semantics->rewrite('SELECT * FROM items ORDER BY size', $tables),
+        );
+    }
+
+    public function testParsesEmptyAndBackslashEscapedEnumMembers(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('','it\x5c's')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items ORDER BY FIELD(size, '', 'it''s')",
+            $semantics->rewrite('SELECT * FROM items ORDER BY size', $tables),
+        );
+    }
+
+    public function testDoubleQuotedIdentifiersResolveByTokenKind(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'Items' => [
+                'rows' => [],
+                'columns' => ['Size'],
+                'columnTypes' => ['Size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM Items ORDER BY FIELD(\"Items\".\"Size\", 'small', 'large')",
+            $semantics->rewrite('SELECT * FROM Items ORDER BY "Items"."Size"', $tables),
+        );
+    }
+
+    public function testIgnoresMalformedEnumDefinitionsBeforeValidColumn(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['plain', 'wrong', 'open', 'empty', 'short', 'unquoted', 'same_edges', 'mismatched', 'valid'],
+                'columnTypes' => [
+                    'plain' => new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR'),
+                    'wrong' => new ColumnType(ColumnTypeFamily::STRING, "SET('a')"),
+                    'open' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('a'"),
+                    'empty' => new ColumnType(ColumnTypeFamily::STRING, 'ENUM()'),
+                    'short' => new ColumnType(ColumnTypeFamily::STRING, "ENUM(')"),
+                    'unquoted' => new ColumnType(ColumnTypeFamily::STRING, 'ENUM(a)'),
+                    'same_edges' => new ColumnType(ColumnTypeFamily::STRING, 'ENUM(aba)'),
+                    'mismatched' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('a\")"),
+                    'valid' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('a','b')"),
+                ],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items WHERE plain > 'a' AND wrong > 'a' AND open > 'a' AND empty > 'a' AND short > 'a' AND unquoted > 'a' AND same_edges > 'a' AND mismatched > 'a' AND FIELD(valid, 'a', 'b') > FIELD('a', 'a', 'b')",
+            $semantics->rewrite("SELECT * FROM items WHERE plain > 'a' AND wrong > 'a' AND open > 'a' AND empty > 'a' AND short > 'a' AND unquoted > 'a' AND same_edges > 'a' AND mismatched > 'a' AND valid > 'a'", $tables),
+        );
     }
 }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlTypeSemanticsTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlTypeSemanticsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlTypeSemantics;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+#[CoversClass(MySqlTypeSemantics::class)]
+final class MySqlTypeSemanticsTest extends TestCase
+{
+    public function testRewritesEnumOrderingAndOrderedComparisonsToRanks(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','medium','large')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items WHERE FIELD(size, 'small', 'medium', 'large') > FIELD('small', 'small', 'medium', 'large') ORDER BY FIELD(size, 'small', 'medium', 'large') DESC",
+            $semantics->rewrite("SELECT * FROM items WHERE size > 'small' ORDER BY size DESC", $tables),
+        );
+    }
+
+    public function testRewritesQualifiedAndQuotedEnumColumns(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['size'],
+                'columnTypes' => ['size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')")],
+            ],
+        ];
+
+        self::assertSame(
+            "SELECT * FROM items WHERE FIELD(`items`.`size`, 'small', 'large') <= FIELD('large', 'small', 'large') ORDER BY FIELD(`items`.`size`, 'small', 'large')",
+            $semantics->rewrite("SELECT * FROM items WHERE `items`.`size` <= 'large' ORDER BY `items`.`size`", $tables),
+        );
+    }
+
+    public function testLeavesPlainStringsAndComplexOrderExpressionsUntouched(): void
+    {
+        $semantics = new MySqlTypeSemantics();
+        $tables = [
+            'items' => [
+                'rows' => [],
+                'columns' => ['name', 'size'],
+                'columnTypes' => [
+                    'name' => new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR(255)'),
+                    'size' => new ColumnType(ColumnTypeFamily::STRING, "ENUM('small','large')"),
+                ],
+            ],
+        ];
+        $sql = "SELECT * FROM items WHERE name > 'a' ORDER BY COALESCE(size, 'small')";
+
+        self::assertSame($sql, $semantics->rewrite($sql, $tables));
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 final class DeleteTransformerTest extends TestCase
 {
     public function testBuildDeleteWithJoinAlias(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
@@ -23,6 +23,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 final class InsertTransformerTest extends TestCase
 {
     public function testUsesInjectedCastRendererAndColumnTypes(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
@@ -27,6 +27,7 @@ use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 final class MySqlTransformerTest extends TestCase
 {
     public function testTransformSelectPassthrough(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
@@ -20,6 +20,7 @@ use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 final class ReplaceTransformerTest extends TestCase
 {
     public function testTransformReplaceWithValues(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
@@ -12,6 +12,7 @@ use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
+use ZtdQuery\Platform\MySql\MySqlTypeSemantics;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -21,6 +22,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(MySqlTypeSemantics::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
     public function testUsesInjectedValueRenderer(): void
@@ -1496,7 +1498,7 @@ final class SelectTransformerTest extends TransformerContractTest
         self::assertStringContainsString("'hello'", $result);
     }
 
-    public function testTransformSetOrderByNonSetTypeSkipsRewriting(): void
+    public function testTransformEnumOrderByUsesDeclarationRank(): void
     {
         $transformer = new SelectTransformer();
         $sql = 'SELECT * FROM items ORDER BY `status`';
@@ -1512,8 +1514,7 @@ final class SelectTransformerTest extends TransformerContractTest
         ];
 
         $result = $transformer->transform($sql, $tables);
-        self::assertStringNotContainsString('FIND_IN_SET', $result);
-        self::assertStringContainsString('ORDER BY `status`', $result);
+        self::assertStringContainsString("ORDER BY FIELD(`status`, 'active', 'inactive')", $result);
     }
 
     public function testTransformSetOrderByWithNonBacktickedColumnNotRewritten(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 final class UpdateTransformerTest extends TestCase
 {
     public function testBuildUpdateSelectUsesAliasAndColumns(): void

--- a/packages/ztd-query-mysqli-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-mysqli-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
@@ -19,7 +19,7 @@ final class SchemaAwareSqlBuilder
     {
         $table = $schema->name;
         $columns = $schema->columns;
-        $variant = $this->faker->numberBetween(0, 4);
+        $variant = $this->faker->numberBetween(0, 5);
 
         switch ($variant) {
             case 0:
@@ -44,6 +44,17 @@ final class SchemaAwareSqlBuilder
                 /** @var string $col */
                 $col = $this->faker->randomElement($columns);
                 return "SELECT DISTINCT `$col` FROM `$table`";
+            case 5:
+                $enumColumns = array_values(array_filter(
+                    $columns,
+                    static fn (string $column): bool => str_contains(strtolower($column), 'enum'),
+                ));
+                if ($enumColumns === []) {
+                    return "SELECT * FROM `$table`";
+                }
+                /** @var string $enumColumn */
+                $enumColumn = $this->faker->randomElement($enumColumns);
+                return "SELECT `$enumColumn` FROM `$table` WHERE `$enumColumn` > 'a' ORDER BY `$enumColumn`";
             default:
                 return "SELECT * FROM `$table`";
         }

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -20,6 +20,27 @@ use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
 #[Large]
 final class MysqliCteShadowingTest extends TestCase
 {
+    public function testEnumUsesDeclarationRanksForOrderingAndComparison(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf("CREATE TABLE `%s` (id INT PRIMARY KEY, size ENUM('small','medium','large'))", $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (1, 'large'), (2, 'small'), (3, 'medium')", $table));
+
+            $ordered = $ztdMysqli->query(sprintf('SELECT size FROM `%s` ORDER BY size', $table));
+            $compared = $ztdMysqli->query(sprintf("SELECT size FROM `%s` WHERE size > 'small' ORDER BY size", $table));
+            self::assertInstanceOf(\mysqli_result::class, $ordered);
+            self::assertInstanceOf(\mysqli_result::class, $compared);
+            self::assertSame(['small', 'medium', 'large'], array_column($ordered->fetch_all(MYSQLI_ASSOC), 'size'));
+            self::assertSame(['medium', 'large'], array_column($compared->fetch_all(MYSQLI_ASSOC), 'size'));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testSetExpressionsRemainSingleStatements(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
@@ -19,7 +19,7 @@ final class SchemaAwareSqlBuilder
     {
         $table = $schema->name;
         $columns = $schema->columns;
-        $variant = $this->faker->numberBetween(0, 4);
+        $variant = $this->faker->numberBetween(0, 5);
 
         switch ($variant) {
             case 0:
@@ -44,6 +44,17 @@ final class SchemaAwareSqlBuilder
                 /** @var string $col */
                 $col = $this->faker->randomElement($columns);
                 return "SELECT DISTINCT `$col` FROM `$table`";
+            case 5:
+                $enumColumns = array_values(array_filter(
+                    $columns,
+                    static fn (string $column): bool => str_contains(strtolower($column), 'enum'),
+                ));
+                if ($enumColumns === []) {
+                    return "SELECT * FROM `$table`";
+                }
+                /** @var string $enumColumn */
+                $enumColumn = $this->faker->randomElement($enumColumns);
+                return "SELECT `$enumColumn` FROM `$table` WHERE `$enumColumn` > 'a' ORDER BY `$enumColumn`";
             default:
                 return "SELECT * FROM `$table`";
         }


### PR DESCRIPTION
Stack 6/16. Base: #216.

Root problem

MySQL cannot cast a CTE column back to an ENUM declaration, so shadow rows expose ENUM values as ordinary strings. Ordered comparisons and ORDER BY then use lexical order instead of the declaration rank.

Changes

- add a token-driven MySQL type-semantics pass
- identify ENUM columns from reflected native types
- rewrite simple qualified/unqualified ENUM ORDER BY items and `<`, `<=`, `>`, `>=` comparisons to `FIELD()` ranks
- avoid rewriting ordinary string columns and complex order expressions
- add focused unit tests and a real MySQL ENUM regression
- extend PDO and MySQLi correctness fuzz generation with ENUM ordered comparisons

Verification

- MySQL unit: 901 tests / 2241 assertions
- MySQL, PDO adapter, and MySQLi adapter lint/PHPStan: pass
- MySQL ENUM ordering/comparison integration: pass

Addresses the rank/comparison portion of #92. The missing-default portion remains assigned to the later insert-projection PR, which will close the issue.