### PR TITLE
Carry original mutation row identity

### DIFF
--- a/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
+++ b/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
@@ -22,6 +22,7 @@ interface SqlTransformer
      *     rows: array<int, array<string, mixed>>,
      *     columns: array<int, string>,
      *     columnTypes: array<string, ColumnType>,
+     *     primaryKeys?: array<int, string>,
      *     columnDefaults?: array<string, string>,
      *     identityStrategies?: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>
      * }> $tables Table name => shadow data and column information.

--- a/packages/ztd-query-core/src/Shadow/Mutation/MutationRowIdentity.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MutationRowIdentity.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+final class MutationRowIdentity
+{
+    private const PREFIX = '__ztd_original_';
+
+    public function column(string $primaryKey): string
+    {
+        return self::PREFIX . $primaryKey;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<int, string> $primaryKeys
+     * @return array{row: array<string, mixed>, identity: array<string, mixed>}
+     */
+    public function extract(array $row, array $primaryKeys): array
+    {
+        $identity = [];
+        foreach ($primaryKeys as $primaryKey) {
+            $metadataColumn = $this->column($primaryKey);
+            if (array_key_exists($metadataColumn, $row)) {
+                $identity[$primaryKey] = $row[$metadataColumn];
+                unset($row[$metadataColumn]);
+                continue;
+            }
+            if (array_key_exists($primaryKey, $row)) {
+                $identity[$primaryKey] = $row[$primaryKey];
+            }
+        }
+
+        return ['row' => $row, 'identity' => $identity];
+    }
+}

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpdateMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpdateMutation.php
@@ -75,6 +75,13 @@ final class UpdateMutation implements ShadowMutation
      */
     public function apply(ShadowStore $store, array $rows): void
     {
+        $identity = new MutationRowIdentity();
+        $updates = [];
+        foreach ($rows as $row) {
+            $updates[] = $identity->extract($row, $this->primaryKeys);
+        }
+        $rows = array_column($updates, 'row');
+
         if ($this->validateConstraints && $this->tableDefinition !== null) {
             $existingRows = $store->get($this->tableName);
 
@@ -84,7 +91,7 @@ final class UpdateMutation implements ShadowMutation
             }
         }
 
-        $store->update($this->tableName, $rows, $this->primaryKeys);
+        $store->updateIdentified($this->tableName, $updates, $this->primaryKeys);
     }
 
     /**

--- a/packages/ztd-query-core/src/Shadow/ShadowStore.php
+++ b/packages/ztd-query-core/src/Shadow/ShadowStore.php
@@ -181,6 +181,30 @@ class ShadowStore
     }
 
     /**
+     * @param list<array{row: array<string, mixed>, identity: array<string, mixed>}> $updates
+     * @param array<int, string> $primaryKeys
+     */
+    public function updateIdentified(string $tableName, array $updates, array $primaryKeys): void
+    {
+        if (!isset($this->fixtures[$tableName])) {
+            return;
+        }
+        if ($primaryKeys === []) {
+            throw new MissingPrimaryKeyException($tableName);
+        }
+
+        $currentRows = &$this->fixtures[$tableName];
+        foreach ($updates as $update) {
+            foreach ($currentRows as &$currentRow) {
+                if ($this->rowsMatch($currentRow, $update['identity'], $primaryKeys)) {
+                    $currentRow = $update['row'];
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
      * @param array<string, mixed> $left
      * @param array<string, mixed> $right
      * @param array<int, string> $primaryKeys

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -19,6 +19,7 @@ use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Session;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(Session::class)]
@@ -29,6 +30,7 @@ use ZtdQuery\Shadow\ShadowStore;
 #[UsesClass(DatabaseException::class)]
 #[UsesClass(RewritePlan::class)]
 #[UsesClass(UpdateMutation::class)]
+#[UsesClass(MutationRowIdentity::class)]
 #[UsesClass(MissingPrimaryKeyException::class)]
 final class SessionTest extends TestCase
 {

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationRowIdentityTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationRowIdentityTest.php
@@ -11,6 +11,11 @@ use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 #[CoversClass(MutationRowIdentity::class)]
 final class MutationRowIdentityTest extends TestCase
 {
+    public function testBuildsReservedMetadataColumnName(): void
+    {
+        self::assertSame('__ztd_original_id', (new MutationRowIdentity())->column('id'));
+    }
+
     public function testSeparatesOriginalCompositeKeyFromTheUpdatedRow(): void
     {
         self::assertSame(

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationRowIdentityTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationRowIdentityTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
+
+#[CoversClass(MutationRowIdentity::class)]
+final class MutationRowIdentityTest extends TestCase
+{
+    public function testSeparatesOriginalCompositeKeyFromTheUpdatedRow(): void
+    {
+        self::assertSame(
+            [
+                'row' => ['tenant_id' => 2, 'id' => 20, 'value' => 'changed'],
+                'identity' => ['tenant_id' => 1, 'id' => 10],
+            ],
+            (new MutationRowIdentity())->extract([
+                'tenant_id' => 2,
+                'id' => 20,
+                'value' => 'changed',
+                '__ztd_original_tenant_id' => 1,
+                '__ztd_original_id' => 10,
+            ], ['tenant_id', 'id']),
+        );
+    }
+
+    public function testFallsBackToCurrentKeyForLegacyProjections(): void
+    {
+        self::assertSame(
+            ['row' => ['id' => 1], 'identity' => ['id' => 1]],
+            (new MutationRowIdentity())->extract(['id' => 1], ['id']),
+        );
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/ShadowMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/ShadowMutationTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\MutationContractTest;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\ShadowStore;
@@ -18,6 +19,7 @@ use ZtdQuery\Shadow\ShadowStore;
 #[CoversClass(UpdateMutation::class)]
 #[CoversClass(TruncateMutation::class)]
 #[UsesClass(ShadowStore::class)]
+#[UsesClass(MutationRowIdentity::class)]
 final class ShadowMutationTest extends MutationContractTest
 {
     protected function initialRows(): array

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpdateMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpdateMutationTest.php
@@ -8,6 +8,7 @@ use ZtdQuery\Exception\DuplicateKeyException;
 use ZtdQuery\Exception\NotNullViolationException;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\ShadowStore;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -17,6 +18,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(NotNullViolationException::class)]
 #[UsesClass(TableDefinition::class)]
 #[UsesClass(ShadowStore::class)]
+#[UsesClass(MutationRowIdentity::class)]
 #[CoversClass(UpdateMutation::class)]
 final class UpdateMutationTest extends TestCase
 {

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -231,6 +231,7 @@ final class MySqlRewriter implements SqlRewriter
                 'columnTypes' => $columnTypes,
                 'columnDefaults' => $columnDefaults,
                 'identityStrategies' => $identityStrategies,
+                'primaryKeys' => $definition !== null ? $definition->primaryKeys : [],
             ];
         }
 
@@ -246,6 +247,7 @@ final class MySqlRewriter implements SqlRewriter
                 'columnTypes' => $definition->typedColumns,
                 'columnDefaults' => $definition->columnDefaults,
                 'identityStrategies' => $definition->identityStrategies,
+                'primaryKeys' => $definition->primaryKeys,
             ];
         }
 

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -10,9 +10,10 @@ use PhpMyAdmin\SqlParser\Components\Limit;
 use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
-use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
+use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Rewrite\SqlTransformer;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 
 /**
  * Transforms UPDATE statements into SELECT projections with CTE shadowing.
@@ -60,7 +61,11 @@ final class UpdateTransformer implements SqlTransformer
 
         $columns = $tables[$targetTable]['columns'] ?? [];
 
-        $projection = $this->buildProjection($statement, $columns);
+        $projection = $this->buildProjection(
+            $statement,
+            $columns,
+            $tables[$targetTable]['primaryKeys'] ?? [],
+        );
 
         return $this->selectTransformer->transform(
             $this->cteComposer->carryPrefix($sql, $projection['sql']),
@@ -73,9 +78,10 @@ final class UpdateTransformer implements SqlTransformer
      *
      * @param UpdateStatement $stmt
      * @param array<int, string> $columns
+     * @param array<int, string> $primaryKeys
      * @return array{sql: string, table: string, tables: array<string, array{alias: string}>}
      */
-    public function buildProjection(UpdateStatement $stmt, array $columns): array
+    public function buildProjection(UpdateStatement $stmt, array $columns, array $primaryKeys = []): array
     {
         if ($stmt->tables === null || $stmt->tables === []) {
             throw new \RuntimeException("Update statement has no tables?");
@@ -121,6 +127,11 @@ final class UpdateTransformer implements SqlTransformer
             }
         }
 
+        $identity = new MutationRowIdentity();
+        foreach ($primaryKeys as $primaryKey) {
+            $selectCols[] = "`$qualifier`.`$primaryKey` AS `" . $identity->column($primaryKey) . '`';
+        }
+
         if ($selectCols === []) {
             $selectCols[] = "*";
         }
@@ -154,7 +165,12 @@ final class UpdateTransformer implements SqlTransformer
             $limitClause = " LIMIT " . Limit::build($stmt->limit);
         }
 
-        $sql = "SELECT $selectList FROM `$targetTableName`$aliasClause$additionalTables$joinClause$whereClause$orderByClause$limitClause";
+        if ($additionalTables === '' && $joinClause === '' && ($orderByClause !== '' || $limitClause !== '')) {
+            $selectedRows = "SELECT * FROM `$targetTableName`$aliasClause$whereClause$orderByClause$limitClause";
+            $sql = "SELECT $selectList FROM ($selectedRows) AS `$qualifier`";
+        } else {
+            $sql = "SELECT $selectList FROM `$targetTableName`$aliasClause$additionalTables$joinClause$whereClause$orderByClause$limitClause";
+        }
 
         return ['sql' => $sql, 'table' => $targetTableName, 'tables' => $allTargetTables];
     }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -220,7 +220,7 @@ final class MySqlRewriterTest extends RewriterContractTest
         $parser = new MySqlParser();
         $schemaParser = new MySqlSchemaParser($parser);
         $registry = new TableDefinitionRegistry();
-        $def = $schemaParser->parse('CREATE TABLE users (id INT, name VARCHAR(255))');
+        $def = $schemaParser->parse('CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255))');
         self::assertNotNull($def);
         $registry->register('users', $def);
 
@@ -238,6 +238,7 @@ final class MySqlRewriterTest extends RewriterContractTest
         self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
         self::assertInstanceOf(UpdateMutation::class, $plan->mutation());
         self::assertSame('users', $plan->mutation()->tableName());
+        self::assertStringContainsString('`users`.`id` AS `__ztd_original_id`', $plan->sql());
         self::assertMatchesRegularExpression('/^(?:WITH\b|SELECT\b)/i', $plan->sql(), 'UPDATE result-select must start with SELECT or WITH...SELECT');
     }
 

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -172,12 +172,14 @@ final class UpdateTransformerTest extends TestCase
                 'rows' => [],
                 'columns' => ['id', 'name'],
                 'columnTypes' => [],
+                'primaryKeys' => ['id'],
             ],
         ];
 
         $result = $transformer->transform($sql, $tables);
         self::assertStringContainsString('SELECT', $result);
         self::assertStringContainsString("'Bob' AS `name`", $result);
+        self::assertStringContainsString('`users`.`id` AS `__ztd_original_id`', $result);
     }
 
     public function testTransformUpdateWithPartitionThrows(): void
