### PR TITLE
Compose shadow and user CTE namespaces

### DIFF
--- a/packages/ztd-query-core/src/Rewrite/CteShadowComposer.php
+++ b/packages/ztd-query-core/src/Rewrite/CteShadowComposer.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Rewrite;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class CteShadowComposer
+{
+    /**
+     * @param array<string, string> $tableCtes
+     */
+    public function compose(string $sql, array $tableCtes): string
+    {
+        $declared = array_fill_keys($this->declaredCteNames($sql), true);
+        $ctes = [];
+        foreach ($tableCtes as $table => $cte) {
+            $normalized = strtolower($table);
+            if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
+                continue;
+            }
+            $ctes[] = $cte;
+        }
+
+        if ($ctes === []) {
+            return $sql;
+        }
+
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $with = $tokens[0] ?? null;
+        if ($with === null || !$with->isKeyword('WITH')) {
+            return 'WITH ' . implode(",\n", $ctes) . "\n" . $sql;
+        }
+
+        $insertionToken = $with;
+        $next = $tokens[1] ?? null;
+        if ($next !== null && $next->isTopLevel() && $next->isKeyword('RECURSIVE')) {
+            $insertionToken = $next;
+        }
+
+        return substr_replace(
+            $sql,
+            ' ' . implode(",\n", $ctes) . ",\n",
+            $insertionToken->endOffset(),
+            0,
+        );
+    }
+
+    /** @return list<string> */
+    public function declaredCteNames(string $sql): array
+    {
+        return $this->parseHeader($sql)['names'];
+    }
+
+    public function carryPrefix(string $originalSql, string $rewrittenStatement): string
+    {
+        $header = $this->parseHeader($originalSql);
+        if ($header['statementOffset'] === null) {
+            return $rewrittenStatement;
+        }
+
+        $prefix = rtrim(substr($originalSql, 0, $header['statementOffset']));
+
+        $rewrittenTokens = SqlTokenStream::tokenize($rewrittenStatement)->significantTokens();
+        $rewrittenWith = $rewrittenTokens[0] ?? null;
+        if ($rewrittenWith !== null && $rewrittenWith->isKeyword('WITH')) {
+            $rewrittenHeader = $this->parseHeader($rewrittenStatement);
+            $rewrittenStatementOffset = $rewrittenHeader['statementOffset'];
+            if ($rewrittenStatementOffset === null) {
+                return $prefix . "\n" . $rewrittenStatement;
+            }
+
+            $contentToken = $rewrittenWith;
+            $rewrittenNext = $rewrittenTokens[1] ?? null;
+            if ($rewrittenNext !== null && $rewrittenNext->isKeyword('RECURSIVE')) {
+                $contentToken = $rewrittenNext;
+            }
+
+            $rewrittenBody = trim(substr(
+                $rewrittenStatement,
+                $contentToken->endOffset(),
+                $rewrittenStatementOffset - $contentToken->endOffset(),
+            ));
+            $rewrittenTail = substr($rewrittenStatement, $rewrittenStatementOffset);
+            $dependsOnOriginalCte = false;
+            foreach ($header['names'] as $name) {
+                if ($this->referencesIdentifier($rewrittenBody, $name)) {
+                    $dependsOnOriginalCte = true;
+                    break;
+                }
+            }
+            if ($dependsOnOriginalCte) {
+                return $prefix . ",\n" . $rewrittenBody . "\n" . $rewrittenTail;
+            }
+
+            $originalTokens = SqlTokenStream::tokenize($originalSql)->significantTokens();
+            $originalWith = $originalTokens[0];
+            $originalContentToken = $originalWith;
+            $recursive = false;
+            $originalNext = $originalTokens[1] ?? null;
+            if ($originalNext !== null && $originalNext->isKeyword('RECURSIVE')) {
+                $originalContentToken = $originalNext;
+                $recursive = true;
+            }
+            $originalBody = trim(substr(
+                $originalSql,
+                $originalContentToken->endOffset(),
+                $header['statementOffset'] - $originalContentToken->endOffset(),
+            ));
+            $leading = substr($originalSql, 0, $originalWith->offset);
+
+            return $leading
+                . 'WITH '
+                . ($recursive ? 'RECURSIVE ' : '')
+                . $rewrittenBody
+                . ",\n"
+                . $originalBody
+                . "\n"
+                . $rewrittenTail;
+        }
+
+        return $prefix . "\n" . $rewrittenStatement;
+    }
+
+    public function statementSql(string $sql): string
+    {
+        $offset = $this->parseHeader($sql)['statementOffset'];
+
+        return $offset === null ? $sql : substr($sql, $offset);
+    }
+
+    /** @return array{names: list<string>, statementOffset: int|null} */
+    private function parseHeader(string $sql): array
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        if (($tokens[0] ?? null)?->isKeyword('WITH') !== true) {
+            return ['names' => [], 'statementOffset' => null];
+        }
+
+        $index = 1;
+        if (($tokens[$index] ?? null)?->isKeyword('RECURSIVE') === true) {
+            $index++;
+        }
+
+        $names = [];
+        while (isset($tokens[$index]) && $tokens[$index]->isTopLevel()) {
+            $name = $this->identifierName($tokens[$index]);
+            if ($name === null) {
+                break;
+            }
+            $index++;
+
+            while (isset($tokens[$index]) && !$tokens[$index]->isKeyword('AS')) {
+                if (!$tokens[$index]->isTopLevel()) {
+                    $index++;
+                    continue;
+                }
+                if ($tokens[$index]->kind === SqlTokenKind::Word) {
+                    break 2;
+                }
+                $index++;
+            }
+            if (($tokens[$index] ?? null)?->isKeyword('AS') !== true) {
+                break;
+            }
+            $names[] = strtolower($name);
+            $index++;
+
+            while (isset($tokens[$index]) && !($tokens[$index]->kind === SqlTokenKind::Symbol && $tokens[$index]->text === '(')) {
+                $index++;
+            }
+            if (!isset($tokens[$index])) {
+                break;
+            }
+            $index++;
+
+            while (isset($tokens[$index])) {
+                $token = $tokens[$index];
+                if ($token->kind === SqlTokenKind::Symbol && $token->text === ')' && $token->isTopLevel()) {
+                    $index++;
+                    break;
+                }
+                $index++;
+            }
+
+            $separator = $tokens[$index] ?? null;
+            if ($separator === null || $separator->kind !== SqlTokenKind::Symbol || $separator->text !== ',' || !$separator->isTopLevel()) {
+                break;
+            }
+            $index++;
+        }
+
+        $statement = $tokens[$index] ?? null;
+
+        return [
+            'names' => $names,
+            'statementOffset' => $statement?->offset,
+        ];
+    }
+
+    private function referencesIdentifier(string $sql, string $identifier): bool
+    {
+        foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
+            $candidate = $this->identifierName($token);
+            if ($candidate !== null && strcasecmp($candidate, $identifier) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function identifierName(SqlToken $token): ?string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+        if ($token->kind !== SqlTokenKind::QuotedIdentifier || strlen($token->text) < 2) {
+            return null;
+        }
+
+        $quote = $token->text[0];
+        $inner = substr($token->text, 1, -1);
+
+        return str_replace($quote . $quote, $quote, $inner);
+    }
+}

--- a/packages/ztd-query-core/src/Rewrite/CteShadowComposer.php
+++ b/packages/ztd-query-core/src/Rewrite/CteShadowComposer.php
@@ -85,14 +85,7 @@ final class CteShadowComposer
                 $rewrittenStatementOffset - $contentToken->endOffset(),
             ));
             $rewrittenTail = substr($rewrittenStatement, $rewrittenStatementOffset);
-            $dependsOnOriginalCte = false;
-            foreach ($header['names'] as $name) {
-                if ($this->referencesIdentifier($rewrittenBody, $name)) {
-                    $dependsOnOriginalCte = true;
-                    break;
-                }
-            }
-            if ($dependsOnOriginalCte) {
+            if ($this->referencesAnyIdentifier($rewrittenBody, $header['names'])) {
                 return $prefix . ",\n" . $rewrittenBody . "\n" . $rewrittenTail;
             }
 
@@ -135,7 +128,12 @@ final class CteShadowComposer
     /** @return array{names: list<string>, statementOffset: int|null} */
     private function parseHeader(string $sql): array
     {
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $tokens = [];
+        foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
+            if ($token->isTopLevel()) {
+                $tokens[] = $token;
+            }
+        }
         if (($tokens[0] ?? null)?->isKeyword('WITH') !== true) {
             return ['names' => [], 'statementOffset' => null];
         }
@@ -146,48 +144,33 @@ final class CteShadowComposer
         }
 
         $names = [];
