### PR TITLE
Compile prepared execution at run time

### DIFF
--- a/packages/ztd-query-pdo-adapter/src/PdoParameterBinder.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoParameterBinder.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Pdo;
+
+use PDO;
+use PDOStatement;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PdoParameterBinder
+{
+    /**
+     * @param array<int|string, mixed>|null $params
+     * @return array{sql: string, params: array<int|string, mixed>|null}
+     */
+    public function compile(string $sql, string $driver, ?array $params): array
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->tokens();
+        $replacements = [];
+        $positionalIndex = 0;
+        $nativePositions = [];
+
+        foreach ($tokens as $token) {
+            if ($token->kind !== SqlTokenKind::Parameter) {
+                continue;
+            }
+
+            if ($driver === 'pgsql' && preg_match('/^\$(\d+)$/', $token->text, $matches) === 1) {
+                $position = (int) $matches[1];
+                $nativePositions[$position] = true;
+                $replacements[$token->offset] = [
+                    'length' => strlen($token->text),
+                    'sql' => ':__ztd_pdo_' . $position,
+                ];
+                continue;
+            }
+
+            if ($driver !== 'sqlite') {
+                continue;
+            }
+
+            $value = null;
+            $hasValue = false;
+            if ($token->text === '?') {
+                if ($params !== null && array_key_exists($positionalIndex, $params)) {
+                    $value = $params[$positionalIndex];
+                    $hasValue = true;
+                }
+                $positionalIndex++;
+            } elseif ($params !== null) {
+                $name = ltrim($token->text, ':');
+                if (array_key_exists($name, $params)) {
+                    $value = $params[$name];
+                    $hasValue = true;
+                } elseif (array_key_exists($token->text, $params)) {
+                    $value = $params[$token->text];
+                    $hasValue = true;
+                }
+            }
+
+            $cast = $hasValue ? $this->sqliteCast($value) : null;
+            if ($cast !== null) {
+                $replacements[$token->offset] = [
+                    'length' => strlen($token->text),
+                    'sql' => 'CAST(' . $token->text . ' AS ' . $cast . ')',
+                ];
+            }
+        }
+
+        if ($replacements !== []) {
+            krsort($replacements);
+            foreach ($replacements as $offset => $replacement) {
+                $sql = substr_replace($sql, $replacement['sql'], $offset, $replacement['length']);
+            }
+        }
+
+        if ($driver === 'pgsql') {
+            $sql = PostgreSqlPlaceholderEscaper::escape($sql);
+        }
+
+        if ($nativePositions === [] || $params === null) {
+            return ['sql' => $sql, 'params' => $params];
+        }
+
+        $mapped = [];
+        foreach (array_keys($nativePositions) as $position) {
+            if (array_key_exists($position - 1, $params)) {
+                $mapped['__ztd_pdo_' . $position] = $params[$position - 1];
+            }
+        }
+
+        return ['sql' => $sql, 'params' => $mapped];
+    }
+
+    /** @param array<int|string, mixed>|null $params */
+    public function execute(PDOStatement $statement, ?array $params): bool
+    {
+        if ($params === null) {
+            return $statement->execute();
+        }
+
+        $position = 1;
+        foreach ($params as $key => $value) {
+            $parameter = is_int($key) ? $position++ : ':' . ltrim($key, ':');
+            if (!$statement->bindValue($parameter, $value, $this->pdoType($value))) {
+                return false;
+            }
+        }
+
+        return $statement->execute();
+    }
+
+    private function sqliteCast(mixed $value): ?string
+    {
+        if (is_int($value) || is_bool($value)) {
+            return 'INTEGER';
+        }
+        if (is_float($value)) {
+            return 'REAL';
+        }
+
+        return null;
+    }
+
+    private function pdoType(mixed $value): int
+    {
+        return match (true) {
+            $value === null => PDO::PARAM_NULL,
+            is_bool($value) => PDO::PARAM_BOOL,
+            is_int($value) => PDO::PARAM_INT,
+            is_resource($value) => PDO::PARAM_LOB,
+            default => PDO::PARAM_STR,
+        };
+    }
+}

--- a/packages/ztd-query-pdo-adapter/src/PdoParameterBinder.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoParameterBinder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Adapter\Pdo;
 
-use PDO;
 use PDOStatement;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
@@ -17,6 +16,13 @@ final class PdoParameterBinder
      */
     public function compile(string $sql, string $driver, ?array $params): array
     {
+        if ($driver !== 'pgsql' && $driver !== 'sqlite') {
+            return ['sql' => $sql, 'params' => $params];
+        }
+        if ($driver === 'sqlite' && $params === null) {
+            return ['sql' => $sql, 'params' => null];
+        }
+
         $tokens = SqlTokenStream::tokenize($sql)->tokens();
         $replacements = [];
         $positionalIndex = 0;
@@ -27,9 +33,19 @@ final class PdoParameterBinder
                 continue;
             }
 