@@ -201,6 +203,51 @@ final class UpdateTransformerTest extends TestCase
 
         self::assertStringContainsString('ORDER BY', $result['sql']);
         self::assertStringContainsString('LIMIT', $result['sql']);
+    }
+
+    public function testBuildUpdateSelectWithOnlyOrderBySelectsRowsBeforeProjecting(): void
+    {
+        $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
+        $parser = new Parser("UPDATE users SET name = 'Bob' ORDER BY id");
+        $statement = $parser->statements[0];
+        self::assertInstanceOf(\PhpMyAdmin\SqlParser\Statements\UpdateStatement::class, $statement);
+
+        $result = $transformer->buildProjection($statement, ['id', 'name']);
+
+        self::assertSame(
+            "SELECT 'Bob' AS `name`, `users`.`id` FROM (SELECT * FROM `users` ORDER BY id ASC) AS `users`",
+            $result['sql'],
+        );
+    }
+
+    public function testBuildUpdateSelectWithOnlyLimitSelectsRowsBeforeProjecting(): void
+    {
+        $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
+        $parser = new Parser("UPDATE users SET name = 'Bob' LIMIT 2");
+        $statement = $parser->statements[0];
+        self::assertInstanceOf(\PhpMyAdmin\SqlParser\Statements\UpdateStatement::class, $statement);
+
+        $result = $transformer->buildProjection($statement, ['id', 'name']);
+
+        self::assertSame(
+            "SELECT 'Bob' AS `name`, `users`.`id` FROM (SELECT * FROM `users` LIMIT 0, 2) AS `users`",
+            $result['sql'],
+        );
+    }
+
+    public function testBuildUpdateSelectWithJoinAndLimitKeepsJoinInResultSelect(): void
+    {
+        $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
+        $parser = new Parser("UPDATE users JOIN orders ON users.id = orders.user_id SET users.name = 'Bob' LIMIT 2");
+        $statement = $parser->statements[0];
+        self::assertInstanceOf(\PhpMyAdmin\SqlParser\Statements\UpdateStatement::class, $statement);
+
+        $result = $transformer->buildProjection($statement, ['id', 'name']);
+
+        self::assertSame(
+            "SELECT 'Bob' AS `name`, `users`.`id` FROM `users` JOIN `orders` ON users.id = orders.user_id LIMIT 0, 2",
+            $result['sql'],
+        );
     }
 
     public function testBuildUpdateSelectWithEmptyColumnsUsesWildcard(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -578,7 +578,7 @@ final class UpdateTransformerTest extends TestCase
         self::assertInstanceOf(\PhpMyAdmin\SqlParser\Statements\UpdateStatement::class, $statement);
 
         $result = $transformer->buildProjection($statement, ['id', 'name']);
-        self::assertSame("SELECT 'X' AS `name`, `users`.`id` FROM `users` ORDER BY id ASC LIMIT 0, 5", $result['sql']);
+        self::assertSame("SELECT 'X' AS `name`, `users`.`id` FROM (SELECT * FROM `users` ORDER BY id ASC LIMIT 0, 5) AS `users`", $result['sql']);
     }
 
     public function testBuildProjectionExactSqlForUpdateWithJoin(): void

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -64,6 +64,29 @@ final class MysqliCteShadowingTest extends TestCase
         }
     }
 