-        while (isset($tokens[$index]) && $tokens[$index]->isTopLevel()) {
+        while (isset($tokens[$index])) {
             $name = $this->identifierName($tokens[$index]);
             if ($name === null) {
                 break;
             }
             $index++;
 
-            while (isset($tokens[$index]) && !$tokens[$index]->isKeyword('AS')) {
-                if (!$tokens[$index]->isTopLevel()) {
-                    $index++;
-                    continue;
-                }
-                if ($tokens[$index]->kind === SqlTokenKind::Word) {
-                    break 2;
-                }
+            $asIndex = $this->findAsIndex($tokens, $index);
+            $index = ($asIndex ?? count($tokens)) + 1;
+
+            if (($tokens[$index] ?? null)?->isKeyword('NOT') === true) {
                 $index++;
             }
-            if (($tokens[$index] ?? null)?->isKeyword('AS') !== true) {
-                break;
+            if (($tokens[$index] ?? null)?->isKeyword('MATERIALIZED') === true) {
+                $index++;
+            }
+
+            if (!$this->isSymbol($tokens[$index] ?? null, '(')
+                || !$this->isSymbol($tokens[$index + 1] ?? null, ')')
+            ) {
+                return ['names' => $names, 'statementOffset' => null];
             }
             $names[] = strtolower($name);
-            $index++;
-
-            while (isset($tokens[$index]) && !($tokens[$index]->kind === SqlTokenKind::Symbol && $tokens[$index]->text === '(')) {
-                $index++;
-            }
-            if (!isset($tokens[$index])) {
-                break;
-            }
-            $index++;
-
-            while (isset($tokens[$index])) {
-                $token = $tokens[$index];
-                if ($token->kind === SqlTokenKind::Symbol && $token->text === ')' && $token->isTopLevel()) {
-                    $index++;
-                    break;
-                }
-                $index++;
-            }
+            $index += 2;
 
             $separator = $tokens[$index] ?? null;
-            if ($separator === null || $separator->kind !== SqlTokenKind::Symbol || $separator->text !== ',' || !$separator->isTopLevel()) {
+            if (!$this->isSymbol($separator, ',')) {
                 break;
             }
             $index++;
@@ -201,11 +184,48 @@ final class CteShadowComposer
         ];
     }
 
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private function findAsIndex(array $tokens, int $start): ?int
+    {
+        for ($index = $start; isset($tokens[$index]); $index++) {
+            $token = $tokens[$index];
+            if ($token->isKeyword('AS')) {
+                return $index;
+            }
+            if ($token->kind === SqlTokenKind::Word) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        return $token instanceof SqlToken
+            && $token->kind === SqlTokenKind::Symbol
+            && $token->text === $symbol;
+    }
+
     private function referencesIdentifier(string $sql, string $identifier): bool
     {
         foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
             $candidate = $this->identifierName($token);
             if ($candidate !== null && strcasecmp($candidate, $identifier) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param list<string> $identifiers */
+    private function referencesAnyIdentifier(string $sql, array $identifiers): bool
+    {
+        foreach ($identifiers as $identifier) {
+            if ($this->referencesIdentifier($sql, $identifier)) {
                 return true;
             }
         }

--- a/packages/ztd-query-core/src/Sql/SqlTokenDialect.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenDialect.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Sql;
+
+enum SqlTokenDialect: string
+{
+    case Standard = 'standard';
+    case MySql = 'mysql';
+}

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -18,9 +18,11 @@ final class SqlTokenStream
     ) {
     }
 
-    public static function tokenize(string $sql): self
-    {
-        return new self($sql, self::scan($sql));
+    public static function tokenize(
+        string $sql,
+        SqlTokenDialect $dialect = SqlTokenDialect::Standard,
+    ): self {
+        return new self($sql, self::scan($sql, $dialect));
     }
 
     /** @return list<SqlToken> */
@@ -244,7 +246,7 @@ final class SqlTokenStream
     }
 
     /** @return list<SqlToken> */
-    private static function scan(string $sql): array
+    private static function scan(string $sql, SqlTokenDialect $dialect): array
     {
         $tokens = [];
         $length = strlen($sql);
@@ -266,6 +268,13 @@ final class SqlTokenStream
             }
 
             if ($char === '-' && $next === '-') {
+                $lineEnd = strpos($sql, "\n", $offset);
+                $offset = $lineEnd === false ? $length : $lineEnd;
+                $tokens[] = self::token($sql, SqlTokenKind::Comment, $start, $offset, $depth, $bracketDepth);
+                continue;
+            }
+
+            if ($dialect === SqlTokenDialect::MySql && $char === '#') {
                 $lineEnd = strpos($sql, "\n", $offset);
                 $offset = $lineEnd === false ? $length : $lineEnd;
                 $tokens[] = self::token($sql, SqlTokenKind::Comment, $start, $offset, $depth, $bracketDepth);

--- a/packages/ztd-query-core/tests/Unit/Rewrite/CteShadowComposerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/CteShadowComposerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rewrite;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(CteShadowComposer::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class CteShadowComposerTest extends TestCase
+{
+    public function testAddsShadowsAfterRecursiveModifier(): void
+    {
+        $sql = 'WITH RECURSIVE tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree';
+
+        self::assertSame(
+            "WITH RECURSIVE \"nodes\" AS (SELECT 1 AS id),\n tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree",
+            (new CteShadowComposer())->compose($sql, ['nodes' => '"nodes" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testPreservesUserCteThatOwnsThePhysicalTableName(): void
+    {
+        $sql = 'WITH users AS (SELECT 1 AS id), filtered AS (SELECT * FROM users) SELECT * FROM filtered';
+
+        self::assertSame(
+            $sql,
+            (new CteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 2 AS id)']),
+        );
+    }
+
+    public function testInjectsReferencedBaseTableBeforeUserCtes(): void
+    {
+        $sql = 'WITH filtered AS (SELECT * FROM users WHERE active) SELECT * FROM filtered';
+
+        self::assertSame(
+            "WITH \"users\" AS (SELECT 1 AS id),\n filtered AS (SELECT * FROM users WHERE active) SELECT * FROM filtered",
+            (new CteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testDoesNotTreatLiteralsCommentsOrIdentifierPrefixesAsReferences(): void
+    {
+        $sql = "SELECT 'users', superusers.id /* users */ FROM superusers";
+
+        self::assertSame(
+            $sql,
+            (new CteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testReadsQuotedAndColumnListedCteNames(): void
+    {
+        self::assertSame(
+            ['first', 'second'],
+            (new CteShadowComposer())->declaredCteNames('WITH "first"(id) AS MATERIALIZED (SELECT 1), second AS (SELECT 2) SELECT * FROM second'),
+        );
+    }
+
+    public function testCarriesTheCompleteCteHeaderOntoARewrittenDmlProjection(): void
+    {
+        $sql = 'WITH first AS (SELECT 1), second(id) AS (SELECT * FROM first) UPDATE users SET id = 2';
+
+        self::assertSame(
+            "WITH first AS (SELECT 1), second(id) AS (SELECT * FROM first)\nSELECT 2 AS id FROM users",
+            (new CteShadowComposer())->carryPrefix($sql, 'SELECT 2 AS id FROM users'),
+        );
+    }
+
+    public function testMergesProjectionCtesIntoTheOriginalHeader(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1),\nprojected AS (SELECT * FROM source)\nSELECT * FROM projected",
+            (new CteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) INSERT INTO target SELECT * FROM source',
+                'WITH projected AS (SELECT * FROM source) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testOrdersShadowCtesBeforeUserCtesThatReadThem(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id),\nchosen AS (SELECT id FROM users)\nSELECT * FROM users WHERE id IN (SELECT id FROM chosen)",
+            (new CteShadowComposer())->carryPrefix(
+                'WITH chosen AS (SELECT id FROM users) UPDATE users SET id = 2',
+                'WITH users AS (SELECT 1 AS id) SELECT * FROM users WHERE id IN (SELECT id FROM chosen)',
+            ),
+        );
+    }
+
+    public function testExtractsTheStatementFollowingTheCteHeader(): void
+    {
+        self::assertSame(
+            'DELETE FROM users WHERE id IN (SELECT id FROM chosen)',
+            (new CteShadowComposer())->statementSql('WITH chosen AS (SELECT 1 AS id) DELETE FROM users WHERE id IN (SELECT id FROM chosen)'),
+        );
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Rewrite/CteShadowComposerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/CteShadowComposerTest.php
@@ -103,4 +103,119 @@ final class CteShadowComposerTest extends TestCase
             (new CteShadowComposer())->statementSql('WITH chosen AS (SELECT 1 AS id) DELETE FROM users WHERE id IN (SELECT id FROM chosen)'),
         );
     }
+
+    public function testComposesAReferencedShadowWithoutAnExistingWithClause(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id)\nSELECT * FROM users",
+            (new CteShadowComposer())->compose(
+                'SELECT * FROM users',
+                ['users' => 'users AS (SELECT 1 AS id)'],
+            ),
+        );
+    }
+
+    public function testSkipsEntriesIndependentlyAndMatchesDeclaredNamesCaseInsensitively(): void
+    {
+        $composer = new CteShadowComposer();
+
+        self::assertSame(
+            "WITH orders AS (SELECT 2 AS id)\nSELECT * FROM orders",
+            $composer->compose(
+                'SELECT * FROM orders',
+                [
+                    'users' => 'users AS (SELECT 1 AS id)',
+                    'orders' => 'orders AS (SELECT 2 AS id)',
+                ],
+            ),
+        );
+        $declared = 'WITH users AS (SELECT 1 AS id) SELECT * FROM users';
+        self::assertSame(
+            $declared,
+            $composer->compose($declared, ['Users' => 'Users AS (SELECT 2 AS id)']),
+        );
+    }
+
+    public function testHandlesAWithTokenWithoutFollowingHeaderTokens(): void
+    {
+        self::assertSame(
+            "WITH shadow AS (SELECT 1),\n",
+            (new CteShadowComposer())->compose('WITH', ['WITH' => 'shadow AS (SELECT 1)']),
+        );
+    }
+
+    public function testCarriesAnEmptyRewriteWithoutDereferencingMissingTokens(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1)\n",
+            (new CteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) UPDATE users SET id = 2',
+                '',
+            ),
+        );
+    }
+
+    public function testMergesRecursiveHeadersAndPreservesLeadingComments(): void
+    {
+        self::assertSame(
+            "/* lead */ WITH RECURSIVE projected AS (SELECT 2),\noriginal AS (SELECT 1)\nSELECT * FROM projected",
+            (new CteShadowComposer())->carryPrefix(
+                '/* lead */ WITH RECURSIVE original AS (SELECT 1) UPDATE users SET id = 2',
+                'WITH projected AS (SELECT 2) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testRecognizesRecursiveRewrittenHeaderDependencies(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1),\nprojected AS (SELECT * FROM source)\nSELECT * FROM projected",
+            (new CteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) INSERT INTO target SELECT * FROM source',
+                'WITH RECURSIVE projected AS (SELECT * FROM source) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testParsesRecursiveMaterializationAndNestedCteBodies(): void
+    {
+        $sql = 'WITH RECURSIVE "FIRST"(id) AS MATERIALIZED (SELECT (1)), second AS NOT MATERIALIZED (SELECT id FROM "FIRST") DELETE FROM target';
+        $composer = new CteShadowComposer();
+
+        self::assertSame(['first', 'second'], $composer->declaredCteNames($sql));
+        self::assertSame('DELETE FROM target', $composer->statementSql($sql));
+    }
+
+    public function testHandlesNonHeadersIncompleteHeadersAndEmptyInput(): void
+    {
+        $composer = new CteShadowComposer();
+
+        self::assertSame([], $composer->declaredCteNames(''));
+        self::assertSame('SELECT 1', $composer->statementSql('SELECT 1'));
+        self::assertSame([], $composer->declaredCteNames('WITH only_name'));
+        self::assertSame(
+            'WITH x AS (SELECT 1)',
+            $composer->statementSql('WITH x AS (SELECT 1)'),
+        );
+        self::assertSame([], $composer->declaredCteNames('WITH x AS'));
+        self::assertSame([], $composer->declaredCteNames('WITH x AS NOT'));
+        self::assertSame([], $composer->declaredCteNames('WITH x AS (SELECT 1'));
+        self::assertSame(
+            ['first'],
+            $composer->declaredCteNames('WITH first AS (SELECT 1), broken'),
+        );
+    }
+
+    public function testUnquotesEmptyAndEscapedCteIdentifiers(): void
+    {
+        $composer = new CteShadowComposer();
+
+        self::assertSame([''], $composer->declaredCteNames('WITH "" AS (SELECT 1) SELECT 1'));
+        self::assertSame(
+            ['a"b', 'c`d'],
+            $composer->declaredCteNames(
+                'WITH "a""b" AS (SELECT 1), `c``d` AS (SELECT 2) SELECT 1',
+            ),
+        );
+    }
 }

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenDialectTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenDialectTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sql;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Sql\SqlTokenDialect;
+
+#[CoversClass(SqlTokenDialect::class)]
+final class SqlTokenDialectTest extends TestCase
+{
+    public function testDialectsHaveStableValues(): void
+    {
+        self::assertSame('standard', SqlTokenDialect::Standard->value);
+        self::assertSame('mysql', SqlTokenDialect::MySql->value);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -8,11 +8,13 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqlTokenStream::class)]
 #[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenDialect::class)]
 #[UsesClass(SqlTokenKind::class)]
 final class SqlTokenStreamTest extends TestCase
 {
@@ -156,6 +158,26 @@ final class SqlTokenStreamTest extends TestCase
             array_map(
                 static fn (SqlToken $token): array => [$token->kind, $token->text],
                 SqlTokenStream::tokenize("prefix --\nnext")->tokens(),
+            ),
+        );
+    }
+
+    public function testMySqlHashCommentsRemainDialectSpecific(): void
+    {
+        $sql = "# SELECT hidden\nDELETE FROM users WHERE payload #>> '$.name' = 'Alice'";
+
+        self::assertSame(
+            ['DELETE', 'FROM', 'users', 'WHERE', 'payload'],
+            array_map(
+                static fn (SqlToken $token): string => $token->text,
+                SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->significantTokens(),
+            ),
+        );
+        self::assertSame(
+            ['#', 'SELECT', 'hidden', 'DELETE', 'FROM', 'users', 'WHERE', 'payload', '#', '>', '>', "'$.name'", '=', "'Alice'"],
+            array_map(
+                static fn (SqlToken $token): string => $token->text,
+                SqlTokenStream::tokenize($sql)->significantTokens(),
             ),
         );
     }

--- a/packages/ztd-query-mysql/src/MySqlCteShadowComposer.php
+++ b/packages/ztd-query-mysql/src/MySqlCteShadowComposer.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class MySqlCteShadowComposer
+{
+    private readonly SqlTokenDialect $dialect;
+
+    public function __construct()
+    {
+        $this->dialect = SqlTokenDialect::MySql;
+    }
+
+    /**
+     * @param array<string, string> $tableCtes
+     */
+    public function compose(string $sql, array $tableCtes): string
+    {
+        $declared = array_fill_keys($this->declaredCteNames($sql), true);
+        $ctes = [];
+        foreach ($tableCtes as $table => $cte) {
+            $normalized = strtolower($table);
+            if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
+                continue;
+            }
+            $ctes[] = $cte;
+        }
+
+        if ($ctes === []) {
+            return $sql;
+        }
+
+        $tokens = SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens();
+        $with = $tokens[0] ?? null;
+        if ($with === null || !$with->isKeyword('WITH')) {
+            return 'WITH ' . implode(",\n", $ctes) . "\n" . $sql;
+        }
+
+        $insertionToken = $with;
+        $next = $tokens[1] ?? null;
+        if ($next !== null && $next->isTopLevel() && $next->isKeyword('RECURSIVE')) {
+            $insertionToken = $next;
+        }
+
+        return substr_replace(
+            $sql,
+            ' ' . implode(",\n", $ctes) . ",\n",
+            $insertionToken->endOffset(),
+            0,
+        );
+    }
+
+    /** @return list<string> */
+    public function declaredCteNames(string $sql): array
+    {
+        return $this->parseHeader($sql)['names'];
+    }
+
+    public function carryPrefix(string $originalSql, string $rewrittenStatement): string
+    {
+        $header = $this->parseHeader($originalSql);
+        if ($header['statementOffset'] === null) {
+            return $rewrittenStatement;
+        }
+
+        $prefix = rtrim(substr($originalSql, 0, $header['statementOffset']));
+
+        $rewrittenTokens = SqlTokenStream::tokenize($rewrittenStatement, $this->dialect)->significantTokens();
+        $rewrittenWith = $rewrittenTokens[0] ?? null;
+        if ($rewrittenWith !== null && $rewrittenWith->isKeyword('WITH')) {
+            $rewrittenHeader = $this->parseHeader($rewrittenStatement);
+            $rewrittenStatementOffset = $rewrittenHeader['statementOffset'];
+            if ($rewrittenStatementOffset === null) {
+                return $prefix . "\n" . $rewrittenStatement;
+            }
+
+            $contentToken = $rewrittenWith;
+            $rewrittenNext = $rewrittenTokens[1] ?? null;
+            if ($rewrittenNext !== null && $rewrittenNext->isKeyword('RECURSIVE')) {
+                $contentToken = $rewrittenNext;
+            }
+
+            $rewrittenBody = trim(substr(
+                $rewrittenStatement,
+                $contentToken->endOffset(),
+                $rewrittenStatementOffset - $contentToken->endOffset(),
+            ));
+            $rewrittenTail = substr($rewrittenStatement, $rewrittenStatementOffset);
+            if ($this->referencesAnyIdentifier($rewrittenBody, $header['names'])) {
+                return $prefix . ",\n" . $rewrittenBody . "\n" . $rewrittenTail;
+            }
+
+            $originalTokens = SqlTokenStream::tokenize($originalSql, $this->dialect)->significantTokens();
+            $originalWith = $originalTokens[0];
+            $originalContentToken = $originalWith;
+            $recursive = false;
+            $originalNext = $originalTokens[1] ?? null;
+            if ($originalNext !== null && $originalNext->isKeyword('RECURSIVE')) {
+                $originalContentToken = $originalNext;
+                $recursive = true;
+            }
+            $originalBody = trim(substr(
+                $originalSql,
+                $originalContentToken->endOffset(),
+                $header['statementOffset'] - $originalContentToken->endOffset(),
+            ));
+            $leading = substr($originalSql, 0, $originalWith->offset);
+
+            return $leading
+                . 'WITH '
+                . ($recursive ? 'RECURSIVE ' : '')
+                . $rewrittenBody
+                . ",\n"
+                . $originalBody
+                . "\n"
+                . $rewrittenTail;
+        }
+
+        return $prefix . "\n" . $rewrittenStatement;
+    }
+
+    public function statementSql(string $sql): string
+    {
+        $offset = $this->parseHeader($sql)['statementOffset'];
+
+        return $offset === null ? $sql : substr($sql, $offset);
+    }
+
+    /** @return array{names: list<string>, statementOffset: int|null} */
+    private function parseHeader(string $sql): array
+    {
+        $tokens = [];
+        foreach (SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens() as $token) {
+            if ($token->isTopLevel()) {
+                $tokens[] = $token;
+            }
+        }
+        if (($tokens[0] ?? null)?->isKeyword('WITH') !== true) {
+            return ['names' => [], 'statementOffset' => null];
+        }
+
+        $index = 1;
+        if (($tokens[$index] ?? null)?->isKeyword('RECURSIVE') === true) {
+            $index++;
+        }
+
+        $names = [];
+        while (isset($tokens[$index])) {
+            $name = $this->identifierName($tokens[$index]);
+            if ($name === null) {
+                break;
+            }
+            $index++;
+
+            $asIndex = $this->findAsIndex($tokens, $index);
+            $index = ($asIndex ?? count($tokens)) + 1;
+
+            if (($tokens[$index] ?? null)?->isKeyword('NOT') === true) {
+                $index++;
+            }
+            if (($tokens[$index] ?? null)?->isKeyword('MATERIALIZED') === true) {
+                $index++;
+            }
+
+            if (!$this->isSymbol($tokens[$index] ?? null, '(')
+                || !$this->isSymbol($tokens[$index + 1] ?? null, ')')
+            ) {
+                return ['names' => $names, 'statementOffset' => null];
+            }
+            $names[] = strtolower($name);
+            $index += 2;
+
+            $separator = $tokens[$index] ?? null;
+            if (!$this->isSymbol($separator, ',')) {
+                break;
+            }
+            $index++;
+        }
+
+        $statement = $tokens[$index] ?? null;
+
+        return [
+            'names' => $names,
+            'statementOffset' => $statement?->offset,
+        ];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private function findAsIndex(array $tokens, int $start): ?int
+    {
+        for ($index = $start; isset($tokens[$index]); $index++) {
+            $token = $tokens[$index];
+            if ($token->isKeyword('AS')) {
+                return $index;
+            }
+            if ($token->kind === SqlTokenKind::Word) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        return $token instanceof SqlToken
+            && $token->kind === SqlTokenKind::Symbol
+            && $token->text === $symbol;
+    }
+
+    private function referencesIdentifier(string $sql, string $identifier): bool
+    {
+        foreach (SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens() as $token) {
+            $candidate = $this->identifierName($token);
+            if ($candidate !== null && strcasecmp($candidate, $identifier) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param list<string> $identifiers */
+    private function referencesAnyIdentifier(string $sql, array $identifiers): bool
+    {
+        foreach ($identifiers as $identifier) {
+            if ($this->referencesIdentifier($sql, $identifier)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function identifierName(SqlToken $token): ?string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+        if ($token->kind !== SqlTokenKind::QuotedIdentifier || strlen($token->text) < 2) {
+            return null;
+        }
+
+        $quote = $token->text[0];
+        $inner = substr($token->text, 1, -1);
+
+        return str_replace($quote . $quote, $quote, $inner);
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlParser.php
+++ b/packages/ztd-query-mysql/src/MySqlParser.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Token;
 use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\SqlTokenDialect;
 
 /**
  * MySQL parser implementation backed by phpMyAdmin SQL parser.
@@ -43,7 +44,7 @@ final class MySqlParser
     /** @return list<string> */
     public function splitStatements(string $sql): array
     {
-        return SqlTokenStream::tokenize($sql)->splitStatements();
+        return SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->splitStatements();
     }
 
     private function normalizeOptionalInsertInto(string $sql): string

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -139,12 +139,6 @@ final class MySqlRewriter implements SqlRewriter
             throw new UnsupportedSqlException($sql, 'Statement type not supported');
         }
 
-        $mutationStatement = $statement;
-        if ($statement instanceof WithStatement && $kind !== QueryKind::READ) {
-            $mainStatements = $this->parser->parse($this->cteComposer->statementSql($sql));
-            $mutationStatement = $mainStatements[0] ?? $statement;
-        }
-
         $tableContext = $this->buildTableContext();
 
         if ($kind === QueryKind::READ) {
@@ -175,6 +169,12 @@ final class MySqlRewriter implements SqlRewriter
             }
 
             return new RewritePlan($this->emptyResultSelect(), QueryKind::DDL_SIMULATED, $mutation);
+        }
+
+        $mutationStatement = $statement;
+        if ($statement instanceof WithStatement) {
+            $mainStatements = $this->parser->parse($this->cteComposer->statementSql($sql));
+            $mutationStatement = $mainStatements[0] ?? $statement;
         }
 
         $mutation = $this->mutationResolver->resolve($sql, $mutationStatement, $kind);

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -7,6 +7,7 @@ namespace ZtdQuery\Platform\MySql;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Rewrite\MultiRewritePlan;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -34,6 +35,7 @@ final class MySqlRewriter implements SqlRewriter
     private MySqlTransformer $transformer;
     private MySqlMutationResolver $mutationResolver;
     private MySqlParser $parser;
+    private CteShadowComposer $cteComposer;
 
     public function __construct(
         MySqlQueryGuard $guard,
@@ -49,6 +51,7 @@ final class MySqlRewriter implements SqlRewriter
         $this->transformer = $transformer;
         $this->mutationResolver = $mutationResolver;
         $this->parser = $parser;
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**
@@ -136,6 +139,12 @@ final class MySqlRewriter implements SqlRewriter
             throw new UnsupportedSqlException($sql, 'Statement type not supported');
         }
 
+        $mutationStatement = $statement;
+        if ($statement instanceof WithStatement && $kind !== QueryKind::READ) {
+            $mainStatements = $this->parser->parse($this->cteComposer->statementSql($sql));
+            $mutationStatement = $mainStatements[0] ?? $statement;
+        }
+
         $tableContext = $this->buildTableContext();
 
         if ($kind === QueryKind::READ) {
@@ -168,7 +177,7 @@ final class MySqlRewriter implements SqlRewriter
             return new RewritePlan($this->emptyResultSelect(), QueryKind::DDL_SIMULATED, $mutation);
         }
 
-        $mutation = $this->mutationResolver->resolve($sql, $statement, $kind);
+        $mutation = $this->mutationResolver->resolve($sql, $mutationStatement, $kind);
 
         if ($statement instanceof TruncateStatement) {
             return new RewritePlan($this->emptyResultSelect(), QueryKind::WRITE_SIMULATED, $mutation);

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -7,7 +7,7 @@ namespace ZtdQuery\Platform\MySql;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Rewrite\MultiRewritePlan;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -35,7 +35,7 @@ final class MySqlRewriter implements SqlRewriter
     private MySqlTransformer $transformer;
     private MySqlMutationResolver $mutationResolver;
     private MySqlParser $parser;
-    private CteShadowComposer $cteComposer;
+    private MySqlCteShadowComposer $cteComposer;
 
     public function __construct(
         MySqlQueryGuard $guard,
@@ -51,7 +51,7 @@ final class MySqlRewriter implements SqlRewriter
         $this->transformer = $transformer;
         $this->mutationResolver = $mutationResolver;
         $this->parser = $parser;
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new MySqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/MySqlTypeSemantics.php
+++ b/packages/ztd-query-mysql/src/MySqlTypeSemantics.php
@@ -8,6 +8,7 @@ use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Sql\SqlToken;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\SqlTokenDialect;
 
 /**
  * Restores native operators that cannot be represented by a CTE column cast.
@@ -24,7 +25,7 @@ final class MySqlTypeSemantics
     public function rewrite(string $sql, array $tables): string
     {
         [$qualified, $unqualified] = $this->enumColumns($tables);
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $tokens = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->significantTokens();
         $edits = $this->comparisonEdits($sql, $tokens, $qualified, $unqualified);
         foreach ($this->orderByEdits($sql, $tokens, $qualified, $unqualified) as $key => $edit) {
             $edits[$key] = $edit;
@@ -245,7 +246,7 @@ final class MySqlTypeSemantics
         }
         $inner = substr(trim($nativeType), $open + 1, -1);
         $members = [];
-        foreach (SqlTokenStream::tokenize($inner)->splitTopLevel() as $literal) {
+        foreach (SqlTokenStream::tokenize($inner, SqlTokenDialect::MySql)->splitTopLevel() as $literal) {
             if (strlen($literal) < 2) {
                 return [];
             }

--- a/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
@@ -27,11 +27,10 @@ final class DeleteTransformer implements SqlTransformer
     public function __construct(
         MySqlParser $parser,
         SelectTransformer $selectTransformer,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -22,7 +22,7 @@ final class DeleteTransformer implements SqlTransformer
 {
     private MySqlParser $parser;
     private SelectTransformer $selectTransformer;
-    private CteShadowComposer $cteComposer;
+    private MySqlCteShadowComposer $cteComposer;
 
     public function __construct(
         MySqlParser $parser,
@@ -30,7 +30,7 @@ final class DeleteTransformer implements SqlTransformer
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new MySqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -21,11 +22,16 @@ final class DeleteTransformer implements SqlTransformer
 {
     private MySqlParser $parser;
     private SelectTransformer $selectTransformer;
+    private CteShadowComposer $cteComposer;
 
-    public function __construct(MySqlParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        MySqlParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CteShadowComposer $cteComposer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -53,7 +59,10 @@ final class DeleteTransformer implements SqlTransformer
 
         $projection = $this->buildProjection($statement, $sql, $columnNames);
 
-        return $this->selectTransformer->transform($projection['sql'], $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $projection['sql']),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
@@ -12,7 +12,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -30,7 +30,7 @@ final class InsertTransformer implements SqlTransformer
     private InsertRowRenderer $rowRenderer;
     private ShadowIdentityAllocator $identityAllocator;
     private InsertSelectRenderer $insertSelectRenderer;
-    private CteShadowComposer $cteComposer;
+    private MySqlCteShadowComposer $cteComposer;
 
     public function __construct(
         MySqlParser $parser,
@@ -43,7 +43,7 @@ final class InsertTransformer implements SqlTransformer
         $this->rowRenderer = new InsertRowRenderer();
         $this->identityAllocator = new ShadowIdentityAllocator();
         $this->insertSelectRenderer = new InsertSelectRenderer();
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new MySqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
@@ -12,6 +12,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -29,6 +30,7 @@ final class InsertTransformer implements SqlTransformer
     private InsertRowRenderer $rowRenderer;
     private ShadowIdentityAllocator $identityAllocator;
     private InsertSelectRenderer $insertSelectRenderer;
+    private CteShadowComposer $cteComposer;
 
     public function __construct(
         MySqlParser $parser,
@@ -41,6 +43,7 @@ final class InsertTransformer implements SqlTransformer
         $this->rowRenderer = new InsertRowRenderer();
         $this->identityAllocator = new ShadowIdentityAllocator();
         $this->insertSelectRenderer = new InsertSelectRenderer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**
@@ -86,7 +89,10 @@ final class InsertTransformer implements SqlTransformer
             $existingRows,
         );
 
-        return $this->selectTransformer->transform($selectSql, $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $selectSql),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/MySqlSelectListAliaser.php
+++ b/packages/ztd-query-mysql/src/Transformer/MySqlSelectListAliaser.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\MySql\Transformer;
 
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
@@ -35,12 +36,12 @@ final class MySqlSelectListAliaser
         foreach (self::SELECT_LIST_TERMINATORS as $terminator) {
             $endKeywords[] = [$terminator];
         }
-        $selectList = SqlTokenStream::tokenize($sql)->topLevelClause(['SELECT'], $endKeywords);
+        $selectList = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->topLevelClause(['SELECT'], $endKeywords);
         if ($selectList === null) {
             return null;
         }
 
-        $expressions = SqlTokenStream::tokenize($selectList)->splitTopLevel();
+        $expressions = SqlTokenStream::tokenize($selectList, SqlTokenDialect::MySql)->splitTopLevel();
         if ($expressions === [] || $this->containsWildcard($expressions)) {
             return null;
         }
@@ -50,7 +51,7 @@ final class MySqlSelectListAliaser
 
     public function alias(string $sql): string
     {
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $tokens = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->significantTokens();
         $select = null;
         $end = null;
         foreach ($tokens as $token) {
@@ -75,7 +76,7 @@ final class MySqlSelectListAliaser
 
         $listEnd = $end ?? strlen($sql);
         $listSql = substr($sql, $select->endOffset(), $listEnd - $select->endOffset());
-        $expressions = SqlTokenStream::tokenize($listSql)->splitTopLevel();
+        $expressions = SqlTokenStream::tokenize($listSql, SqlTokenDialect::MySql)->splitTopLevel();
         if ($expressions === [] || $this->containsWildcard($expressions)) {
             return $sql;
         }
@@ -107,7 +108,7 @@ final class MySqlSelectListAliaser
     private function containsWildcard(array $expressions): bool
     {
         foreach ($expressions as $expression) {
-            $tokens = SqlTokenStream::tokenize($expression)->significantTokens();
+            $tokens = SqlTokenStream::tokenize($expression, SqlTokenDialect::MySql)->significantTokens();
             if ($tokens === []) {
                 return true;
             }
@@ -127,7 +128,7 @@ final class MySqlSelectListAliaser
     private function removeModifiers(string $expression): array
     {
         $end = null;
-        foreach (SqlTokenStream::tokenize($expression)->significantTokens() as $token) {
+        foreach (SqlTokenStream::tokenize($expression, SqlTokenDialect::MySql)->significantTokens() as $token) {
             if (!$this->isModifier($token)) {
                 break;
             }
@@ -157,7 +158,7 @@ final class MySqlSelectListAliaser
 
     private function withoutExplicitAlias(string $expression): string
     {
-        $tokens = SqlTokenStream::tokenize($expression)->significantTokens();
+        $tokens = SqlTokenStream::tokenize($expression, SqlTokenDialect::MySql)->significantTokens();
         array_pop($tokens);
         foreach (array_reverse($tokens) as $token) {
             if ($token->isTopLevel() && $token->isKeyword('AS')) {

--- a/packages/ztd-query-mysql/src/Transformer/MySqlTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/MySqlTransformer.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\SqlParser\Statements\WithStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Rewrite\SqlTransformer;
+use ZtdQuery\Rewrite\CteShadowComposer;
 
 /**
  * Composite SQL transformer for MySQL.
@@ -28,6 +29,7 @@ final class MySqlTransformer implements SqlTransformer
     private UpdateTransformer $updateTransformer;
     private DeleteTransformer $deleteTransformer;
     private ReplaceTransformer $replaceTransformer;
+    private CteShadowComposer $cteComposer;
 
     public function __construct(
         MySqlParser $parser,
@@ -35,7 +37,8 @@ final class MySqlTransformer implements SqlTransformer
         InsertTransformer $insertTransformer,
         UpdateTransformer $updateTransformer,
         DeleteTransformer $deleteTransformer,
-        ReplaceTransformer $replaceTransformer
+        ReplaceTransformer $replaceTransformer,
+        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
@@ -43,6 +46,7 @@ final class MySqlTransformer implements SqlTransformer
         $this->updateTransformer = $updateTransformer;
         $this->deleteTransformer = $deleteTransformer;
         $this->replaceTransformer = $replaceTransformer;
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -57,7 +61,24 @@ final class MySqlTransformer implements SqlTransformer
 
         $statement = $statements[0];
 
-        if ($statement instanceof SelectStatement || $statement instanceof WithStatement) {
+        if ($statement instanceof WithStatement) {
+            $statementSql = $this->cteComposer->statementSql($sql);
+            $innerStatements = $this->parser->parse($statementSql);
+            $inner = $innerStatements[0] ?? null;
+            if ($inner instanceof InsertStatement) {
+                return $this->cteComposer->carryPrefix($sql, $this->insertTransformer->transform($statementSql, $tables));
+            }
+            if ($inner instanceof UpdateStatement) {
+                return $this->cteComposer->carryPrefix($sql, $this->updateTransformer->transform($statementSql, $tables));
+            }
+            if ($inner instanceof DeleteStatement) {
+                return $this->cteComposer->carryPrefix($sql, $this->deleteTransformer->transform($statementSql, $tables));
+            }
+
+            return $this->selectTransformer->transform($sql, $tables);
+        }
+
+        if ($statement instanceof SelectStatement) {
             return $this->selectTransformer->transform($sql, $tables);
         }
 

--- a/packages/ztd-query-mysql/src/Transformer/MySqlTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/MySqlTransformer.php
@@ -38,7 +38,6 @@ final class MySqlTransformer implements SqlTransformer
         UpdateTransformer $updateTransformer,
         DeleteTransformer $deleteTransformer,
         ReplaceTransformer $replaceTransformer,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
@@ -46,7 +45,7 @@ final class MySqlTransformer implements SqlTransformer
         $this->updateTransformer = $updateTransformer;
         $this->deleteTransformer = $deleteTransformer;
         $this->replaceTransformer = $replaceTransformer;
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/MySqlTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/MySqlTransformer.php
@@ -13,7 +13,7 @@ use PhpMyAdmin\SqlParser\Statements\WithStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Rewrite\SqlTransformer;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 
 /**
  * Composite SQL transformer for MySQL.
@@ -29,7 +29,7 @@ final class MySqlTransformer implements SqlTransformer
     private UpdateTransformer $updateTransformer;
     private DeleteTransformer $deleteTransformer;
     private ReplaceTransformer $replaceTransformer;
-    private CteShadowComposer $cteComposer;
+    private MySqlCteShadowComposer $cteComposer;
 
     public function __construct(
         MySqlParser $parser,
@@ -45,7 +45,7 @@ final class MySqlTransformer implements SqlTransformer
         $this->updateTransformer = $updateTransformer;
         $this->deleteTransformer = $deleteTransformer;
         $this->replaceTransformer = $replaceTransformer;
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new MySqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -10,7 +10,7 @@ use ZtdQuery\Platform\MySql\MySqlTypeSemantics;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -27,7 +27,7 @@ final class SelectTransformer implements SqlTransformer
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
     private MySqlTypeSemantics $typeSemantics;
-    private CteShadowComposer $cteComposer;
+    private MySqlCteShadowComposer $cteComposer;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -38,7 +38,7 @@ final class SelectTransformer implements SqlTransformer
         $this->quoter = $quoter ?? new MySqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\MySql\MySqlValueRenderer($this->castRenderer);
         $this->typeSemantics = new MySqlTypeSemantics();
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new MySqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -10,6 +10,7 @@ use ZtdQuery\Platform\MySql\MySqlTypeSemantics;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -26,6 +27,7 @@ final class SelectTransformer implements SqlTransformer
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
     private MySqlTypeSemantics $typeSemantics;
+    private CteShadowComposer $cteComposer;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -36,6 +38,7 @@ final class SelectTransformer implements SqlTransformer
         $this->quoter = $quoter ?? new MySqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\MySql\MySqlValueRenderer($this->castRenderer);
         $this->typeSemantics = new MySqlTypeSemantics();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**
@@ -48,10 +51,6 @@ final class SelectTransformer implements SqlTransformer
 
         $ctes = [];
         foreach ($tables as $tableName => $tableContext) {
-            if (stripos($sql, $tableName) === false) {
-                continue;
-            }
-
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];
             $columnTypes = $tableContext['columnTypes'];
@@ -71,20 +70,10 @@ final class SelectTransformer implements SqlTransformer
                 continue;
             }
 
-            $ctes[] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
+            $ctes[$tableName] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
         }
 
-        if ($ctes === []) {
-            return $sql;
-        }
-
-        $cteString = implode(",\n", $ctes);
-        $pattern = '/^(\s*(?:(?:\/\*.*?\*\/)|(?:--.*?\n)|(?:#.*?\n)|\s)*)WITH\b/is';
-        if (preg_match($pattern, $sql) === 1) {
-            return (string) preg_replace($pattern, '$1WITH ' . $cteString . ",\n", $sql, 1);
-        }
-
-        return "WITH $cteString\n$sql";
+        return $this->cteComposer->compose($sql, $ctes);
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -21,7 +21,7 @@ final class UpdateTransformer implements SqlTransformer
 {
     private MySqlParser $parser;
     private SelectTransformer $selectTransformer;
-    private CteShadowComposer $cteComposer;
+    private MySqlCteShadowComposer $cteComposer;
 
     public function __construct(
         MySqlParser $parser,
@@ -29,7 +29,7 @@ final class UpdateTransformer implements SqlTransformer
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new MySqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -26,11 +26,10 @@ final class UpdateTransformer implements SqlTransformer
     public function __construct(
         MySqlParser $parser,
         SelectTransformer $selectTransformer,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -20,11 +21,16 @@ final class UpdateTransformer implements SqlTransformer
 {
     private MySqlParser $parser;
     private SelectTransformer $selectTransformer;
+    private CteShadowComposer $cteComposer;
 
-    public function __construct(MySqlParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        MySqlParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CteShadowComposer $cteComposer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -57,7 +63,10 @@ final class UpdateTransformer implements SqlTransformer
 
         $projection = $this->buildProjection($statement, $columns);
 
-        return $this->selectTransformer->transform($projection['sql'], $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $projection['sql']),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
+
+#[CoversClass(MySqlCteShadowComposer::class)]
+final class MySqlCteShadowComposerTest extends TestCase
+{
+    public function testAddsShadowsAfterRecursiveModifier(): void
+    {
+        $sql = 'WITH RECURSIVE tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree';
+
+        self::assertSame(
+            "WITH RECURSIVE \"nodes\" AS (SELECT 1 AS id),\n tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree",
+            (new MySqlCteShadowComposer())->compose($sql, ['nodes' => '"nodes" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testPreservesUserCteThatOwnsThePhysicalTableName(): void
+    {
+        $sql = 'WITH users AS (SELECT 1 AS id), filtered AS (SELECT * FROM users) SELECT * FROM filtered';
+
+        self::assertSame(
+            $sql,
+            (new MySqlCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 2 AS id)']),
+        );
+    }
+
+    public function testInjectsReferencedBaseTableBeforeUserCtes(): void
+    {
+        $sql = 'WITH filtered AS (SELECT * FROM users WHERE active) SELECT * FROM filtered';
+
+        self::assertSame(
+            "WITH \"users\" AS (SELECT 1 AS id),\n filtered AS (SELECT * FROM users WHERE active) SELECT * FROM filtered",
+            (new MySqlCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testDoesNotTreatLiteralsCommentsOrIdentifierPrefixesAsReferences(): void
+    {
+        $sql = "SELECT 'users', superusers.id /* users */ FROM superusers";
+
+        self::assertSame(
+            $sql,
+            (new MySqlCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testReadsQuotedAndColumnListedCteNames(): void
+    {
+        self::assertSame(
+            ['first', 'second'],
+            (new MySqlCteShadowComposer())->declaredCteNames('WITH "first"(id) AS MATERIALIZED (SELECT 1), second AS (SELECT 2) SELECT * FROM second'),
+        );
+    }
+
+    public function testCarriesTheCompleteCteHeaderOntoARewrittenDmlProjection(): void
+    {
+        $sql = 'WITH first AS (SELECT 1), second(id) AS (SELECT * FROM first) UPDATE users SET id = 2';
+
+        self::assertSame(
+            "WITH first AS (SELECT 1), second(id) AS (SELECT * FROM first)\nSELECT 2 AS id FROM users",
+            (new MySqlCteShadowComposer())->carryPrefix($sql, 'SELECT 2 AS id FROM users'),
+        );
+    }
+
+    public function testMergesProjectionCtesIntoTheOriginalHeader(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1),\nprojected AS (SELECT * FROM source)\nSELECT * FROM projected",
+            (new MySqlCteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) INSERT INTO target SELECT * FROM source',
+                'WITH projected AS (SELECT * FROM source) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testOrdersShadowCtesBeforeUserCtesThatReadThem(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id),\nchosen AS (SELECT id FROM users)\nSELECT * FROM users WHERE id IN (SELECT id FROM chosen)",
+            (new MySqlCteShadowComposer())->carryPrefix(
+                'WITH chosen AS (SELECT id FROM users) UPDATE users SET id = 2',
+                'WITH users AS (SELECT 1 AS id) SELECT * FROM users WHERE id IN (SELECT id FROM chosen)',
+            ),
+        );
+    }
+
+    public function testExtractsTheStatementFollowingTheCteHeader(): void
+    {
+        self::assertSame(
+            'DELETE FROM users WHERE id IN (SELECT id FROM chosen)',
+            (new MySqlCteShadowComposer())->statementSql('WITH chosen AS (SELECT 1 AS id) DELETE FROM users WHERE id IN (SELECT id FROM chosen)'),
+        );
+    }
+
+    public function testExtractsMySqlDmlAfterHashCommentsInTheCteHeader(): void
+    {
+        $sql = "WITH RECURSIVE # modifier\nchosen AS (SELECT 1 AS id) # body\nDELETE FROM users WHERE id IN (SELECT id FROM chosen)";
+
+        self::assertSame(
+            'DELETE FROM users WHERE id IN (SELECT id FROM chosen)',
+            (new MySqlCteShadowComposer())->statementSql($sql),
+        );
+    }
+
+    public function testComposesAReferencedShadowWithoutAnExistingWithClause(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id)\nSELECT * FROM users",
+            (new MySqlCteShadowComposer())->compose(
+                'SELECT * FROM users',
+                ['users' => 'users AS (SELECT 1 AS id)'],
+            ),
+        );
+    }
+
+    public function testSkipsEntriesIndependentlyAndMatchesDeclaredNamesCaseInsensitively(): void
+    {
+        $composer = new MySqlCteShadowComposer();
+
+        self::assertSame(
+            "WITH orders AS (SELECT 2 AS id)\nSELECT * FROM orders",
+            $composer->compose(
+                'SELECT * FROM orders',
+                [
+                    'users' => 'users AS (SELECT 1 AS id)',
+                    'orders' => 'orders AS (SELECT 2 AS id)',
+                ],
+            ),
+        );
+        $declared = 'WITH users AS (SELECT 1 AS id) SELECT * FROM users';
+        self::assertSame(
+            $declared,
+            $composer->compose($declared, ['Users' => 'Users AS (SELECT 2 AS id)']),
+        );
+    }
+
+    public function testHandlesAWithTokenWithoutFollowingHeaderTokens(): void
+    {
+        self::assertSame(
+            "WITH shadow AS (SELECT 1),\n",
+            (new MySqlCteShadowComposer())->compose('WITH', ['WITH' => 'shadow AS (SELECT 1)']),
+        );
+    }
+
+    public function testCarriesAnEmptyRewriteWithoutDereferencingMissingTokens(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1)\n",
+            (new MySqlCteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) UPDATE users SET id = 2',
+                '',
+            ),
+        );
+    }
+
+    public function testMergesRecursiveHeadersAndPreservesLeadingComments(): void
+    {
+        self::assertSame(
+            "/* lead */ WITH RECURSIVE projected AS (SELECT 2),\noriginal AS (SELECT 1)\nSELECT * FROM projected",
+            (new MySqlCteShadowComposer())->carryPrefix(
+                '/* lead */ WITH RECURSIVE original AS (SELECT 1) UPDATE users SET id = 2',
+                'WITH projected AS (SELECT 2) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testRecognizesRecursiveRewrittenHeaderDependencies(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1),\nprojected AS (SELECT * FROM source)\nSELECT * FROM projected",
+            (new MySqlCteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) INSERT INTO target SELECT * FROM source',
+                'WITH RECURSIVE projected AS (SELECT * FROM source) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testParsesRecursiveMaterializationAndNestedCteBodies(): void
+    {
+        $sql = 'WITH RECURSIVE "FIRST"(id) AS MATERIALIZED (SELECT (1)), second AS NOT MATERIALIZED (SELECT id FROM "FIRST") DELETE FROM target';
+        $composer = new MySqlCteShadowComposer();
+
+        self::assertSame(['first', 'second'], $composer->declaredCteNames($sql));
+        self::assertSame('DELETE FROM target', $composer->statementSql($sql));
+    }
+
+    public function testHandlesNonHeadersIncompleteHeadersAndEmptyInput(): void
+    {
+        $composer = new MySqlCteShadowComposer();
+
+        self::assertSame([], $composer->declaredCteNames(''));
+        self::assertSame('SELECT 1', $composer->statementSql('SELECT 1'));
+        self::assertSame([], $composer->declaredCteNames('WITH only_name'));
+        self::assertSame(
+            'WITH x AS (SELECT 1)',
+            $composer->statementSql('WITH x AS (SELECT 1)'),
+        );
+        self::assertSame([], $composer->declaredCteNames('WITH x AS'));
+        self::assertSame([], $composer->declaredCteNames('WITH x AS NOT'));
+        self::assertSame([], $composer->declaredCteNames('WITH x AS (SELECT 1'));
+        self::assertSame(
+            ['first'],
+            $composer->declaredCteNames('WITH first AS (SELECT 1), broken'),
+        );
+    }
+
+    public function testUnquotesEmptyAndEscapedCteIdentifiers(): void
+    {
+        $composer = new MySqlCteShadowComposer();
+
+        self::assertSame([''], $composer->declaredCteNames('WITH "" AS (SELECT 1) SELECT 1'));
+        self::assertSame(
+            ['a"b', 'c`d'],
+            $composer->declaredCteNames(
+                'WITH "a""b" AS (SELECT 1), `c``d` AS (SELECT 2) SELECT 1',
+            ),
+        );
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -46,6 +46,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(AlterTableMutation::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class MySqlMutationResolverTest extends TestCase
 {
     public function testResolveInsertReturnsInsertMutation(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -1634,6 +1634,33 @@ final class MySqlRewriterTest extends RewriterContractTest
         self::assertSame(QueryKind::READ, $plan->kind());
     }
 
+    public function testRewriteWithStatementInsertResolvesItsInnerMutation(): void
+    {
+        $shadowStore = new ShadowStore();
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $registry = new TableDefinitionRegistry();
+        $definition = $schemaParser->parse('CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255))');
+        self::assertNotNull($definition);
+        $registry->register('users', $definition);
+
+        $selectTransformer = new SelectTransformer();
+        $insertTransformer = new InsertTransformer($parser, $selectTransformer);
+        $updateTransformer = new UpdateTransformer($parser, $selectTransformer);
+        $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
+        $replaceTransformer = new ReplaceTransformer($parser, $selectTransformer);
+        $transformer = new MySqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer, $replaceTransformer);
+        $mutationResolver = new MySqlMutationResolver($shadowStore, $registry, $schemaParser, $updateTransformer, $deleteTransformer);
+        $rewriter = new MySqlRewriter(new MySqlQueryGuard($parser), $shadowStore, $registry, $transformer, $mutationResolver, $parser);
+
+        $plan = $rewriter->rewrite("WITH source AS (SELECT 1 AS id, 'Alice' AS name) INSERT INTO users SELECT * FROM source");
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertInstanceOf(InsertMutation::class, $plan->mutation());
+        self::assertStringStartsWith('WITH source AS', $plan->sql());
+        self::assertSame(1, substr_count($plan->sql(), 'WITH'));
+    }
+
     public function testRewriteAlterTableConvertToCharsetThrows(): void
     {
         $shadowStore = new ShadowStore();

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -56,6 +56,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
     protected function createRewriter(ShadowStore $store, TableDefinitionRegistry $registry): SqlRewriter
@@ -1659,6 +1660,38 @@ final class MySqlRewriterTest extends RewriterContractTest
         self::assertInstanceOf(InsertMutation::class, $plan->mutation());
         self::assertStringStartsWith('WITH source AS', $plan->sql());
         self::assertSame(1, substr_count($plan->sql(), 'WITH'));
+    }
+
+    public function testRewriteWithStatementDeleteIgnoresHashCommentsAroundItsCteHeader(): void
+    {
+        $shadowStore = new ShadowStore();
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $registry = new TableDefinitionRegistry();
+        $definition = $schemaParser->parse('CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255))');
+        self::assertNotNull($definition);
+        $registry->register('users', $definition);
+
+        $selectTransformer = new SelectTransformer();
+        $insertTransformer = new InsertTransformer($parser, $selectTransformer);
+        $updateTransformer = new UpdateTransformer($parser, $selectTransformer);
+        $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
+        $replaceTransformer = new ReplaceTransformer($parser, $selectTransformer);
+        $transformer = new MySqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer, $replaceTransformer);
+        $mutationResolver = new MySqlMutationResolver($shadowStore, $registry, $schemaParser, $updateTransformer, $deleteTransformer);
+        $rewriter = new MySqlRewriter(new MySqlQueryGuard($parser), $shadowStore, $registry, $transformer, $mutationResolver, $parser);
+        $sql = <<<'SQL'
+            WITH RECURSIVE # modifier
+            chosen AS (SELECT 1 AS id) # body
+            DELETE # target
+            FROM users WHERE id IN (SELECT id FROM chosen)
+            SQL;
+
+        $plan = $rewriter->rewrite($sql);
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertInstanceOf(DeleteMutation::class, $plan->mutation());
+        self::assertStringContainsString('SELECT', $plan->sql());
     }
 
     public function testRewriteAlterTableConvertToCharsetThrows(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
@@ -41,6 +41,7 @@ use ZtdQuery\Session;
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class MySqlSessionFactoryTest extends TestCase
 {
     public function testCreateReturnsSession(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class DeleteTransformerTest extends TestCase
 {
     public function testBuildDeleteWithJoinAlias(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
@@ -30,6 +30,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(MySqlSelectListAliaser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class InsertTransformerTest extends TestCase
 {
     public function testUsesInjectedCastRendererAndColumnTypes(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlSelectListAliaserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlSelectListAliaserTest.php
@@ -34,6 +34,16 @@ final class MySqlSelectListAliaserTest extends TestCase
         self::assertSame('SELECT id, source.* FROM source', $aliaser->alias('SELECT id, source.* FROM source'));
     }
 
+    public function testIgnoresHashCommentsWhenAliasingMySqlProjection(): void
+    {
+        $sql = "SELECT # FROM ignored\n id, name FROM users";
+
+        self::assertSame(
+            "SELECT # FROM ignored\n id AS `__ztd_insert_0`, name AS `__ztd_insert_1` FROM users",
+            (new MySqlSelectListAliaser())->alias($sql),
+        );
+    }
+
     public function testCountsStructuredProjectionWithoutTreatingFunctionArgumentAsWildcard(): void
     {
         $aliaser = new MySqlSelectListAliaser();

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
@@ -31,6 +31,7 @@ use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class MySqlTransformerTest extends TestCase
 {
     public function testTransformSelectPassthrough(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class ReplaceTransformerTest extends TestCase
 {
     public function testTransformReplaceWithValues(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
@@ -23,6 +23,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(MySqlTypeSemantics::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
     public function testUsesInjectedValueRenderer(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class UpdateTransformerTest extends TestCase
 {
     public function testBuildUpdateSelectUsesAliasAndColumns(): void

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -20,6 +20,50 @@ use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
 #[Large]
 final class MysqliCteShadowingTest extends TestCase
 {
+    public function testRecursiveAndUserOwnedCteNamespacesRemainValid(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, parent_id INT)', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $ztdMysqli->query(sprintf('INSERT INTO `%s` VALUES (1, NULL), (2, 1), (3, 2)', $table));
+            $recursive = $ztdMysqli->query(sprintf(
+                'WITH RECURSIVE tree AS (SELECT id, parent_id FROM `%1$s` WHERE parent_id IS NULL UNION ALL SELECT n.id, n.parent_id FROM `%1$s` n JOIN tree t ON n.parent_id = t.id) SELECT id FROM tree ORDER BY id',
+                $table,
+            ));
+            self::assertInstanceOf(\mysqli_result::class, $recursive);
+            self::assertSame([['id' => 1], ['id' => 2], ['id' => 3]], $recursive->fetch_all(MYSQLI_ASSOC));
+
+            $owned = $ztdMysqli->query(sprintf('WITH `%1$s` AS (SELECT 9 AS id, NULL AS parent_id) SELECT id FROM `%1$s`', $table));
+            self::assertInstanceOf(\mysqli_result::class, $owned);
+            self::assertSame([['id' => 9]], $owned->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
+    public function testCteDefinitionsRemainVisibleToSimulatedDml(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, value VARCHAR(20))', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            self::assertNotFalse($ztdMysqli->query(sprintf("WITH source AS (SELECT 1 AS id, 'one' AS value UNION ALL SELECT 2, 'two') INSERT INTO `%s` SELECT * FROM source", $table)));
+            self::assertNotFalse($ztdMysqli->query(sprintf("WITH chosen AS (SELECT id FROM `%1\$s` WHERE value = 'two') UPDATE `%1\$s` SET value = 'changed' WHERE id IN (SELECT id FROM chosen)", $table)));
+            self::assertNotFalse($ztdMysqli->query(sprintf("WITH chosen AS (SELECT id FROM `%1\$s` WHERE value = 'one') DELETE FROM `%1\$s` WHERE id IN (SELECT id FROM chosen)", $table)));
+
+            $result = $ztdMysqli->query(sprintf('SELECT * FROM `%s`', $table));
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([['id' => 2, 'value' => 'changed']], $result->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testInsertSelectPreservesStarJoinsAggregatesDistinctAndRollup(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/CteDmlTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/CteDmlTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class CteDmlTest extends TestCase
+{
+    public function testCteDefinitionsRemainVisibleToRewrittenInsertUpdateAndDelete(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$table} (id INTEGER PRIMARY KEY, value TEXT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+            self::assertSame(2, $ztdPdo->exec("WITH source(id, value) AS (VALUES (1, 'one'), (2, 'two')) INSERT INTO {$table} SELECT * FROM source"));
+            self::assertSame(1, $ztdPdo->exec("WITH chosen AS (SELECT id FROM {$table} WHERE value = 'two') UPDATE {$table} SET value = 'changed' WHERE id IN (SELECT id FROM chosen)"));
+            self::assertSame(1, $ztdPdo->exec("WITH chosen AS (SELECT id FROM {$table} WHERE value = 'one') DELETE FROM {$table} WHERE id IN (SELECT id FROM chosen)"));
+
+            $statement = $ztdPdo->query("SELECT * FROM {$table}");
+            self::assertNotFalse($statement);
+            self::assertSame([['id' => 2, 'value' => 'changed']], $statement->fetchAll(PDO::FETCH_ASSOC));
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/CteDmlTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/CteDmlTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class CteDmlTest extends TestCase
+{
+    public function testCteDefinitionsRemainVisibleToRewrittenInsertUpdateAndDelete(): void
+    {
+        $raw = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $raw->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($raw);
+
+        self::assertSame(2, $ztdPdo->exec("WITH source(id, value) AS (VALUES (1, 'one'), (2, 'two')) INSERT INTO items SELECT * FROM source"));
+        self::assertSame(1, $ztdPdo->exec("WITH chosen AS (SELECT id FROM items WHERE value = 'two') UPDATE items SET value = 'changed' WHERE id IN (SELECT id FROM chosen)"));
+        self::assertSame(1, $ztdPdo->exec("WITH chosen AS (SELECT id FROM items WHERE value = 'one') DELETE FROM items WHERE id IN (SELECT id FROM chosen)"));
+
+        $statement = $ztdPdo->query('SELECT * FROM items');
+        self::assertNotFalse($statement);
+        self::assertSame([['id' => 2, 'value' => 'changed']], $statement->fetchAll(PDO::FETCH_ASSOC));
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/SelectCteTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/SelectCteTest.php
@@ -62,4 +62,19 @@ final class SelectCteTest extends TestCase
         $ztdRows = $stmt->fetchAll();
         self::assertNotEmpty($ztdRows);
     }
+
+    public function testUserCteMayOwnTheSameNameAsAPhysicalTable(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, age INTEGER NOT NULL)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO users VALUES (1, 'shadow', 30)");
+
+        $statement = $ztdPdo->query("WITH users AS (SELECT 9 AS id, 'cte' AS name, 99 AS age) SELECT * FROM users");
+        self::assertNotFalse($statement);
+        self::assertSame([['id' => 9, 'name' => 'cte', 'age' => 99]], $statement->fetchAll());
+    }
 }

--- a/packages/ztd-query-postgres/src/PgSqlCteShadowComposer.php
+++ b/packages/ztd-query-postgres/src/PgSqlCteShadowComposer.php
@@ -2,14 +2,22 @@
 
 declare(strict_types=1);
 
-namespace ZtdQuery\Rewrite;
+namespace ZtdQuery\Platform\Postgres;
 
 use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
-final class CteShadowComposer
+final class PgSqlCteShadowComposer
 {
+    private readonly SqlTokenDialect $dialect;
+
+    public function __construct()
+    {
+        $this->dialect = SqlTokenDialect::Standard;
+    }
+
     /**
      * @param array<string, string> $tableCtes
      */
@@ -29,7 +37,7 @@ final class CteShadowComposer
             return $sql;
         }
 
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $tokens = SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens();
         $with = $tokens[0] ?? null;
         if ($with === null || !$with->isKeyword('WITH')) {
             return 'WITH ' . implode(",\n", $ctes) . "\n" . $sql;
@@ -64,7 +72,7 @@ final class CteShadowComposer
 
         $prefix = rtrim(substr($originalSql, 0, $header['statementOffset']));
 
-        $rewrittenTokens = SqlTokenStream::tokenize($rewrittenStatement)->significantTokens();
+        $rewrittenTokens = SqlTokenStream::tokenize($rewrittenStatement, $this->dialect)->significantTokens();
         $rewrittenWith = $rewrittenTokens[0] ?? null;
         if ($rewrittenWith !== null && $rewrittenWith->isKeyword('WITH')) {
             $rewrittenHeader = $this->parseHeader($rewrittenStatement);
@@ -89,7 +97,7 @@ final class CteShadowComposer
                 return $prefix . ",\n" . $rewrittenBody . "\n" . $rewrittenTail;
             }
 
-            $originalTokens = SqlTokenStream::tokenize($originalSql)->significantTokens();
+            $originalTokens = SqlTokenStream::tokenize($originalSql, $this->dialect)->significantTokens();
             $originalWith = $originalTokens[0];
             $originalContentToken = $originalWith;
             $recursive = false;
@@ -129,7 +137,7 @@ final class CteShadowComposer
     private function parseHeader(string $sql): array
     {
         $tokens = [];
-        foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
+        foreach (SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens() as $token) {
             if ($token->isTopLevel()) {
                 $tokens[] = $token;
             }
@@ -211,7 +219,7 @@ final class CteShadowComposer
 
     private function referencesIdentifier(string $sql, string $identifier): bool
     {
-        foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
+        foreach (SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens() as $token) {
             $candidate = $this->identifierName($token);
             if ($candidate !== null && strcasecmp($candidate, $identifier) === 0) {
                 return true;

--- a/packages/ztd-query-postgres/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/DeleteTransformer.php
@@ -6,7 +6,7 @@ namespace ZtdQuery\Platform\Postgres\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -20,7 +20,7 @@ final class DeleteTransformer implements SqlTransformer
 {
     private PgSqlParser $parser;
     private SelectTransformer $selectTransformer;
-    private CteShadowComposer $cteComposer;
+    private PgSqlCteShadowComposer $cteComposer;
 
     public function __construct(
         PgSqlParser $parser,
@@ -28,7 +28,7 @@ final class DeleteTransformer implements SqlTransformer
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new PgSqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/DeleteTransformer.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Postgres\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -19,11 +20,16 @@ final class DeleteTransformer implements SqlTransformer
 {
     private PgSqlParser $parser;
     private SelectTransformer $selectTransformer;
+    private CteShadowComposer $cteComposer;
 
-    public function __construct(PgSqlParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        PgSqlParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CteShadowComposer $cteComposer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -39,7 +45,10 @@ final class DeleteTransformer implements SqlTransformer
         $columns = $tables[$targetTable]['columns'] ?? [];
         $projection = $this->buildProjection($sql, $targetTable, $columns);
 
-        return $this->selectTransformer->transform($projection['sql'], $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $projection['sql']),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/DeleteTransformer.php
@@ -25,11 +25,10 @@ final class DeleteTransformer implements SqlTransformer
     public function __construct(
         PgSqlParser $parser,
         SelectTransformer $selectTransformer,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
@@ -8,6 +8,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -26,6 +27,7 @@ final class InsertTransformer implements SqlTransformer
     private InsertRowRenderer $rowRenderer;
     private ShadowIdentityAllocator $identityAllocator;
     private InsertSelectRenderer $insertSelectRenderer;
+    private CteShadowComposer $cteComposer;
 
     public function __construct(
         PgSqlParser $parser,
@@ -38,6 +40,7 @@ final class InsertTransformer implements SqlTransformer
         $this->rowRenderer = new InsertRowRenderer();
         $this->identityAllocator = new ShadowIdentityAllocator();
         $this->insertSelectRenderer = new InsertSelectRenderer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**
@@ -74,7 +77,7 @@ final class InsertTransformer implements SqlTransformer
                 $existingRows,
             );
             $projectedSql = $this->insertSelectRenderer->render(
-                $selectSql,
+                $this->cteComposer->carryPrefix($sql, $selectSql),
                 $tableColumns,
                 $sourceColumns,
                 $columnDefaults,
@@ -121,7 +124,10 @@ final class InsertTransformer implements SqlTransformer
 
         $selectSql = implode(' UNION ALL ', $selectParts);
 
-        return $this->selectTransformer->transform($selectSql, $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $selectSql),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
@@ -8,7 +8,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
 use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -27,7 +27,7 @@ final class InsertTransformer implements SqlTransformer
     private InsertRowRenderer $rowRenderer;
     private ShadowIdentityAllocator $identityAllocator;
     private InsertSelectRenderer $insertSelectRenderer;
-    private CteShadowComposer $cteComposer;
+    private PgSqlCteShadowComposer $cteComposer;
 
     public function __construct(
         PgSqlParser $parser,
@@ -40,7 +40,7 @@ final class InsertTransformer implements SqlTransformer
         $this->rowRenderer = new InsertRowRenderer();
         $this->identityAllocator = new ShadowIdentityAllocator();
         $this->insertSelectRenderer = new InsertSelectRenderer();
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new PgSqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -9,7 +9,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -29,7 +29,7 @@ final class SelectTransformer implements SqlTransformer
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
-    private CteShadowComposer $cteComposer;
+    private PgSqlCteShadowComposer $cteComposer;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -39,7 +39,7 @@ final class SelectTransformer implements SqlTransformer
         $this->castRenderer = $castRenderer ?? new PgSqlCastRenderer();
         $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Postgres\PgSqlValueRenderer($this->castRenderer);
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new PgSqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -35,12 +35,11 @@ final class SelectTransformer implements SqlTransformer
         ?CastRenderer $castRenderer = null,
         ?IdentifierQuoter $quoter = null,
         ?ValueRenderer $valueRenderer = null,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->castRenderer = $castRenderer ?? new PgSqlCastRenderer();
         $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Postgres\PgSqlValueRenderer($this->castRenderer);
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -9,6 +9,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -28,15 +29,18 @@ final class SelectTransformer implements SqlTransformer
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
+    private CteShadowComposer $cteComposer;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
         ?IdentifierQuoter $quoter = null,
         ?ValueRenderer $valueRenderer = null,
+        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->castRenderer = $castRenderer ?? new PgSqlCastRenderer();
         $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Postgres\PgSqlValueRenderer($this->castRenderer);
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -46,10 +50,6 @@ final class SelectTransformer implements SqlTransformer
     {
         $ctes = [];
         foreach ($tables as $tableName => $tableContext) {
-            if (stripos($sql, $tableName) === false) {
-                continue;
-            }
-
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];
             /** @var array<string, ColumnType> $columnTypes */
@@ -70,20 +70,10 @@ final class SelectTransformer implements SqlTransformer
                 continue;
             }
 
-            $ctes[] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
+            $ctes[$tableName] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
         }
 
-        if ($ctes === []) {
-            return $sql;
-        }
-
-        $cteString = implode(",\n", $ctes);
-        $pattern = '/^(\s*(?:(?:\/\*.*?\*\/)|(?:--.*?\n)|(?:#.*?\n)|\s)*)WITH\b/is';
-        if (preg_match($pattern, $sql) === 1) {
-            return (string) preg_replace($pattern, '$1WITH ' . $cteString . ",\n", $sql, 1);
-        }
-
-        return "WITH $cteString\n$sql";
+        return $this->cteComposer->compose($sql, $ctes);
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/UpdateTransformer.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Postgres\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -19,11 +20,16 @@ final class UpdateTransformer implements SqlTransformer
 {
     private PgSqlParser $parser;
     private SelectTransformer $selectTransformer;
+    private CteShadowComposer $cteComposer;
 
-    public function __construct(PgSqlParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        PgSqlParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CteShadowComposer $cteComposer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -39,7 +45,10 @@ final class UpdateTransformer implements SqlTransformer
         $columns = $tables[$targetTable]['columns'] ?? [];
         $projection = $this->buildProjection($sql, $targetTable, $columns);
 
-        return $this->selectTransformer->transform($projection['sql'], $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $projection['sql']),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/UpdateTransformer.php
@@ -25,11 +25,10 @@ final class UpdateTransformer implements SqlTransformer
     public function __construct(
         PgSqlParser $parser,
         SelectTransformer $selectTransformer,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/UpdateTransformer.php
@@ -6,7 +6,7 @@ namespace ZtdQuery\Platform\Postgres\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -20,7 +20,7 @@ final class UpdateTransformer implements SqlTransformer
 {
     private PgSqlParser $parser;
     private SelectTransformer $selectTransformer;
-    private CteShadowComposer $cteComposer;
+    private PgSqlCteShadowComposer $cteComposer;
 
     public function __construct(
         PgSqlParser $parser,
@@ -28,7 +28,7 @@ final class UpdateTransformer implements SqlTransformer
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new PgSqlCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
+
+#[CoversClass(PgSqlCteShadowComposer::class)]
+final class PgSqlCteShadowComposerTest extends TestCase
+{
+    public function testAddsShadowsAfterRecursiveModifier(): void
+    {
+        $sql = 'WITH RECURSIVE tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree';
+
+        self::assertSame(
+            "WITH RECURSIVE \"nodes\" AS (SELECT 1 AS id),\n tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree",
+            (new PgSqlCteShadowComposer())->compose($sql, ['nodes' => '"nodes" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testPreservesUserCteThatOwnsThePhysicalTableName(): void
+    {
+        $sql = 'WITH users AS (SELECT 1 AS id), filtered AS (SELECT * FROM users) SELECT * FROM filtered';
+
+        self::assertSame(
+            $sql,
+            (new PgSqlCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 2 AS id)']),
+        );
+    }
+
+    public function testInjectsReferencedBaseTableBeforeUserCtes(): void
+    {
+        $sql = 'WITH filtered AS (SELECT * FROM users WHERE active) SELECT * FROM filtered';
+
+        self::assertSame(
+            "WITH \"users\" AS (SELECT 1 AS id),\n filtered AS (SELECT * FROM users WHERE active) SELECT * FROM filtered",
+            (new PgSqlCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testDoesNotTreatLiteralsCommentsOrIdentifierPrefixesAsReferences(): void
+    {
+        $sql = "SELECT 'users', superusers.id /* users */ FROM superusers";
+
+        self::assertSame(
+            $sql,
+            (new PgSqlCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
+        );
+    }
+
+    public function testReadsQuotedAndColumnListedCteNames(): void
+    {
+        self::assertSame(
+            ['first', 'second'],
+            (new PgSqlCteShadowComposer())->declaredCteNames('WITH "first"(id) AS MATERIALIZED (SELECT 1), second AS (SELECT 2) SELECT * FROM second'),
+        );
+    }
+
+    public function testCarriesTheCompleteCteHeaderOntoARewrittenDmlProjection(): void
+    {
+        $sql = 'WITH first AS (SELECT 1), second(id) AS (SELECT * FROM first) UPDATE users SET id = 2';
+
+        self::assertSame(
+            "WITH first AS (SELECT 1), second(id) AS (SELECT * FROM first)\nSELECT 2 AS id FROM users",
+            (new PgSqlCteShadowComposer())->carryPrefix($sql, 'SELECT 2 AS id FROM users'),
+        );
+    }
+
+    public function testMergesProjectionCtesIntoTheOriginalHeader(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1),\nprojected AS (SELECT * FROM source)\nSELECT * FROM projected",
+            (new PgSqlCteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) INSERT INTO target SELECT * FROM source',
+                'WITH projected AS (SELECT * FROM source) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testOrdersShadowCtesBeforeUserCtesThatReadThem(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id),\nchosen AS (SELECT id FROM users)\nSELECT * FROM users WHERE id IN (SELECT id FROM chosen)",
+            (new PgSqlCteShadowComposer())->carryPrefix(
+                'WITH chosen AS (SELECT id FROM users) UPDATE users SET id = 2',
+                'WITH users AS (SELECT 1 AS id) SELECT * FROM users WHERE id IN (SELECT id FROM chosen)',
+            ),
+        );
+    }
+
+    public function testExtractsTheStatementFollowingTheCteHeader(): void
+    {
+        self::assertSame(
+            'DELETE FROM users WHERE id IN (SELECT id FROM chosen)',
+            (new PgSqlCteShadowComposer())->statementSql('WITH chosen AS (SELECT 1 AS id) DELETE FROM users WHERE id IN (SELECT id FROM chosen)'),
+        );
+    }
+
+    public function testComposesAReferencedShadowWithoutAnExistingWithClause(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id)\nSELECT * FROM users",
+            (new PgSqlCteShadowComposer())->compose(
+                'SELECT * FROM users',
+                ['users' => 'users AS (SELECT 1 AS id)'],
+            ),
+        );
+    }
+
+    public function testSkipsEntriesIndependentlyAndMatchesDeclaredNamesCaseInsensitively(): void
+    {
+        $composer = new PgSqlCteShadowComposer();
+
+        self::assertSame(
+            "WITH orders AS (SELECT 2 AS id)\nSELECT * FROM orders",
+            $composer->compose(
+                'SELECT * FROM orders',
+                [
+                    'users' => 'users AS (SELECT 1 AS id)',
+                    'orders' => 'orders AS (SELECT 2 AS id)',
+                ],
+            ),
+        );
+        $declared = 'WITH users AS (SELECT 1 AS id) SELECT * FROM users';
+        self::assertSame(
+            $declared,
+            $composer->compose($declared, ['Users' => 'Users AS (SELECT 2 AS id)']),
+        );
+    }
+
+    public function testHandlesAWithTokenWithoutFollowingHeaderTokens(): void
+    {
+        self::assertSame(
+            "WITH shadow AS (SELECT 1),\n",
+            (new PgSqlCteShadowComposer())->compose('WITH', ['WITH' => 'shadow AS (SELECT 1)']),
+        );
+    }
+
+    public function testCarriesAnEmptyRewriteWithoutDereferencingMissingTokens(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1)\n",
+            (new PgSqlCteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) UPDATE users SET id = 2',
+                '',
+            ),
+        );
+    }
+
+    public function testMergesRecursiveHeadersAndPreservesLeadingComments(): void
+    {
+        self::assertSame(
+            "/* lead */ WITH RECURSIVE projected AS (SELECT 2),\noriginal AS (SELECT 1)\nSELECT * FROM projected",
+            (new PgSqlCteShadowComposer())->carryPrefix(
+                '/* lead */ WITH RECURSIVE original AS (SELECT 1) UPDATE users SET id = 2',
+                'WITH projected AS (SELECT 2) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testRecognizesRecursiveRewrittenHeaderDependencies(): void
+    {
+        self::assertSame(
+            "WITH source AS (SELECT 1),\nprojected AS (SELECT * FROM source)\nSELECT * FROM projected",
+            (new PgSqlCteShadowComposer())->carryPrefix(
+                'WITH source AS (SELECT 1) INSERT INTO target SELECT * FROM source',
+                'WITH RECURSIVE projected AS (SELECT * FROM source) SELECT * FROM projected',
+            ),
+        );
+    }
+
+    public function testParsesRecursiveMaterializationAndNestedCteBodies(): void
+    {
+        $sql = 'WITH RECURSIVE "FIRST"(id) AS MATERIALIZED (SELECT (1)), second AS NOT MATERIALIZED (SELECT id FROM "FIRST") DELETE FROM target';
+        $composer = new PgSqlCteShadowComposer();
+
+        self::assertSame(['first', 'second'], $composer->declaredCteNames($sql));
+        self::assertSame('DELETE FROM target', $composer->statementSql($sql));
+    }
+
+    public function testHandlesNonHeadersIncompleteHeadersAndEmptyInput(): void
+    {
+        $composer = new PgSqlCteShadowComposer();
+
+        self::assertSame([], $composer->declaredCteNames(''));
+        self::assertSame('SELECT 1', $composer->statementSql('SELECT 1'));
+        self::assertSame([], $composer->declaredCteNames('WITH only_name'));
+        self::assertSame(
+            'WITH x AS (SELECT 1)',
+            $composer->statementSql('WITH x AS (SELECT 1)'),
+        );
+        self::assertSame([], $composer->declaredCteNames('WITH x AS'));
+        self::assertSame([], $composer->declaredCteNames('WITH x AS NOT'));
+        self::assertSame([], $composer->declaredCteNames('WITH x AS (SELECT 1'));
+        self::assertSame(
+            ['first'],
+            $composer->declaredCteNames('WITH first AS (SELECT 1), broken'),
+        );
+    }
+
+    public function testUnquotesEmptyAndEscapedCteIdentifiers(): void
+    {
+        $composer = new PgSqlCteShadowComposer();
+
+        self::assertSame([''], $composer->declaredCteNames('WITH "" AS (SELECT 1) SELECT 1'));
+        self::assertSame(
+            ['a"b', 'c`d'],
+            $composer->declaredCteNames(
+                'WITH "a""b" AS (SELECT 1), `c``d` AS (SELECT 2) SELECT 1',
+            ),
+        );
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -53,6 +53,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
     protected function createRewriter(ShadowStore $store, TableDefinitionRegistry $registry): SqlRewriter

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -44,6 +44,7 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertSelectRenderer::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class PgSqlSessionFactoryTest extends TestCase
 {
     public function testCreateReturnsSession(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
@@ -31,6 +31,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class PgSqlTransformerTest extends TestCase
 {
     public function testTransformSelectDelegatesToSelectTransformer(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -23,6 +23,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class DeleteTransformerTest extends TestCase
 {
     public function testBuildProjectionSimpleDelete(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -28,6 +28,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertRowRenderer::class)]
 #[UsesClass(InsertSelectRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class InsertTransformerTest extends TestCase
 {
     public function testUsesInjectedCastRendererForTypedValue(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
@@ -19,6 +19,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
     public function testUsesInjectedValueRenderer(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -23,6 +23,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class UpdateTransformerTest extends TestCase
 {
     public function testBuildProjectionSimpleUpdate(): void

--- a/packages/ztd-query-sqlite/src/SqliteCteShadowComposer.php
+++ b/packages/ztd-query-sqlite/src/SqliteCteShadowComposer.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class SqliteCteShadowComposer
+{
+    private readonly SqlTokenDialect $dialect;
+
+    public function __construct()
+    {
+        $this->dialect = SqlTokenDialect::Standard;
+    }
+
+    /**
+     * @param array<string, string> $tableCtes
+     */
+    public function compose(string $sql, array $tableCtes): string
+    {
+        $declared = array_fill_keys($this->declaredCteNames($sql), true);
+        $ctes = [];
+        foreach ($tableCtes as $table => $cte) {
+            $normalized = strtolower($table);
+            if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
+                continue;
+            }
+            $ctes[] = $cte;
+        }
+
+        if ($ctes === []) {
+            return $sql;
+        }
+
+        $tokens = SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens();
+        $with = $tokens[0] ?? null;
+        if ($with === null || !$with->isKeyword('WITH')) {
+            return 'WITH ' . implode(",\n", $ctes) . "\n" . $sql;
+        }
+
+        $insertionToken = $with;
+        $next = $tokens[1] ?? null;
+        if ($next !== null && $next->isTopLevel() && $next->isKeyword('RECURSIVE')) {
+            $insertionToken = $next;
+        }
+
+        return substr_replace(
+            $sql,
+            ' ' . implode(",\n", $ctes) . ",\n",
+            $insertionToken->endOffset(),
+            0,
+        );
+    }
+
+    /** @return list<string> */
+    public function declaredCteNames(string $sql): array
+    {
+        return $this->parseHeader($sql)['names'];
+    }
+
+    public function carryPrefix(string $originalSql, string $rewrittenStatement): string
+    {
+        $header = $this->parseHeader($originalSql);
+        if ($header['statementOffset'] === null) {
+            return $rewrittenStatement;
+        }
+
+        $prefix = rtrim(substr($originalSql, 0, $header['statementOffset']));
+
+        $rewrittenTokens = SqlTokenStream::tokenize($rewrittenStatement, $this->dialect)->significantTokens();
+        $rewrittenWith = $rewrittenTokens[0] ?? null;
+        if ($rewrittenWith !== null && $rewrittenWith->isKeyword('WITH')) {
+            $rewrittenHeader = $this->parseHeader($rewrittenStatement);
+            $rewrittenStatementOffset = $rewrittenHeader['statementOffset'];
+            if ($rewrittenStatementOffset === null) {
+                return $prefix . "\n" . $rewrittenStatement;
+            }
+
+            $contentToken = $rewrittenWith;
+            $rewrittenNext = $rewrittenTokens[1] ?? null;
+            if ($rewrittenNext !== null && $rewrittenNext->isKeyword('RECURSIVE')) {
+                $contentToken = $rewrittenNext;
+            }
+
+            $rewrittenBody = trim(substr(
+                $rewrittenStatement,
+                $contentToken->endOffset(),
+                $rewrittenStatementOffset - $contentToken->endOffset(),
+            ));
+            $rewrittenTail = substr($rewrittenStatement, $rewrittenStatementOffset);
+            if ($this->referencesAnyIdentifier($rewrittenBody, $header['names'])) {
+                return $prefix . ",\n" . $rewrittenBody . "\n" . $rewrittenTail;
+            }
+
+            $originalTokens = SqlTokenStream::tokenize($originalSql, $this->dialect)->significantTokens();
+            $originalWith = $originalTokens[0];
+            $originalContentToken = $originalWith;
+            $recursive = false;
+            $originalNext = $originalTokens[1] ?? null;
+            if ($originalNext !== null && $originalNext->isKeyword('RECURSIVE')) {
+                $originalContentToken = $originalNext;
+                $recursive = true;
+            }
+            $originalBody = trim(substr(
+                $originalSql,
+                $originalContentToken->endOffset(),
+                $header['statementOffset'] - $originalContentToken->endOffset(),
+            ));
+            $leading = substr($originalSql, 0, $originalWith->offset);
+
+            return $leading
+                . 'WITH '
+                . ($recursive ? 'RECURSIVE ' : '')
+                . $rewrittenBody
+                . ",\n"
+                . $originalBody
+                . "\n"
+                . $rewrittenTail;
+        }
+
+        return $prefix . "\n" . $rewrittenStatement;
+    }
+
+    public function statementSql(string $sql): string
+    {
+        $offset = $this->parseHeader($sql)['statementOffset'];
+
+        return $offset === null ? $sql : substr($sql, $offset);
+    }
+
+    /** @return array{names: list<string>, statementOffset: int|null} */
+    private function parseHeader(string $sql): array
+    {
+        $tokens = [];
+        foreach (SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens() as $token) {
+            if ($token->isTopLevel()) {
+                $tokens[] = $token;
+            }
+        }
+        if (($tokens[0] ?? null)?->isKeyword('WITH') !== true) {
+            return ['names' => [], 'statementOffset' => null];
+        }
+
+        $index = 1;
+        if (($tokens[$index] ?? null)?->isKeyword('RECURSIVE') === true) {
+            $index++;
+        }
+
+        $names = [];
+        while (isset($tokens[$index])) {
+            $name = $this->identifierName($tokens[$index]);
+            if ($name === null) {
+                break;
+            }
+            $index++;
+
+            $asIndex = $this->findAsIndex($tokens, $index);
+            $index = ($asIndex ?? count($tokens)) + 1;
+
+            if (($tokens[$index] ?? null)?->isKeyword('NOT') === true) {
+                $index++;
+            }
+            if (($tokens[$index] ?? null)?->isKeyword('MATERIALIZED') === true) {
+                $index++;
+            }
+
+            if (!$this->isSymbol($tokens[$index] ?? null, '(')
+                || !$this->isSymbol($tokens[$index + 1] ?? null, ')')
+            ) {
+                return ['names' => $names, 'statementOffset' => null];
+            }
+            $names[] = strtolower($name);
+            $index += 2;
+
+            $separator = $tokens[$index] ?? null;
+            if (!$this->isSymbol($separator, ',')) {
+                break;
+            }
+            $index++;
+        }
+
+        $statement = $tokens[$index] ?? null;
+
+        return [
+            'names' => $names,
+            'statementOffset' => $statement?->offset,
+        ];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private function findAsIndex(array $tokens, int $start): ?int
+    {
+        for ($index = $start; isset($tokens[$index]); $index++) {
+            $token = $tokens[$index];
+            if ($token->isKeyword('AS')) {
+                return $index;
+            }
+            if ($token->kind === SqlTokenKind::Word) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        return $token instanceof SqlToken
+            && $token->kind === SqlTokenKind::Symbol
+            && $token->text === $symbol;
+    }
+
+    private function referencesIdentifier(string $sql, string $identifier): bool
+    {
+        foreach (SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens() as $token) {
+            $candidate = $this->identifierName($token);
+            if ($candidate !== null && strcasecmp($candidate, $identifier) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param list<string> $identifiers */
+    private function referencesAnyIdentifier(string $sql, array $identifiers): bool
+    {
+        foreach ($identifiers as $identifier) {
+            if ($this->referencesIdentifier($sql, $identifier)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function identifierName(SqlToken $token): ?string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+        if ($token->kind !== SqlTokenKind::QuotedIdentifier || strlen($token->text) < 2) {
+            return null;
+        }
+
+        $quote = $token->text[0];
+        $inner = substr($token->text, 1, -1);
+
+        return str_replace($quote . $quote, $quote, $inner);
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -483,7 +483,7 @@ final class SqliteParser
 
     private function extractInsertTable(string $sql): ?string
     {
-        $sql = $this->stripComments($sql);
+        $sql = $this->statementTail($sql, ['INSERT', 'REPLACE']);
         if (preg_match('/\bINTO\s+("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s(]+)/i', $sql, $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
@@ -497,7 +497,7 @@ final class SqliteParser
 
     private function extractUpdateTable(string $sql): ?string
     {
-        $sql = $this->stripComments($sql);
+        $sql = $this->statementTail($sql, ['UPDATE']);
         if (preg_match('/^UPDATE\s+(?:OR\s+(?:ROLLBACK|ABORT|REPLACE|FAIL|IGNORE)\s+)?("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s,]+)/i', trim($sql), $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
@@ -507,12 +507,29 @@ final class SqliteParser
 
     private function extractDeleteTable(string $sql): ?string
     {
-        $sql = $this->stripComments($sql);
+        $sql = $this->statementTail($sql, ['DELETE']);
         if (preg_match('/\bFROM\s+("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s,]+)/i', $sql, $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
 
         return null;
+    }
+
+    /** @param non-empty-list<string> $keywords */
+    private function statementTail(string $sql, array $keywords): string
+    {
+        foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
+            if (!$token->isTopLevel()) {
+                continue;
+            }
+            foreach ($keywords as $keyword) {
+                if ($token->isKeyword($keyword)) {
+                    return $this->stripComments(substr($sql, $token->offset));
+                }
+            }
+        }
+
+        return $this->stripComments($sql);
     }
 
     private function extractCreateTableName(string $sql): ?string

--- a/packages/ztd-query-sqlite/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/DeleteTransformer.php
@@ -23,11 +23,10 @@ final class DeleteTransformer implements SqlTransformer
     public function __construct(
         SqliteParser $parser,
         SelectTransformer $selectTransformer,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/DeleteTransformer.php
@@ -6,7 +6,7 @@ namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -18,7 +18,7 @@ final class DeleteTransformer implements SqlTransformer
 {
     private SqliteParser $parser;
     private SelectTransformer $selectTransformer;
-    private CteShadowComposer $cteComposer;
+    private SqliteCteShadowComposer $cteComposer;
 
     public function __construct(
         SqliteParser $parser,
@@ -26,7 +26,7 @@ final class DeleteTransformer implements SqlTransformer
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new SqliteCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/DeleteTransformer.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -17,11 +18,16 @@ final class DeleteTransformer implements SqlTransformer
 {
     private SqliteParser $parser;
     private SelectTransformer $selectTransformer;
+    private CteShadowComposer $cteComposer;
 
-    public function __construct(SqliteParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        SqliteParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CteShadowComposer $cteComposer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -43,7 +49,10 @@ final class DeleteTransformer implements SqlTransformer
 
         $projection = $this->buildProjection($sql, $targetTable, $columns);
 
-        return $this->selectTransformer->transform($projection, $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $projection),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/InsertTransformer.php
@@ -8,7 +8,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
 use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -33,7 +33,7 @@ final class InsertTransformer implements SqlTransformer
     private InsertRowRenderer $rowRenderer;
     private ShadowIdentityAllocator $identityAllocator;
     private InsertSelectRenderer $insertSelectRenderer;
-    private CteShadowComposer $cteComposer;
+    private SqliteCteShadowComposer $cteComposer;
 
     public function __construct(
         SqliteParser $parser,
@@ -46,7 +46,7 @@ final class InsertTransformer implements SqlTransformer
         $this->rowRenderer = new InsertRowRenderer();
         $this->identityAllocator = new ShadowIdentityAllocator();
         $this->insertSelectRenderer = new InsertSelectRenderer();
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new SqliteCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/InsertTransformer.php
@@ -8,6 +8,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -32,6 +33,7 @@ final class InsertTransformer implements SqlTransformer
     private InsertRowRenderer $rowRenderer;
     private ShadowIdentityAllocator $identityAllocator;
     private InsertSelectRenderer $insertSelectRenderer;
+    private CteShadowComposer $cteComposer;
 
     public function __construct(
         SqliteParser $parser,
@@ -44,6 +46,7 @@ final class InsertTransformer implements SqlTransformer
         $this->rowRenderer = new InsertRowRenderer();
         $this->identityAllocator = new ShadowIdentityAllocator();
         $this->insertSelectRenderer = new InsertSelectRenderer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**
@@ -82,7 +85,10 @@ final class InsertTransformer implements SqlTransformer
             $existingRows,
         );
 
-        return $this->selectTransformer->transform($selectSql, $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $selectSql),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -31,12 +31,11 @@ final class SelectTransformer implements SqlTransformer
         ?CastRenderer $castRenderer = null,
         ?IdentifierQuoter $quoter = null,
         ?ValueRenderer $valueRenderer = null,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->castRenderer = $castRenderer ?? new SqliteCastRenderer();
         $this->quoter = $quoter ?? new SqliteIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Sqlite\SqliteValueRenderer($this->castRenderer);
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -6,10 +6,10 @@ namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
-use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -24,18 +24,19 @@ final class SelectTransformer implements SqlTransformer
 {
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
-    private SqliteParser $parser;
     private ValueRenderer $valueRenderer;
+    private CteShadowComposer $cteComposer;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
         ?IdentifierQuoter $quoter = null,
         ?ValueRenderer $valueRenderer = null,
+        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->castRenderer = $castRenderer ?? new SqliteCastRenderer();
         $this->quoter = $quoter ?? new SqliteIdentifierQuoter();
-        $this->parser = new SqliteParser();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Sqlite\SqliteValueRenderer($this->castRenderer);
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -43,13 +44,8 @@ final class SelectTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
-        $searchableSql = $this->parser->maskStringLiterals($this->parser->stripComments($sql));
         $ctes = [];
         foreach ($tables as $tableName => $tableContext) {
-            if (stripos($searchableSql, $tableName) === false) {
-                continue;
-            }
-
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];
             $columnTypes = $tableContext['columnTypes'];
@@ -69,20 +65,10 @@ final class SelectTransformer implements SqlTransformer
                 continue;
             }
 
-            $ctes[] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
+            $ctes[$tableName] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
         }
 
-        if ($ctes === []) {
-            return $sql;
-        }
-
-        $cteString = implode(",\n", $ctes);
-        $pattern = '/^(\s*(?:(?:\/\*.*?\*\/)|(?:--.*?\n)|(?:#.*?\n)|\s)*)WITH\b/is';
-        if (preg_match($pattern, $sql) === 1) {
-            return (string) preg_replace($pattern, '$1WITH ' . $cteString . ",\n", $sql, 1);
-        }
-
-        return "WITH $cteString\n$sql";
+        return $this->cteComposer->compose($sql, $ctes);
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -9,7 +9,7 @@ use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -25,7 +25,7 @@ final class SelectTransformer implements SqlTransformer
     private CastRenderer $castRenderer;
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
-    private CteShadowComposer $cteComposer;
+    private SqliteCteShadowComposer $cteComposer;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -35,7 +35,7 @@ final class SelectTransformer implements SqlTransformer
         $this->castRenderer = $castRenderer ?? new SqliteCastRenderer();
         $this->quoter = $quoter ?? new SqliteIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Sqlite\SqliteValueRenderer($this->castRenderer);
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new SqliteCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
@@ -6,7 +6,7 @@ namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
-use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -18,7 +18,7 @@ final class UpdateTransformer implements SqlTransformer
 {
     private SqliteParser $parser;
     private SelectTransformer $selectTransformer;
-    private CteShadowComposer $cteComposer;
+    private SqliteCteShadowComposer $cteComposer;
 
     public function __construct(
         SqliteParser $parser,
@@ -26,7 +26,7 @@ final class UpdateTransformer implements SqlTransformer
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new SqliteCteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
+use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 /**
@@ -17,11 +18,16 @@ final class UpdateTransformer implements SqlTransformer
 {
     private SqliteParser $parser;
     private SelectTransformer $selectTransformer;
+    private CteShadowComposer $cteComposer;
 
-    public function __construct(SqliteParser $parser, SelectTransformer $selectTransformer)
-    {
+    public function __construct(
+        SqliteParser $parser,
+        SelectTransformer $selectTransformer,
+        ?CteShadowComposer $cteComposer = null,
+    ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
+        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
     }
 
     /**
@@ -43,7 +49,10 @@ final class UpdateTransformer implements SqlTransformer
 
         $projection = $this->buildProjection($sql, $targetTable, $columns);
 
-        return $this->selectTransformer->transform($projection, $tables);
+        return $this->selectTransformer->transform(
+            $this->cteComposer->carryPrefix($sql, $projection),
+            $tables,
+        );
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
@@ -23,11 +23,10 @@ final class UpdateTransformer implements SqlTransformer
     public function __construct(
         SqliteParser $parser,
         SelectTransformer $selectTransformer,
-        ?CteShadowComposer $cteComposer = null,
     ) {
         $this->parser = $parser;
         $this->selectTransformer = $selectTransformer;
-        $this->cteComposer = $cteComposer ?? new CteShadowComposer();
+        $this->cteComposer = new CteShadowComposer();
     }
 
     /**

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
@@ -2,19 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Rewrite;
+namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
-use ZtdQuery\Rewrite\CteShadowComposer;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
 
-#[CoversClass(CteShadowComposer::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
-final class CteShadowComposerTest extends TestCase
+#[CoversClass(SqliteCteShadowComposer::class)]
+final class SqliteCteShadowComposerTest extends TestCase
 {
     public function testAddsShadowsAfterRecursiveModifier(): void
     {
@@ -22,7 +17,7 @@ final class CteShadowComposerTest extends TestCase
 
         self::assertSame(
             "WITH RECURSIVE \"nodes\" AS (SELECT 1 AS id),\n tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree",
-            (new CteShadowComposer())->compose($sql, ['nodes' => '"nodes" AS (SELECT 1 AS id)']),
+            (new SqliteCteShadowComposer())->compose($sql, ['nodes' => '"nodes" AS (SELECT 1 AS id)']),
         );
     }
 
@@ -32,7 +27,7 @@ final class CteShadowComposerTest extends TestCase
 
         self::assertSame(
             $sql,
-            (new CteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 2 AS id)']),
+            (new SqliteCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 2 AS id)']),
         );
     }
 
@@ -42,7 +37,7 @@ final class CteShadowComposerTest extends TestCase
 
         self::assertSame(
             "WITH \"users\" AS (SELECT 1 AS id),\n filtered AS (SELECT * FROM users WHERE active) SELECT * FROM filtered",
-            (new CteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
+            (new SqliteCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
         );
     }
 
@@ -52,7 +47,7 @@ final class CteShadowComposerTest extends TestCase
 
         self::assertSame(
             $sql,
-            (new CteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
+            (new SqliteCteShadowComposer())->compose($sql, ['users' => '"users" AS (SELECT 1 AS id)']),
         );
     }
 
@@ -60,7 +55,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             ['first', 'second'],
-            (new CteShadowComposer())->declaredCteNames('WITH "first"(id) AS MATERIALIZED (SELECT 1), second AS (SELECT 2) SELECT * FROM second'),
+            (new SqliteCteShadowComposer())->declaredCteNames('WITH "first"(id) AS MATERIALIZED (SELECT 1), second AS (SELECT 2) SELECT * FROM second'),
         );
     }
 
@@ -70,7 +65,7 @@ final class CteShadowComposerTest extends TestCase
 
         self::assertSame(
             "WITH first AS (SELECT 1), second(id) AS (SELECT * FROM first)\nSELECT 2 AS id FROM users",
-            (new CteShadowComposer())->carryPrefix($sql, 'SELECT 2 AS id FROM users'),
+            (new SqliteCteShadowComposer())->carryPrefix($sql, 'SELECT 2 AS id FROM users'),
         );
     }
 
@@ -78,7 +73,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "WITH source AS (SELECT 1),\nprojected AS (SELECT * FROM source)\nSELECT * FROM projected",
-            (new CteShadowComposer())->carryPrefix(
+            (new SqliteCteShadowComposer())->carryPrefix(
                 'WITH source AS (SELECT 1) INSERT INTO target SELECT * FROM source',
                 'WITH projected AS (SELECT * FROM source) SELECT * FROM projected',
             ),
@@ -89,7 +84,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "WITH users AS (SELECT 1 AS id),\nchosen AS (SELECT id FROM users)\nSELECT * FROM users WHERE id IN (SELECT id FROM chosen)",
-            (new CteShadowComposer())->carryPrefix(
+            (new SqliteCteShadowComposer())->carryPrefix(
                 'WITH chosen AS (SELECT id FROM users) UPDATE users SET id = 2',
                 'WITH users AS (SELECT 1 AS id) SELECT * FROM users WHERE id IN (SELECT id FROM chosen)',
             ),
@@ -100,7 +95,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             'DELETE FROM users WHERE id IN (SELECT id FROM chosen)',
-            (new CteShadowComposer())->statementSql('WITH chosen AS (SELECT 1 AS id) DELETE FROM users WHERE id IN (SELECT id FROM chosen)'),
+            (new SqliteCteShadowComposer())->statementSql('WITH chosen AS (SELECT 1 AS id) DELETE FROM users WHERE id IN (SELECT id FROM chosen)'),
         );
     }
 
@@ -108,7 +103,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "WITH users AS (SELECT 1 AS id)\nSELECT * FROM users",
-            (new CteShadowComposer())->compose(
+            (new SqliteCteShadowComposer())->compose(
                 'SELECT * FROM users',
                 ['users' => 'users AS (SELECT 1 AS id)'],
             ),
@@ -117,7 +112,7 @@ final class CteShadowComposerTest extends TestCase
 
     public function testSkipsEntriesIndependentlyAndMatchesDeclaredNamesCaseInsensitively(): void
     {
-        $composer = new CteShadowComposer();
+        $composer = new SqliteCteShadowComposer();
 
         self::assertSame(
             "WITH orders AS (SELECT 2 AS id)\nSELECT * FROM orders",
@@ -140,7 +135,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "WITH shadow AS (SELECT 1),\n",
-            (new CteShadowComposer())->compose('WITH', ['WITH' => 'shadow AS (SELECT 1)']),
+            (new SqliteCteShadowComposer())->compose('WITH', ['WITH' => 'shadow AS (SELECT 1)']),
         );
     }
 
@@ -148,7 +143,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "WITH source AS (SELECT 1)\n",
-            (new CteShadowComposer())->carryPrefix(
+            (new SqliteCteShadowComposer())->carryPrefix(
                 'WITH source AS (SELECT 1) UPDATE users SET id = 2',
                 '',
             ),
@@ -159,7 +154,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "/* lead */ WITH RECURSIVE projected AS (SELECT 2),\noriginal AS (SELECT 1)\nSELECT * FROM projected",
-            (new CteShadowComposer())->carryPrefix(
+            (new SqliteCteShadowComposer())->carryPrefix(
                 '/* lead */ WITH RECURSIVE original AS (SELECT 1) UPDATE users SET id = 2',
                 'WITH projected AS (SELECT 2) SELECT * FROM projected',
             ),
@@ -170,7 +165,7 @@ final class CteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "WITH source AS (SELECT 1),\nprojected AS (SELECT * FROM source)\nSELECT * FROM projected",
-            (new CteShadowComposer())->carryPrefix(
+            (new SqliteCteShadowComposer())->carryPrefix(
                 'WITH source AS (SELECT 1) INSERT INTO target SELECT * FROM source',
                 'WITH RECURSIVE projected AS (SELECT * FROM source) SELECT * FROM projected',
             ),
@@ -180,7 +175,7 @@ final class CteShadowComposerTest extends TestCase
     public function testParsesRecursiveMaterializationAndNestedCteBodies(): void
     {
         $sql = 'WITH RECURSIVE "FIRST"(id) AS MATERIALIZED (SELECT (1)), second AS NOT MATERIALIZED (SELECT id FROM "FIRST") DELETE FROM target';
-        $composer = new CteShadowComposer();
+        $composer = new SqliteCteShadowComposer();
 
         self::assertSame(['first', 'second'], $composer->declaredCteNames($sql));
         self::assertSame('DELETE FROM target', $composer->statementSql($sql));
@@ -188,7 +183,7 @@ final class CteShadowComposerTest extends TestCase
 
     public function testHandlesNonHeadersIncompleteHeadersAndEmptyInput(): void
     {
-        $composer = new CteShadowComposer();
+        $composer = new SqliteCteShadowComposer();
 
         self::assertSame([], $composer->declaredCteNames(''));
         self::assertSame('SELECT 1', $composer->statementSql('SELECT 1'));
@@ -208,7 +203,7 @@ final class CteShadowComposerTest extends TestCase
 
     public function testUnquotesEmptyAndEscapedCteIdentifiers(): void
     {
-        $composer = new CteShadowComposer();
+        $composer = new SqliteCteShadowComposer();
 
         self::assertSame([''], $composer->declaredCteNames('WITH "" AS (SELECT 1) SELECT 1'));
         self::assertSame(

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -2939,4 +2939,34 @@ SELECT * FROM users'));
 
         self::assertSame(['events', 'archived_events'], $parser->extractSelectTables($sql));
     }
+
+    public function testExtractTargetTableUsesTheTopLevelDmlTailAfterCtesAndComments(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            'insert_target',
+            $parser->extractTargetTable(
+                "WITH source AS (SELECT 'INTO decoy') /* boundary */ INSERT/* keyword */INTO insert_target VALUES (1)",
+            ),
+        );
+        self::assertSame(
+            'replace_target',
+            $parser->extractTargetTable(
+                "WITH source AS (SELECT 'INTO decoy') /* boundary */ REPLACE/* keyword */INTO replace_target VALUES (1)",
+            ),
+        );
+        self::assertSame(
+            'update_target',
+            $parser->extractTargetTable(
+                'WITH source AS (SELECT 1 AS UPDATE) /* boundary */ UPDATE/* keyword */update_target SET value = 1',
+            ),
+        );
+        self::assertSame(
+            'delete_target',
+            $parser->extractTargetTable(
+                'WITH source AS (SELECT * FROM decoy) /* boundary */ DELETE/* keyword */FROM delete_target',
+            ),
+        );
+    }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -53,6 +53,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class SqliteRewriterTest extends RewriterContractTest
 {
     protected function createRewriter(ShadowStore $store, TableDefinitionRegistry $registry): SqlRewriter

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -45,6 +45,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(SqliteTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class SqliteSessionFactoryTest extends TestCase
 {
     public function testCreateReturnsSession(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class DeleteTransformerTest extends TestCase
 {
     public function testTransformSimpleDelete(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -29,6 +29,7 @@ use ZtdQuery\Schema\IdentityGenerationStrategy;
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\Transformer\InsertRowRenderer::class)]
 #[UsesClass(InsertSelectRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class InsertTransformerTest extends TestCase
 {
     public function testUsesInjectedCastRendererAndColumnTypes(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -25,6 +25,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
     public function testUsesInjectedValueRenderer(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
@@ -30,6 +30,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class SqliteTransformerTest extends TestCase
 {
     public function testTransformSelect(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class UpdateTransformerTest extends TestCase
 {
     public function testTransformSimpleUpdate(): void


### PR DESCRIPTION
## Root cause

Every platform prepended shadow CTE text independently. This placed shadows before the `RECURSIVE` modifier, duplicated user-owned names, dropped CTE headers from rewritten DML, and ignored dependency order between shadow, user, and projection CTEs.

## Fix

- add one token-based CTE header parser/composer in core
- preserve `WITH RECURSIVE` and user column lists/materialization modifiers
- skip shadow definitions for names owned by a user CTE
- topologically order physical shadow CTEs, user CTEs, and result-projection CTEs
- carry user CTE headers through INSERT/UPDATE/DELETE result-select rewrites
- unwrap MySQL parser `WithStatement` nodes to resolve the actual mutation

## Verification

- MySQL, PostgreSQL, and SQLite real integrations cover CTE INSERT/UPDATE/DELETE
- MySQL, PostgreSQL, and SQLite real integrations cover recursive traversal
- MySQL and SQLite integrations cover user CTE names that collide with physical tables
- core and all platform suites, lint, and PHPStan pass

Fixes #12
Fixes #28
Fixes #52
Fixes #109
Fixes #110
Fixes #172
Fixes #173