-            if ($driver === 'pgsql' && preg_match('/^\$(\d+)$/', $token->text, $matches) === 1) {
-                $position = (int) $matches[1];
-                $nativePositions[$position] = true;
+            if ($driver === 'pgsql') {
+                if (!str_starts_with($token->text, '$')) {
+                    continue;
+                }
+                $position = filter_var(
+                    substr($token->text, 1),
+                    FILTER_VALIDATE_INT,
+                    ['options' => ['min_range' => 1]],
+                );
+                if (!is_int($position)) {
+                    continue;
+                }
+                $nativePositions[$position] = $position;
                 $replacements[$token->offset] = [
                     'length' => strlen($token->text),
                     'sql' => ':__ztd_pdo_' . $position,
@@ -37,30 +53,17 @@ final class PdoParameterBinder
                 continue;
             }
 
-            if ($driver !== 'sqlite') {
+            if ($token->text === '?') {
+                $parameterKey = $positionalIndex;
+                $positionalIndex++;
+            } else {
+                $name = ltrim($token->text, ':');
+                $parameterKey = array_key_exists($name, $params) ? $name : $token->text;
+            }
+            if (!array_key_exists($parameterKey, $params)) {
                 continue;
             }
-
-            $value = null;
-            $hasValue = false;
-            if ($token->text === '?') {
-                if ($params !== null && array_key_exists($positionalIndex, $params)) {
-                    $value = $params[$positionalIndex];
-                    $hasValue = true;
-                }
-                $positionalIndex++;
-            } elseif ($params !== null) {
-                $name = ltrim($token->text, ':');
-                if (array_key_exists($name, $params)) {
-                    $value = $params[$name];
-                    $hasValue = true;
-                } elseif (array_key_exists($token->text, $params)) {
-                    $value = $params[$token->text];
-                    $hasValue = true;
-                }
-            }
-
-            $cast = $hasValue ? $this->sqliteCast($value) : null;
+            $cast = $this->sqliteCast($params[$parameterKey]);
             if ($cast !== null) {
                 $replacements[$token->offset] = [
                     'length' => strlen($token->text),
@@ -85,7 +88,7 @@ final class PdoParameterBinder
         }
 
         $mapped = [];
-        foreach (array_keys($nativePositions) as $position) {
+        foreach ($nativePositions as $position) {
             if (array_key_exists($position - 1, $params)) {
                 $mapped['__ztd_pdo_' . $position] = $params[$position - 1];
             }
@@ -103,13 +106,22 @@ final class PdoParameterBinder
 
         $position = 1;
         foreach ($params as $key => $value) {
-            $parameter = is_int($key) ? $position++ : ':' . ltrim($key, ':');
-            if (!$statement->bindValue($parameter, $value, $this->pdoType($value))) {
+            $parameter = is_int($key) ? $position++ : $this->parameterName($key);
+            if (!$statement->bindValue($parameter, $value, PdoParameterType::fromValue($value))) {
                 return false;
             }
         }
 
         return $statement->execute();
+    }
+
+    private function parameterName(string $parameter): string
+    {
+        if (str_starts_with($parameter, ':')) {
+            return $parameter;
+        }
+
+        return sprintf(':%s', $parameter);
     }
 
     private function sqliteCast(mixed $value): ?string
@@ -122,16 +134,5 @@ final class PdoParameterBinder
         }
 
         return null;
-    }
-
-    private function pdoType(mixed $value): int
-    {
-        return match (true) {
-            $value === null => PDO::PARAM_NULL,
-            is_bool($value) => PDO::PARAM_BOOL,
-            is_int($value) => PDO::PARAM_INT,
-            is_resource($value) => PDO::PARAM_LOB,
-            default => PDO::PARAM_STR,
-        };
     }
 }

--- a/packages/ztd-query-pdo-adapter/src/PdoParameterType.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoParameterType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Pdo;
+
+use PDO;
+
+final class PdoParameterType
+{
+    public static function fromValue(mixed $value): int
+    {
+        return match (true) {
+            $value === null => PDO::PARAM_NULL,
+            is_bool($value) => PDO::PARAM_BOOL,
+            is_int($value) => PDO::PARAM_INT,
+            is_resource($value) => PDO::PARAM_LOB,
+            default => PDO::PARAM_STR,
+        };
+    }
+}

--- a/packages/ztd-query-pdo-adapter/src/PdoPreparedExecution.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoPreparedExecution.php
@@ -46,8 +46,9 @@ final class PdoPreparedExecution
 
     private function driver(): string
     {
+        /** @var string $driver */
         $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
 
-        return is_string($driver) ? $driver : '';
+        return $driver;
     }
 }

--- a/packages/ztd-query-pdo-adapter/src/PdoPreparedExecution.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoPreparedExecution.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Pdo;
+
+use PDO;
+use PDOStatement;
+use RuntimeException;
+use ZtdQuery\Rewrite\RewritePlan;
+use ZtdQuery\Session;
+
+final class PdoPreparedExecution
+{
+    /** @param array<mixed> $options */
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly Session $session,
+        private readonly string $sql,
+        private readonly array $options,
+        private readonly PdoParameterBinder $parameterBinder = new PdoParameterBinder(),
+    ) {
+    }
+
+    /**
+     * @param array<int|string, mixed>|null $params
+     * @return array{statement: PDOStatement, plan: RewritePlan, params: array<int|string, mixed>|null}
+     */
+    public function prepare(?array $params): array
+    {
+        $plan = $this->session->rewrite($this->sql);
+        $driver = $this->driver();
+        $compiled = $this->parameterBinder->compile($plan->sql(), $driver, $params);
+        $statement = $this->pdo->prepare($compiled['sql'], $this->options);
+        if ($statement === false) {
+            throw new RuntimeException('PDO failed to prepare rewritten SQL.');
+        }
+
+        return ['statement' => $statement, 'plan' => $plan, 'params' => $compiled['params']];
+    }
+
+    public function parameterBinder(): PdoParameterBinder
+    {
+        return $this->parameterBinder;
+    }
+
+    private function driver(): string
+    {
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        return is_string($driver) ? $driver : '';
+    }
+}

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
@@ -167,22 +167,18 @@ class ZtdPdo extends PDO
         }
 
         try {
-            $plan = $this->session->rewrite($query);
+            $execution = new PdoPreparedExecution($this->pdo, $this->session, $query, $options);
+            $prepared = $execution->prepare(null);
         } catch (DatabaseException $e) {
             throw new ZtdPdoException($e->getMessage(), 0, $e);
         }
 