+    public function testOrderedLimitedUpdateKeepsOriginalIdentityAndSwapSnapshot(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, left_value VARCHAR(20), right_value VARCHAR(20))', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (1, 'a1', 'b1'), (2, 'a2', 'b2'), (3, 'a3', 'b3')", $table));
+            $ztdMysqli->query(sprintf('UPDATE `%s` SET id = 30, left_value = right_value, right_value = left_value ORDER BY id DESC LIMIT 1', $table));
+
+            $result = $ztdMysqli->query(sprintf('SELECT * FROM `%s` ORDER BY id', $table));
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([
+                ['id' => 1, 'left_value' => 'a1', 'right_value' => 'b1'],
+                ['id' => 2, 'left_value' => 'a2', 'right_value' => 'b2'],
+                ['id' => 30, 'left_value' => 'b3', 'right_value' => 'a3'],
+            ], $result->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testInsertSelectPreservesStarJoinsAggregatesDistinctAndRollup(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateBasicTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateBasicTest.php
@@ -91,5 +91,10 @@ final class UpdateBasicTest extends TestCase
             ['id' => 2, 'left_value' => 'second', 'right_value' => 'row'],
             ['id' => 10, 'left_value' => 'right', 'right_value' => 'left'],
         ], $statement->fetchAll());