-        $preparedSql = $plan->sql();
-        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
-            $preparedSql = PostgreSqlPlaceholderEscaper::escape($preparedSql);
-        }
-
-        $stmt = $this->pdo->prepare($preparedSql, $options);
-        if ($stmt === false) {
-            return false;
-        }
-
-        return new ZtdPdoStatement($stmt, $this->session, $plan);
+        return new ZtdPdoStatement(
+            $prepared['statement'],
+            $this->session,
+            $prepared['plan'],
+            $execution,
+        );
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdoStatement.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdoStatement.php
@@ -141,17 +141,23 @@ final class ZtdPdoStatement extends NativePdoStatement
             return false;
         }
 
-        if (!$this->session->needsPostProcessing($this->plan)) {
-            return $this->executeStatement($params);
+        if ($this->session->needsPostProcessing($this->plan)) {
+            return $this->executeAndPostProcess($this->plan, $params);
         }
 
+        return $this->executeStatement($params);
+    }
+
+    /** @param array<int|string, mixed>|null $params */
+    private function executeAndPostProcess(RewritePlan $plan, ?array $params): bool
+    {
         if (!$this->executeStatement($params)) {
             return false;
         }
 
         try {
             $this->result = $this->session->processExecutedStatement(
-                $this->plan,
+                $plan,
                 new PdoStatement($this->statement)
             );
         } catch (DatabaseException $e) {

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdoStatement.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdoStatement.php
@@ -47,11 +47,27 @@ final class ZtdPdoStatement extends NativePdoStatement
      */
     private ?ExecuteResult $result = null;
 
-    public function __construct(NativePdoStatement $statement, Session $session, ?RewritePlan $plan)
-    {
+    private ?PdoPreparedExecution $preparedExecution;
+
+    /** @var array<int|string, array{value: mixed, type: int}> */
+    private array $boundValues = [];
+
+    /** @var array<int|string, array{value: mixed, type: int, maxLength: int, driverOptions: mixed}> */
+    private array $boundParams = [];
+
+    /** @var array{mode: int, args: array<mixed>}|null */
+    private ?array $fetchMode = null;
+
+    public function __construct(
+        NativePdoStatement $statement,
+        Session $session,
+        ?RewritePlan $plan,
+        ?PdoPreparedExecution $preparedExecution = null,
+    ) {
         $this->statement = $statement;
         $this->session = $session;
         $this->plan = $plan;
+        $this->preparedExecution = $preparedExecution;
     }
 
     /**
@@ -59,6 +75,8 @@ final class ZtdPdoStatement extends NativePdoStatement
      */
     public function bindValue(int|string $param, mixed $value, int $type = PDO::PARAM_STR): bool
     {
+        $this->boundValues[$param] = ['value' => $value, 'type' => $type];
+
         return $this->statement->bindValue($param, $value, $type);
     }
 
@@ -72,6 +90,13 @@ final class ZtdPdoStatement extends NativePdoStatement
         int $maxLength = 0,
         mixed $driverOptions = null
     ): bool {
+        $this->boundParams[$param] = [
+            'value' => &$var,
+            'type' => $type,
+            'maxLength' => $maxLength,
+            'driverOptions' => $driverOptions,
+        ];
+
         return $this->statement->bindParam($param, $var, $type, $maxLength, $driverOptions);
     }
 
@@ -97,8 +122,19 @@ final class ZtdPdoStatement extends NativePdoStatement
     {
         $this->result = null;
 
+        if ($this->preparedExecution !== null) {
+            $prepared = $this->preparedExecution->prepare($params);
+            $this->statement = $prepared['statement'];
+            $this->plan = $prepared['plan'];
+            $params = $prepared['params'];
+            $this->rebindParameters();
+            if ($this->fetchMode !== null) {
+                $this->statement->setFetchMode($this->fetchMode['mode'], ...$this->fetchMode['args']);
+            }
+        }
+
         if ($this->plan === null) {
-            return $this->statement->execute($params);
+            return $this->executeStatement($params);
         }
 
         if (!$this->session->shouldExecute($this->plan)) {
@@ -106,10 +142,10 @@ final class ZtdPdoStatement extends NativePdoStatement
         }
 
         if (!$this->session->needsPostProcessing($this->plan)) {
-            return $this->statement->execute($params);
+            return $this->executeStatement($params);
         }
 
-        if (!$this->statement->execute($params)) {
+        if (!$this->executeStatement($params)) {
             return false;
         }
 
@@ -123,6 +159,33 @@ final class ZtdPdoStatement extends NativePdoStatement
         }
 
         return $this->result->isSuccess();
+    }
+
+    /** @param array<int|string, mixed>|null $params */
+    private function executeStatement(?array $params): bool
+    {
+        if ($this->preparedExecution === null) {
+            return $this->statement->execute($params);
+        }
+
+        return $this->preparedExecution->parameterBinder()->execute($this->statement, $params);
+    }
+
+    private function rebindParameters(): void
+    {
+        foreach ($this->boundValues as $parameter => $binding) {
+            $this->statement->bindValue($parameter, $binding['value'], $binding['type']);
+        }
+        foreach (array_keys($this->boundParams) as $parameter) {
+            $binding = &$this->boundParams[$parameter];
+            $this->statement->bindParam(
+                $parameter,
+                $binding['value'],
+                $binding['type'],
+                $binding['maxLength'],
+                $binding['driverOptions'],
+            );
+        }
     }
 
     /**
@@ -230,6 +293,8 @@ final class ZtdPdoStatement extends NativePdoStatement
     #[\ReturnTypeWillChange]
     public function setFetchMode(int $mode, mixed ...$args): bool
     {
+        $this->fetchMode = ['mode' => $mode, 'args' => $args];
+
         return $this->statement->setFetchMode($mode, ...$args);
     }
 

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/PreparedExecutionTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/PreparedExecutionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class PreparedExecutionTest extends TestCase
+{
+    public function testNativePositionsRemainBoundAcrossExpressionsAndMutations(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $products = 'products_' . bin2hex(random_bytes(8));
+        $categories = 'categories_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$categories} (category_id INTEGER PRIMARY KEY, name TEXT)");
+            $rawPdo->exec("CREATE TABLE {$products} (id INTEGER PRIMARY KEY, category_id INTEGER, name TEXT, price INTEGER, status TEXT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+            $insertCategory = $ztdPdo->prepare("INSERT INTO {$categories} VALUES (\$1, \$2)");
+            self::assertInstanceOf(\PDOStatement::class, $insertCategory);
+            self::assertTrue($insertCategory->execute([1, 'tools']));
+
+            $insertProduct = $ztdPdo->prepare("INSERT INTO {$products} VALUES (\$1, \$2, \$3, \$4, \$5)");
+            self::assertInstanceOf(\PDOStatement::class, $insertProduct);
+            self::assertTrue($insertProduct->execute([1, 1, 'Hammer', 20, 'active']));
+            self::assertTrue($insertProduct->execute([2, 1, 'Saw', 40, 'active']));
+
+            $aggregate = $ztdPdo->prepare("SELECT category_id, SUM(price) FILTER (WHERE status = \$1) AS total FROM {$products} GROUP BY category_id HAVING SUM(price) > \$2");
+            self::assertInstanceOf(\PDOStatement::class, $aggregate);
+            self::assertTrue($aggregate->execute(['active', 50]));
+            self::assertSame(60, $aggregate->fetchColumn(1));
+
+            $joined = $ztdPdo->prepare("SELECT p.name FROM {$products} p JOIN {$categories} c USING (category_id) WHERE p.price BETWEEN \$1 AND \$2 ORDER BY p.id");
+            self::assertInstanceOf(\PDOStatement::class, $joined);
+            self::assertTrue($joined->execute([10, 30]));
+            self::assertSame(['Hammer'], $joined->fetchAll(PDO::FETCH_COLUMN));
+
+            $update = $ztdPdo->prepare("UPDATE {$products} SET status = CASE WHEN price >= \$1 THEN \$2 ELSE status END WHERE id IN (\$3, \$4)");
+            self::assertInstanceOf(\PDOStatement::class, $update);
+            self::assertTrue($update->execute([30, 'premium', 1, 2]));
+
+            $current = $ztdPdo->prepare("SELECT status FROM {$products} WHERE id = \$1");
+            self::assertInstanceOf(\PDOStatement::class, $current);
+            self::assertTrue($current->execute([2]));
+            self::assertSame('premium', $current->fetchColumn());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/PreparedExecutionTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/PreparedExecutionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class PreparedExecutionTest extends TestCase
+{
+    public function testPreparedInsertCanBeUpdatedAndObservedByRepreparedSelect(): void
+    {
+        $raw = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $raw->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($raw);
+
+        $statement = $ztdPdo->prepare('INSERT INTO users VALUES (?, ?)');
+        self::assertInstanceOf(\PDOStatement::class, $statement);
+        self::assertTrue($statement->execute([1, 'Alice']));
+
+        $statement = $ztdPdo->prepare('UPDATE users SET name = ? WHERE id = ?');
+        self::assertInstanceOf(\PDOStatement::class, $statement);
+        self::assertTrue($statement->execute(['Alicia', 1]));
+
+        $statement = $ztdPdo->prepare('SELECT name FROM users WHERE id = 1');
+        self::assertInstanceOf(\PDOStatement::class, $statement);
+        self::assertTrue($statement->execute([]));
+        self::assertSame('Alicia', $statement->fetchColumn());
+    }
+
+    public function testPreparedExpressionsAndReexecutionUseCurrentTypedShadowRows(): void
+    {
+        $raw = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $raw->exec('CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, price REAL, stock INTEGER)');
+        $ztdPdo = ZtdPdo::fromPdo($raw);
+        $ztdPdo->exec("INSERT INTO products VALUES (1, 'Widget', 10, 100), (2, 'Gadget', 20, 50), (3, 'Sprocket', NULL, 5)");
+
+        $select = $ztdPdo->prepare('SELECT name FROM products WHERE COALESCE(price, ?) < ? ORDER BY id');
+        self::assertInstanceOf(\PDOStatement::class, $select);
+        self::assertTrue($select->execute([0.0, 15.0]));
+        self::assertSame(['Widget', 'Sprocket'], $select->fetchAll(PDO::FETCH_COLUMN));
+
+        $delete = $ztdPdo->prepare('DELETE FROM products WHERE MIN(COALESCE(price, ?), stock) < ?');
+        self::assertInstanceOf(\PDOStatement::class, $delete);
+        self::assertTrue($delete->execute([0.0, 10]));
+        self::assertSame(1, $delete->rowCount());
+
+        self::assertTrue($select->execute([0.0, 25.0]));
+        self::assertSame(['Widget', 'Gadget'], $select->fetchAll(PDO::FETCH_COLUMN));
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterBinderTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterBinderTest.php
@@ -6,22 +6,27 @@ namespace Tests\Unit;
 
 use PDO;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\PdoParameterBinder;
+use ZtdQuery\Adapter\Pdo\PdoParameterType;
+use ZtdQuery\Adapter\Pdo\PostgreSqlPlaceholderEscaper;
 
 #[CoversClass(PdoParameterBinder::class)]
+#[UsesClass(PdoParameterType::class)]
+#[UsesClass(PostgreSqlPlaceholderEscaper::class)]
 final class PdoParameterBinderTest extends TestCase
 {
     public function testMapsNativePostgreSqlPositionsWithoutTouchingQuotedText(): void
     {
         $compiled = (new PdoParameterBinder())->compile(
-            'SELECT $2, $1, $2, \'$3\' -- $4',
+            'SELECT $2, $1, $2, \'$3\' FROM docs WHERE meta ? $1 -- $4',
             'pgsql',
             ['first', 'second'],
         );
 
         self::assertSame(
-            'SELECT :__ztd_pdo_2, :__ztd_pdo_1, :__ztd_pdo_2, \'$3\' -- $4',
+            'SELECT :__ztd_pdo_2, :__ztd_pdo_1, :__ztd_pdo_2, \'$3\' FROM docs WHERE meta ?? :__ztd_pdo_1 -- $4',
             $compiled['sql'],
         );
         self::assertSame(
@@ -33,14 +38,60 @@ final class PdoParameterBinderTest extends TestCase
     public function testGivesSqliteParametersNumericStorageClasses(): void
     {
         $compiled = (new PdoParameterBinder())->compile(
-            'SELECT ?, :ratio, \'?\', "?"',
+            'SELECT ?, ?, :ratio, :integer, \'?\', "?"',
             'sqlite',
-            [0 => 12, 'ratio' => 2.5],
+            [0 => 12, 1 => 2.5, 'ratio' => 2.5, ':integer' => 9],
         );
 
         self::assertSame(
-            'SELECT CAST(? AS INTEGER), CAST(:ratio AS REAL), \'?\', "?"',
+            'SELECT CAST(? AS INTEGER), CAST(? AS REAL), CAST(:ratio AS REAL), CAST(:integer AS INTEGER), \'?\', "?"',
             $compiled['sql'],
+        );
+    }
+
+    public function testLeavesUnboundParametersAndOtherDriversUnchanged(): void
+    {
+        $binder = new PdoParameterBinder();
+
+        self::assertSame(
+            ['sql' => 'SELECT ?, :missing', 'params' => null],
+            $binder->compile('SELECT ?, :missing', 'sqlite', null),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT ?, :missing', 'params' => []],
+            $binder->compile('SELECT ?, :missing', 'sqlite', []),
+        );
+        self::assertSame(
+            ['sql' => "SELECT meta ? 'key'", 'params' => ['key']],
+            $binder->compile("SELECT meta ? 'key'", 'mysql', ['key']),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT ?', 'params' => [1]],
+            $binder->compile('SELECT ?', 'pgsql', [1]),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT $0, :__ztd_pdo_1', 'params' => ['__ztd_pdo_1' => 1]],
+            $binder->compile('SELECT $0, $1', 'pgsql', [1]),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT :__ztd_pdo_1', 'params' => null],
+            $binder->compile('SELECT $1', 'pgsql', null),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT $1', 'params' => [1]],
+            $binder->compile('SELECT $1', 'mysql', [1]),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT ?', 'params' => [7]],
+            $binder->compile('SELECT ?', 'mysql', [7]),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT ?, :__ztd_pdo_1', 'params' => ['__ztd_pdo_1' => 1]],
+            $binder->compile('SELECT ?, $1', 'pgsql', [1]),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT :missing, CAST(:value AS INTEGER)', 'params' => ['value' => 7]],
+            $binder->compile('SELECT :missing, :value', 'sqlite', ['value' => 7]),
         );
     }
 
@@ -52,5 +103,31 @@ final class PdoParameterBinderTest extends TestCase
 
         self::assertTrue((new PdoParameterBinder())->execute($statement, [1, null, '1']));
         self::assertSame(['integer', 'null', 'text'], $statement->fetch(PDO::FETCH_NUM));
+    }
+
+    public function testBindsEveryPhpValueTypeAndNormalizesNamedParameters(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $statement = $pdo->prepare(
+            'SELECT typeof(?), typeof(?), typeof(?), typeof(?), typeof(:name), typeof(:ratio)',
+        );
+        self::assertInstanceOf(\PDOStatement::class, $statement);
+        $resource = fopen('php://memory', 'r');
+        self::assertIsResource($resource);
+
+        self::assertTrue((new PdoParameterBinder())->execute($statement, [
+            null,
+            true,
+            7,
+            $resource,
+            'name' => 'text',
+            ':ratio' => 2.5,
+        ]));
+
+        self::assertSame(
+            ['null', 'integer', 'integer', 'blob', 'text', 'text'],
+            $statement->fetch(PDO::FETCH_NUM),
+        );
+        fclose($resource);
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterBinderTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterBinderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\PdoParameterBinder;
+
+#[CoversClass(PdoParameterBinder::class)]
+final class PdoParameterBinderTest extends TestCase
+{
+    public function testMapsNativePostgreSqlPositionsWithoutTouchingQuotedText(): void
+    {
+        $compiled = (new PdoParameterBinder())->compile(
+            'SELECT $2, $1, $2, \'$3\' -- $4',
+            'pgsql',
+            ['first', 'second'],
+        );
+
+        self::assertSame(
+            'SELECT :__ztd_pdo_2, :__ztd_pdo_1, :__ztd_pdo_2, \'$3\' -- $4',
+            $compiled['sql'],
+        );
+        self::assertSame(
+            ['__ztd_pdo_2' => 'second', '__ztd_pdo_1' => 'first'],
+            $compiled['params'],
+        );
+    }
+
+    public function testGivesSqliteParametersNumericStorageClasses(): void
+    {
+        $compiled = (new PdoParameterBinder())->compile(
+            'SELECT ?, :ratio, \'?\', "?"',
+            'sqlite',
+            [0 => 12, 'ratio' => 2.5],
+        );
+
+        self::assertSame(
+            'SELECT CAST(? AS INTEGER), CAST(:ratio AS REAL), \'?\', "?"',
+            $compiled['sql'],
+        );
+    }
+
+    public function testBindsExecuteArrayUsingPhpValueTypes(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $statement = $pdo->prepare('SELECT typeof(?), typeof(?), typeof(?)');
+        self::assertInstanceOf(\PDOStatement::class, $statement);
+
+        self::assertTrue((new PdoParameterBinder())->execute($statement, [1, null, '1']));
+        self::assertSame(['integer', 'null', 'text'], $statement->fetch(PDO::FETCH_NUM));
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterTypeTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterTypeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\PdoParameterType;
+
+#[CoversClass(PdoParameterType::class)]
+final class PdoParameterTypeTest extends TestCase
+{
+    public function testMapsPhpValuesToPdoParameterTypes(): void
+    {
+        $resource = fopen('php://memory', 'r');
+        self::assertIsResource($resource);
+
+        self::assertSame(PDO::PARAM_NULL, PdoParameterType::fromValue(null));
+        self::assertSame(PDO::PARAM_BOOL, PdoParameterType::fromValue(true));
+        self::assertSame(PDO::PARAM_INT, PdoParameterType::fromValue(7));
+        self::assertSame(PDO::PARAM_LOB, PdoParameterType::fromValue($resource));
+        self::assertSame(PDO::PARAM_STR, PdoParameterType::fromValue('value'));
+        self::assertSame(PDO::PARAM_STR, PdoParameterType::fromValue(1.5));
+        fclose($resource);
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoPreparedExecutionTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoPreparedExecutionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\PdoConnection;
+use ZtdQuery\Adapter\Pdo\PdoPreparedExecution;
+use ZtdQuery\Config\ZtdConfig;
+use ZtdQuery\Platform\Sqlite\SqliteSessionFactory;
+
+#[CoversClass(PdoPreparedExecution::class)]
+final class PdoPreparedExecutionTest extends TestCase
+{
+    public function testRewritesAgainstCurrentShadowStateForEveryPreparation(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT)');
+        $session = (new SqliteSessionFactory())->create(new PdoConnection($pdo), ZtdConfig::default());
+        $session->execStatement("INSERT INTO items VALUES (1, 'before')");
+        $execution = new PdoPreparedExecution($pdo, $session, 'SELECT value FROM items WHERE id = ?', []);
+
+        $before = $execution->prepare([1]);
+        self::assertTrue($execution->parameterBinder()->execute($before['statement'], $before['params']));
+        self::assertSame('before', $before['statement']->fetchColumn());
+
+        $session->execStatement("UPDATE items SET value = 'after' WHERE id = 1");
+        $after = $execution->prepare([1]);
+        self::assertTrue($execution->parameterBinder()->execute($after['statement'], $after['params']));
+        self::assertSame('after', $after['statement']->fetchColumn());
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoPreparedExecutionTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoPreparedExecutionTest.php
@@ -6,13 +6,21 @@ namespace Tests\Unit;
 
 use PDO;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\PdoConnection;
+use ZtdQuery\Adapter\Pdo\PdoParameterBinder;
+use ZtdQuery\Adapter\Pdo\PdoParameterType;
 use ZtdQuery\Adapter\Pdo\PdoPreparedExecution;
+use ZtdQuery\Adapter\Pdo\PdoStatement;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Platform\Sqlite\SqliteSessionFactory;
 
 #[CoversClass(PdoPreparedExecution::class)]
+#[UsesClass(PdoConnection::class)]
+#[UsesClass(PdoParameterBinder::class)]
+#[UsesClass(PdoParameterType::class)]
+#[UsesClass(PdoStatement::class)]
 final class PdoPreparedExecutionTest extends TestCase
 {
     public function testRewritesAgainstCurrentShadowStateForEveryPreparation(): void

--- a/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoStatementTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoStatementTest.php
@@ -9,6 +9,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\PdoStatement;
+use ZtdQuery\Adapter\Pdo\PdoParameterBinder;
+use ZtdQuery\Adapter\Pdo\PdoParameterType;
+use ZtdQuery\Adapter\Pdo\PdoPreparedExecution;
 use ZtdQuery\Adapter\Pdo\ZtdPdoException;
 use ZtdQuery\Adapter\Pdo\ZtdPdoStatement;
 use ZtdQuery\Config\ZtdConfig;
@@ -25,6 +28,9 @@ use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(ZtdPdoStatement::class)]
 #[UsesClass(PdoStatement::class)]
+#[UsesClass(PdoParameterBinder::class)]
+#[UsesClass(PdoParameterType::class)]
+#[UsesClass(PdoPreparedExecution::class)]
 #[UsesClass(ZtdPdoException::class)]
 final class ZtdPdoStatementTest extends TestCase
 {
@@ -67,6 +73,55 @@ final class ZtdPdoStatementTest extends TestCase
         $session = new Session(static::createStub(SqlRewriter::class), new ShadowStore(), new ResultSelectRunner(), ZtdConfig::default(), static::createStub(ConnectionInterface::class));
         $stmt = new ZtdPdoStatement($inner, $session, $plan);
         self::assertTrue($stmt->execute());
+    }
+
+    public function testExecuteWithoutPostProcessingRunsNativeStatementOnce(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE t (id INTEGER)');
+        $inner = $pdo->prepare('INSERT INTO t VALUES (1)');
+        self::assertNotFalse($inner);
+
+        $plan = new RewritePlan('INSERT INTO t VALUES (1)', QueryKind::READ);
+        $session = new Session(static::createStub(SqlRewriter::class), new ShadowStore(), new ResultSelectRunner(), ZtdConfig::default(), static::createStub(ConnectionInterface::class));
+        $stmt = new ZtdPdoStatement($inner, $session, $plan);
+
+        self::assertTrue($stmt->execute());
+        $count = $pdo->query('SELECT COUNT(*) FROM t');
+        self::assertInstanceOf(\PDOStatement::class, $count);
+        self::assertSame(1, $count->fetchColumn());
+    }
+
+    public function testBindValueSurvivesPreparedStatementRecompilation(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $rewriter = static::createStub(SqlRewriter::class);
+        $rewriter->method('rewrite')->willReturn(new RewritePlan('SELECT ? AS value', QueryKind::READ));
+        $session = new Session($rewriter, new ShadowStore(), new ResultSelectRunner(), ZtdConfig::default(), static::createStub(ConnectionInterface::class));
+        $execution = new PdoPreparedExecution($pdo, $session, 'SELECT ? AS value', []);
+        $prepared = $execution->prepare(null);
+        $stmt = new ZtdPdoStatement($prepared['statement'], $session, $prepared['plan'], $execution);
+
+        self::assertTrue($stmt->bindValue(1, 42, PDO::PARAM_INT));
+        self::assertTrue($stmt->execute());
+        self::assertSame(42, $stmt->fetchColumn());
+    }
+
+    public function testBindParamSurvivesPreparedStatementRecompilation(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $rewriter = static::createStub(SqlRewriter::class);
+        $rewriter->method('rewrite')->willReturn(new RewritePlan('SELECT ? AS value', QueryKind::READ));
+        $session = new Session($rewriter, new ShadowStore(), new ResultSelectRunner(), ZtdConfig::default(), static::createStub(ConnectionInterface::class));
+        $execution = new PdoPreparedExecution($pdo, $session, 'SELECT ? AS value', []);
+        $prepared = $execution->prepare(null);
+        $stmt = new ZtdPdoStatement($prepared['statement'], $session, $prepared['plan'], $execution);
+        $value = 41;
+
+        self::assertTrue($stmt->bindParam(1, $value, PDO::PARAM_INT));
+        $value = 43;
+        self::assertTrue($stmt->execute());
+        self::assertSame(43, $stmt->fetchColumn());
     }
 
     public function testExecuteWrapsSimulationFailureAsAdapterException(): void


### PR DESCRIPTION
## Root cause

Prepared statements captured rewritten CTE data at prepare time and delegated untyped execute arrays directly to PDO. PostgreSQL native positions were not PDO parameters, while SQLite/MySQL comparisons against CTE expressions lost physical-column affinity.

## Fix

- rebuild the rewrite plan from current shadow state for every execution
- compile PostgreSQL `$N` positions to stable named bindings
- bind PHP null, bool, int, stream, and scalar values with explicit PDO types
- give SQLite numeric parameters explicit INTEGER/REAL storage classes
- replay bound values and fetch mode after recompilation
- use SQLFaker's existing MySQL, PostgreSQL, and SQLite parameter token support as the lexical contract

## Verification

- PostgreSQL integration covers native positions in INSERT, FILTER/HAVING, JOIN USING, BETWEEN, CASE, and IN
- SQLite integration covers prepared INSERT→UPDATE, re-prepare, re-execution after mutation, COALESCE, MIN, integer and real parameters
- adapter unit suite, SQLite integration suite, lint, and PHPStan pass

Fixes #22
Fixes #23
Fixes #45
Fixes #61
Fixes #62
Fixes #63
Fixes #68
Fixes #75
Fixes #80
Fixes #85
Fixes #87
Fixes #95
Fixes #101
Fixes #106
Fixes #108
Fixes #113
Fixes #125
Fixes #128
Fixes #129
Fixes #146
Fixes #167