+
+        self::assertSame(2, $ztdPdo->exec('DELETE FROM pairs'));
+        $statement = $ztdPdo->query('SELECT * FROM pairs');
+        self::assertNotFalse($statement);
+        self::assertSame([], $statement->fetchAll());
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateBasicTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateBasicTest.php
@@ -91,10 +91,5 @@ final class UpdateBasicTest extends TestCase
             ['id' => 2, 'left_value' => 'second', 'right_value' => 'row'],
             ['id' => 10, 'left_value' => 'right', 'right_value' => 'left'],
         ], $statement->fetchAll());
-
-        self::assertSame(2, $ztdPdo->exec('DELETE FROM pairs'));
-        $statement = $ztdPdo->query('SELECT * FROM pairs');
-        self::assertNotFalse($statement);
-        self::assertSame([], $statement->fetchAll());
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateBasicTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateBasicTest.php
@@ -76,4 +76,25 @@ final class UpdateBasicTest extends TestCase
         $rawRows = $stmt->fetchAll();
         self::assertSame('Alice', $rawRows[0]['name']);
     }
+
+    public function testPrimaryKeyChangesAndColumnSwapsRetainOriginalRowIdentity(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $rawPdo->exec('CREATE TABLE pairs (id INTEGER PRIMARY KEY, left_value TEXT, right_value TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO pairs VALUES (1, 'left', 'right'), (2, 'second', 'row')");
+
+        self::assertSame(1, $ztdPdo->exec('UPDATE pairs SET id = 10, left_value = right_value, right_value = left_value WHERE id = 1'));
+        $statement = $ztdPdo->query('SELECT * FROM pairs ORDER BY id');
+        self::assertNotFalse($statement);
+        self::assertSame([
+            ['id' => 2, 'left_value' => 'second', 'right_value' => 'row'],
+            ['id' => 10, 'left_value' => 'right', 'right_value' => 'left'],
+        ], $statement->fetchAll());
+
+        self::assertSame(2, $ztdPdo->exec('DELETE FROM pairs'));
+        $statement = $ztdPdo->query('SELECT * FROM pairs');
+        self::assertNotFalse($statement);
+        self::assertSame([], $statement->fetchAll());
+    }
 }

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -190,6 +190,7 @@ final class PgSqlRewriter implements SqlRewriter
                 'columnTypes' => $columnTypes,
                 'columnDefaults' => $columnDefaults,
                 'identityStrategies' => $identityStrategies,
+                'primaryKeys' => $definition !== null ? $definition->primaryKeys : [],
             ];
         }
 
@@ -205,6 +206,7 @@ final class PgSqlRewriter implements SqlRewriter
                 'columnTypes' => $definition->typedColumns,
                 'columnDefaults' => $definition->columnDefaults,
                 'identityStrategies' => $definition->identityStrategies,
+                'primaryKeys' => $definition->primaryKeys,
             ];
         }
 

--- a/packages/ztd-query-postgres/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/UpdateTransformer.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Postgres\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
-use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
+use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Rewrite\SqlTransformer;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 
 /**
  * Transforms UPDATE statements into SELECT projections with CTE shadowing.
@@ -42,7 +43,12 @@ final class UpdateTransformer implements SqlTransformer
         }
 
         $columns = $tables[$targetTable]['columns'] ?? [];
-        $projection = $this->buildProjection($sql, $targetTable, $columns);
+        $projection = $this->buildProjection(
+            $sql,
+            $targetTable,
+            $columns,
+            $tables[$targetTable]['primaryKeys'] ?? [],
+        );
 
         return $this->selectTransformer->transform(
             $this->cteComposer->carryPrefix($sql, $projection['sql']),
@@ -54,10 +60,15 @@ final class UpdateTransformer implements SqlTransformer
      * Build a result-select SQL from an UPDATE statement.
      *
      * @param array<int, string> $columns
+     * @param array<int, string> $primaryKeys
      * @return array{sql: string, table: string, tables: array<string, array{alias: string}>}
      */
-    public function buildProjection(string $sql, string $targetTable, array $columns): array
-    {
+    public function buildProjection(
+        string $sql,
+        string $targetTable,
+        array $columns,
+        array $primaryKeys = [],
+    ): array {
         $alias = $this->parser->extractUpdateAlias($sql);
         $qualifier = $alias ?? $targetTable;
 
@@ -75,6 +86,11 @@ final class UpdateTransformer implements SqlTransformer
             if (!isset($coveredCols[$col])) {
                 $selectCols[] = "\"$qualifier\".\"$col\"";
             }
+        }
+
+        $identity = new MutationRowIdentity();
+        foreach ($primaryKeys as $primaryKey) {
+            $selectCols[] = '"' . $qualifier . '"."' . $primaryKey . '" AS "' . $identity->column($primaryKey) . '"';
         }
 
         if ($selectCols === []) {

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -252,6 +252,7 @@ final class PgSqlRewriterTest extends RewriterContractTest
         self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
         self::assertNotNull($plan->mutation());
         self::assertInstanceOf(UpdateMutation::class, $plan->mutation());
+        self::assertStringContainsString('"users"."id" AS "__ztd_original_id"', $plan->sql());
     }
 
     public function testDeleteReturnsWriteSimulatedWithMutation(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -115,12 +115,14 @@ final class UpdateTransformerTest extends TestCase
                     'id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
                     'name' => new ColumnType(ColumnTypeFamily::TEXT, 'TEXT'),
                 ],
+                'primaryKeys' => ['id'],
             ],
         ];
 
         $result = $transformer->transform($sql, $tables);
         self::assertStringContainsString('WITH', $result);
         self::assertStringContainsString('"users" AS MATERIALIZED', $result);
+        self::assertStringContainsString('"users"."id" AS "__ztd_original_id"', $result);
     }
 
     public function testTransformThrowsOnUnresolvableTarget(): void

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -118,11 +118,6 @@ final class SqliteRewriter implements SqlRewriter
 
         $mutation = $this->mutationResolver->resolve($stmtSql, $kind);
 
-        $stripped = trim($this->parser->stripComments($stmtSql));
-        if (preg_match('/^DELETE\s+FROM\s+(?:"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s;]+)\s*;?\s*$/i', $stripped) === 1) {
-            return new RewritePlan($this->emptyResultSelect(), QueryKind::WRITE_SIMULATED, $mutation);
-        }
-
         $transformedSql = $this->transformer->transform($stmtSql, $tableContext);
 
         return new RewritePlan($transformedSql, QueryKind::WRITE_SIMULATED, $mutation);

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -167,6 +167,7 @@ final class SqliteRewriter implements SqlRewriter
                 'columnTypes' => $columnTypes,
                 'columnDefaults' => $columnDefaults,
                 'identityStrategies' => $identityStrategies,
+                'primaryKeys' => $definition !== null ? $definition->primaryKeys : [],
             ];
         }
 
@@ -182,6 +183,7 @@ final class SqliteRewriter implements SqlRewriter
                 'columnTypes' => $definition->typedColumns,
                 'columnDefaults' => $definition->columnDefaults,
                 'identityStrategies' => $definition->identityStrategies,
+                'primaryKeys' => $definition->primaryKeys,
             ];
         }
 

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -11,6 +11,7 @@ use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
 
@@ -135,7 +136,8 @@ final class SqliteRewriter implements SqlRewriter
      *     columns: array<int, string>,
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
      *     columnDefaults: array<string, string>,
-     *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>
+     *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
+     *     primaryKeys: array<int, string>
      * }>
      */
     private function buildTableContext(): array
@@ -145,30 +147,30 @@ final class SqliteRewriter implements SqlRewriter
 
         foreach ($allData as $tableName => $rows) {
             $definition = $this->registry->get($tableName);
-            $columns = $definition?->columns;
-            if ($columns === null && $rows !== []) {
-                $columns = array_keys($rows[0]);
-                foreach ($rows as $row) {
-                    foreach (array_keys($row) as $column) {
-                        if (!in_array($column, $columns, true)) {
-                            $columns[] = $column;
+            if ($definition !== null) {
+                $context[$tableName] = self::contextFromDefinition($definition, $rows);
+            } else {
+                $columns = [];
+                if ($rows !== []) {
+                    $columns = array_keys($rows[0]);
+                    foreach ($rows as $row) {
+                        foreach (array_keys($row) as $column) {
+                            if (!in_array($column, $columns, true)) {
+                                $columns[] = $column;
+                            }
                         }
                     }
                 }
+
+                $context[$tableName] = [
+                    'rows' => $rows,
+                    'columns' => $columns,
+                    'columnTypes' => [],
+                    'columnDefaults' => [],
+                    'identityStrategies' => [],
+                    'primaryKeys' => [],
+                ];
             }
-
-            $columnTypes = $definition !== null ? $definition->typedColumns : [];
-            $columnDefaults = $definition !== null ? $definition->columnDefaults : [];
-            $identityStrategies = $definition !== null ? $definition->identityStrategies : [];
-
-            $context[$tableName] = [
-                'rows' => $rows,
-                'columns' => $columns ?? [],
-                'columnTypes' => $columnTypes,
-                'columnDefaults' => $columnDefaults,
-                'identityStrategies' => $identityStrategies,
-                'primaryKeys' => $definition !== null ? $definition->primaryKeys : [],
-            ];
         }
 
         $allDefinitions = $this->registry->getAll();
@@ -177,17 +179,33 @@ final class SqliteRewriter implements SqlRewriter
                 continue;
             }
 
-            $context[$tableName] = [
-                'rows' => [],
-                'columns' => $definition->columns,
-                'columnTypes' => $definition->typedColumns,
-                'columnDefaults' => $definition->columnDefaults,
-                'identityStrategies' => $definition->identityStrategies,
-                'primaryKeys' => $definition->primaryKeys,
-            ];
+            $context[$tableName] = self::contextFromDefinition($definition, []);
         }
 
         return $context;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @return array{
+     *     rows: array<int, array<string, mixed>>,
+     *     columns: array<int, string>,
+     *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
+     *     columnDefaults: array<string, string>,
+     *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
+     *     primaryKeys: array<int, string>
+     * }
+     */
+    private static function contextFromDefinition(TableDefinition $definition, array $rows): array
+    {
+        return [
+            'rows' => $rows,
+            'columns' => $definition->columns,
+            'columnTypes' => $definition->typedColumns,
+            'columnDefaults' => $definition->columnDefaults,
+            'identityStrategies' => $definition->identityStrategies,
+            'primaryKeys' => $definition->primaryKeys,
+        ];
     }
 
     private function findUnknownTable(string $sql): ?string

--- a/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
-use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
+use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Rewrite\SqlTransformer;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 
 /**
  * Transforms UPDATE statements into SELECT projections with CTE shadowing for SQLite.
@@ -46,7 +47,12 @@ final class UpdateTransformer implements SqlTransformer
 
         $columns = $tables[$targetTable]['columns'] ?? [];
 
-        $projection = $this->buildProjection($sql, $targetTable, $columns);
+        $projection = $this->buildProjection(
+            $sql,
+            $targetTable,
+            $columns,
+            $tables[$targetTable]['primaryKeys'] ?? [],
+        );
 
         return $this->selectTransformer->transform(
             $this->cteComposer->carryPrefix($sql, $projection),
@@ -60,10 +66,15 @@ final class UpdateTransformer implements SqlTransformer
      * @param string $sql
      * @param string $targetTable
      * @param array<int, string> $columns
+     * @param array<int, string> $primaryKeys
      * @return string
      */
-    public function buildProjection(string $sql, string $targetTable, array $columns): string
-    {
+    public function buildProjection(
+        string $sql,
+        string $targetTable,
+        array $columns,
+        array $primaryKeys = [],
+    ): string {
         $assignments = $this->parser->extractUpdateAssignments($sql);
 
         $selectCols = [];
@@ -78,6 +89,11 @@ final class UpdateTransformer implements SqlTransformer
             if (!isset($coveredCols[$col])) {
                 $selectCols[] = "\"$targetTable\".\"$col\"";
             }
+        }
+
+        $identity = new MutationRowIdentity();
+        foreach ($primaryKeys as $primaryKey) {
+            $selectCols[] = '"' . $targetTable . '"."' . $primaryKey . '" AS "' . $identity->column($primaryKey) . '"';
         }
 
         if ($selectCols === []) {

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -747,7 +747,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $rewriter = new SqliteRewriter($guard, $store, $registry, $transformer, $mutationResolver, $parser);
 
         $plan = $rewriter->rewrite('DELETE FROM users');
-        self::assertSame('SELECT 1 WHERE 0', $plan->sql());
+        self::assertStringContainsString('FROM "users"', $plan->sql());
     }
 
     public function testDdlSimulatedReturnsSqlSelectWhere0(): void
@@ -1082,7 +1082,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $rewriter = new SqliteRewriter($guard, $store, $registry, $transformer, $mutationResolver, $parser);
 
         $plan = $rewriter->rewrite('DELETE FROM "my_table"');
-        self::assertSame('SELECT 1 WHERE 0', $plan->sql());
+        self::assertStringContainsString('FROM "my_table"', $plan->sql());
     }
 
     public function testDeleteFromWithSemicolonAndWhitespace(): void
@@ -1109,7 +1109,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $rewriter = new SqliteRewriter($guard, $store, $registry, $transformer, $mutationResolver, $parser);
 
         $plan = $rewriter->rewrite('DELETE FROM users ;');
-        self::assertSame('SELECT 1 WHERE 0', $plan->sql());
+        self::assertStringContainsString('FROM "users"', $plan->sql());
     }
 
     public function testUpdateEnsuresShadowStoreCalledOnTarget(): void
@@ -1257,7 +1257,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $rewriter = new SqliteRewriter($guard, $store, $registry, $transformer, $mutationResolver, $parser);
 
         $plan = $rewriter->rewrite('DELETE FROM `t`');
-        self::assertSame('SELECT 1 WHERE 0', $plan->sql());
+        self::assertStringContainsString('FROM "t"', $plan->sql());
     }
 
     public function testDeleteFromBracketQuotedTableReturnsSqlWhere0(): void
@@ -1284,7 +1284,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $rewriter = new SqliteRewriter($guard, $store, $registry, $transformer, $mutationResolver, $parser);
 
         $plan = $rewriter->rewrite('DELETE FROM [t]');
-        self::assertSame('SELECT 1 WHERE 0', $plan->sql());
+        self::assertStringContainsString('FROM "t"', $plan->sql());
     }
 
     public function testUpdateEnsuresShadowStoreForTargetTable(): void
@@ -1366,7 +1366,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $rewriter = new SqliteRewriter($guard, $store, $registry, $transformer, $mutationResolver, $parser);
 
         $plan = $rewriter->rewrite('delete from users');
-        self::assertSame('SELECT 1 WHERE 0', $plan->sql());
+        self::assertStringContainsString('FROM "users"', $plan->sql());
     }
 
     public function testBuildTableContextIncludesMultipleTablesFromRegistry(): void
@@ -1506,7 +1506,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $rewriter = new SqliteRewriter($guard, $store, $registry, $transformer, $mutationResolver, $parser);
 
         $plan = $rewriter->rewrite('/* comment */ DELETE FROM users');
-        self::assertSame('SELECT 1 WHERE 0', $plan->sql());
+        self::assertStringContainsString('FROM "users"', $plan->sql());
     }
 
     public function testSelectRewritesTableAfterBlockComment(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -202,6 +202,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
         self::assertInstanceOf(UpdateMutation::class, $plan->mutation());
         self::assertSame('users', $plan->mutation()->tableName());
+        self::assertStringContainsString('"users"."id" AS "__ztd_original_id"', $plan->sql());
         self::assertMatchesRegularExpression('/^(?:WITH\b|SELECT\b)/i', $plan->sql());
     }
 

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -36,6 +36,7 @@ final class UpdateTransformerTest extends TestCase
                 'rows' => [],
                 'columns' => ['id', 'name', 'email'],
                 'columnTypes' => [],
+                'primaryKeys' => ['id'],
             ],
         ];
 
@@ -45,6 +46,7 @@ final class UpdateTransformerTest extends TestCase
         self::assertStringContainsString("'Bob'", $result);
         self::assertStringContainsString('"name"', $result);
         self::assertStringContainsString('WHERE id = 1', $result);
+        self::assertStringContainsString('"users"."id" AS "__ztd_original_id"', $result);
     }
 
     public function testTransformUpdateWithMultipleAssignments(): void


### PR DESCRIPTION
## Root cause

UPDATE result rows were matched back to shadow rows using post-update primary keys. Changing a key therefore created a ghost row, and ORDER/LIMIT was evaluated after projecting new values. SQLite also special-cased DELETE without WHERE into an empty result.

## Fix

- carry original primary-key values in reserved result metadata
- split identity metadata from user rows at the mutation boundary
- replace rows by original composite identity, then store the clean updated row
- select MySQL ORDER/LIMIT targets before evaluating SET projections
- evaluate DELETE without WHERE as the complete target set
- expose primary-key metadata to all platform transformers

## Verification

- SQLite integration covers PK changes, simultaneous column swaps, and full-table DELETE
- MySQL integration covers ORDER BY DESC/LIMIT, PK changes, and simultaneous swaps
- core identity tests cover composite keys and legacy projections
- platform suites, lint, and PHPStan pass

Fixes #7
Fixes #65
Fixes #94
Fixes #130
Fixes #141