### PR TITLE
Fix conflict detection with candidate keys

### DIFF
--- a/packages/ztd-query-core/src/Schema/CandidateKeyConflict.php
+++ b/packages/ztd-query-core/src/Schema/CandidateKeyConflict.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+/**
+ * Identifies the existing row and candidate key responsible for a conflict.
+ */
+final class CandidateKeyConflict
+{
+    /**
+     * @param array<string, mixed> $values
+     */
+    public function __construct(
+        public readonly int $rowIndex,
+        public readonly string $keyName,
+        public readonly array $values,
+    ) {
+    }
+}

--- a/packages/ztd-query-core/src/Schema/CandidateKeySet.php
+++ b/packages/ztd-query-core/src/Schema/CandidateKeySet.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+/**
+ * Relational candidate keys used to detect INSERT conflicts.
+ */
+final class CandidateKeySet
+{
+    /**
+     * @param array<string, array<int, string>> $keys
+     */
+    public function __construct(private readonly array $keys)
+    {
+    }
+
+    /**
+     * @param array<int, string> $primaryKey
+     * @param array<string, array<int, string>> $uniqueConstraints
+     */
+    public static function fromSchema(array $primaryKey, array $uniqueConstraints = []): self
+    {
+        $keys = $uniqueConstraints;
+        if ($primaryKey !== []) {
+            $keys = ['PRIMARY' => $primaryKey] + $keys;
+        }
+
+        return new self($keys);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<int, array<string, mixed>> $existingRows
+     */
+    public function findConflict(array $row, array $existingRows): ?CandidateKeyConflict
+    {
+        foreach ($this->keys as $keyName => $columns) {
+            $values = $this->values($row, $columns);
+            if ($values === null) {
+                continue;
+            }
+
+            foreach ($existingRows as $rowIndex => $existingRow) {
+                if ($this->matches($values, $existingRow)) {
+                    return new CandidateKeyConflict($rowIndex, $keyName, $values);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<int, string> $columns
+     * @return array<string, mixed>|null
+     */
+    private function values(array $row, array $columns): ?array
+    {
+        if ($columns === []) {
+            return null;
+        }
+
+        $values = [];
+        foreach ($columns as $column) {
+            if (!array_key_exists($column, $row) || $row[$column] === null) {
+                return null;
+            }
+            $values[$column] = $row[$column];
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, mixed> $row
+     */
+    private function matches(array $values, array $row): bool
+    {
+        foreach ($values as $column => $value) {
+            if (!array_key_exists($column, $row) || $row[$column] === null || $row[$column] !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/packages/ztd-query-core/src/Schema/CandidateKeySet.php
+++ b/packages/ztd-query-core/src/Schema/CandidateKeySet.php
@@ -65,7 +65,7 @@ final class CandidateKeySet
 
         $values = [];
         foreach ($columns as $column) {
-            if (!array_key_exists($column, $row) || $row[$column] === null) {
+            if (!isset($row[$column])) {
                 return null;
             }
             $values[$column] = $row[$column];
@@ -81,7 +81,7 @@ final class CandidateKeySet
     private function matches(array $values, array $row): bool
     {
         foreach ($values as $column => $value) {
-            if (!array_key_exists($column, $row) || $row[$column] === null || $row[$column] !== $value) {
+            if (($row[$column] ?? null) !== $value) {
                 return false;
             }
         }

--- a/packages/ztd-query-core/src/Schema/TableDefinition.php
+++ b/packages/ztd-query-core/src/Schema/TableDefinition.php
@@ -44,4 +44,9 @@ final class TableDefinition
         $this->columnDefaults = $columnDefaults;
         $this->identityStrategies = $identityStrategies;
     }
+
+    public function candidateKeys(): CandidateKeySet
+    {
+        return CandidateKeySet::fromSchema($this->primaryKeys, $this->uniqueConstraints);
+    }
 }

--- a/packages/ztd-query-core/src/Shadow/Mutation/InsertMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/InsertMutation.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Shadow\Mutation;
 
 use ZtdQuery\Exception\DuplicateKeyException;
 use ZtdQuery\Exception\NotNullViolationException;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\ShadowStore;
 
@@ -20,13 +21,6 @@ final class InsertMutation implements ShadowMutation
      * @var string
      */
     private string $tableName;
-
-    /**
-     * Primary key columns for duplicate detection.
-     *
-     * @var array<int, string>
-     */
-    private array $primaryKeys;
 
     /**
      * Whether to ignore duplicate key errors.
@@ -56,6 +50,8 @@ final class InsertMutation implements ShadowMutation
      */
     private bool $validateConstraints;
 
+    private CandidateKeySet $candidateKeys;
+
     /**
      * @param string $tableName Target table.
      * @param array<int, string> $primaryKeys Primary key columns.
@@ -63,6 +59,7 @@ final class InsertMutation implements ShadowMutation
      * @param TableDefinition|null $tableDefinition Table definition for constraint validation.
      * @param string $sql Original SQL statement for exception messages.
      * @param bool $validateConstraints Whether to validate constraints.
+     * @param CandidateKeySet|null $candidateKeys Candidate keys used for duplicate detection.
      */
     public function __construct(
         string $tableName,
@@ -70,14 +67,15 @@ final class InsertMutation implements ShadowMutation
         bool $ignore = false,
         ?TableDefinition $tableDefinition = null,
         string $sql = '',
-        bool $validateConstraints = false
+        bool $validateConstraints = false,
+        ?CandidateKeySet $candidateKeys = null,
     ) {
         $this->tableName = $tableName;
-        $this->primaryKeys = $primaryKeys;
         $this->ignore = $ignore;
         $this->tableDefinition = $tableDefinition;
         $this->sql = $sql;
         $this->validateConstraints = $validateConstraints;
+        $this->candidateKeys = $candidateKeys ?? CandidateKeySet::fromSchema($primaryKeys);
     }
 
     /**
@@ -93,23 +91,19 @@ final class InsertMutation implements ShadowMutation
                 $this->validateNotNullConstraints($row);
             }
 
-            if ($this->primaryKeys !== []) {
-                $isDuplicate = $this->isDuplicate($row, $existingRows);
+            $conflict = $this->candidateKeys->findConflict($row, $existingRows);
+            if ($conflict !== null) {
+                if ($this->ignore) {
+                    continue;
+                }
 
-                if ($isDuplicate) {
-                    if ($this->ignore) {
-                        continue;
-                    }
-
-                    if ($this->validateConstraints) {
-                        $keyValues = $this->extractKeyValues($row, $this->primaryKeys);
-                        throw new DuplicateKeyException(
-                            $this->sql,
-                            $this->tableName,
-                            'PRIMARY',
-                            $keyValues
-                        );
-                    }
+                if ($this->validateConstraints) {
+                    throw new DuplicateKeyException(
+                        $this->sql,
+                        $this->tableName,
+                        $conflict->keyName,
+                        $conflict->values
+                    );
                 }
             }
 
@@ -130,35 +124,6 @@ final class InsertMutation implements ShadowMutation
     public function tableName(): string
     {
         return $this->tableName;
-    }
-
-    /**
-     * Check if a row would be a duplicate based on primary keys.
-     *
-     * @param array<string, mixed> $row Row to check.
-     * @param array<int, array<string, mixed>> $existingRows Existing rows in the store.
-     * @return bool True if duplicate.
-     */
-    private function isDuplicate(array $row, array $existingRows): bool
-    {
-        foreach ($existingRows as $existing) {
-            $match = true;
-            foreach ($this->primaryKeys as $key) {
-                if (!isset($row[$key]) || !isset($existing[$key])) {
-                    $match = false;
-                    break;
-                }
-                if ($row[$key] !== $existing[$key]) {
-                    $match = false;
-                    break;
-                }
-            }
-            if ($match) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/packages/ztd-query-core/src/Shadow/Mutation/ReplaceMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/ReplaceMutation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Shadow\Mutation;
 
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\ShadowStore;
 
 /**
@@ -19,21 +20,17 @@ final class ReplaceMutation implements ShadowMutation
      */
     private string $tableName;
 
-    /**
-     * Primary key columns for duplicate detection.
-     *
-     * @var array<int, string>
-     */
-    private array $primaryKeys;
+    private CandidateKeySet $candidateKeys;
 
     /**
      * @param string $tableName Target table.
      * @param array<int, string> $primaryKeys Primary key columns.
+     * @param CandidateKeySet|null $candidateKeys Candidate keys used for conflict detection.
      */
-    public function __construct(string $tableName, array $primaryKeys = [])
+    public function __construct(string $tableName, array $primaryKeys = [], ?CandidateKeySet $candidateKeys = null)
     {
         $this->tableName = $tableName;
-        $this->primaryKeys = $primaryKeys;
+        $this->candidateKeys = $candidateKeys ?? CandidateKeySet::fromSchema($primaryKeys);
     }
 
     /**
@@ -44,9 +41,10 @@ final class ReplaceMutation implements ShadowMutation
         $existingRows = $store->get($this->tableName);
 
         foreach ($rows as $row) {
-            $existingRows = array_filter($existingRows, function ($existing) use ($row) {
-                return !$this->rowsMatch($existing, $row);
-            });
+            while (($conflict = $this->candidateKeys->findConflict($row, $existingRows)) !== null) {
+                unset($existingRows[$conflict->rowIndex]);
+                $existingRows = array_values($existingRows);
+            }
         }
 
         $existingRows = array_values($existingRows);
@@ -60,30 +58,5 @@ final class ReplaceMutation implements ShadowMutation
     public function tableName(): string
     {
         return $this->tableName;
-    }
-
-    /**
-     * Check if rows match based on primary keys.
-     *
-     * @param array<string, mixed> $existing Existing row.
-     * @param array<string, mixed> $new New row.
-     * @return bool True if rows match on primary keys.
-     */
-    private function rowsMatch(array $existing, array $new): bool
-    {
-        if ($this->primaryKeys === []) {
-            return $existing === $new;
-        }
-
-        foreach ($this->primaryKeys as $key) {
-            if (!isset($existing[$key]) || !isset($new[$key])) {
-                return false;
-            }
-            if ($existing[$key] !== $new[$key]) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/packages/ztd-query-core/src/Shadow/Mutation/ReplaceMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/ReplaceMutation.php
@@ -43,7 +43,6 @@ final class ReplaceMutation implements ShadowMutation
         foreach ($rows as $row) {
             while (($conflict = $this->candidateKeys->findConflict($row, $existingRows)) !== null) {
                 unset($existingRows[$conflict->rowIndex]);
-                $existingRows = array_values($existingRows);
             }
         }
 

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Shadow\Mutation;
 
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\ShadowStore;
 
 /**
@@ -39,18 +40,27 @@ final class UpsertMutation implements ShadowMutation
      */
     private array $updateValues;
 
+    private CandidateKeySet $candidateKeys;
+
     /**
      * @param string $tableName Target table.
      * @param array<int, string> $primaryKeys Primary key columns.
      * @param array<int, string> $updateColumns Columns to update on duplicate.
      * @param array<string, string> $updateValues Values to use for update on duplicate.
+     * @param CandidateKeySet|null $candidateKeys Candidate keys used for conflict detection.
      */
-    public function __construct(string $tableName, array $primaryKeys, array $updateColumns = [], array $updateValues = [])
-    {
+    public function __construct(
+        string $tableName,
+        array $primaryKeys,
+        array $updateColumns = [],
+        array $updateValues = [],
+        ?CandidateKeySet $candidateKeys = null,
+    ) {
         $this->tableName = $tableName;
         $this->primaryKeys = $primaryKeys;
         $this->updateColumns = $updateColumns;
         $this->updateValues = $updateValues;
+        $this->candidateKeys = $candidateKeys ?? CandidateKeySet::fromSchema($primaryKeys);
     }
 
     /**
@@ -63,8 +73,9 @@ final class UpsertMutation implements ShadowMutation
         $updateRows = [];
 
         foreach ($rows as $row) {
-            $existingIndex = $this->findDuplicateIndex($row, $existingRows);
-            if ($existingIndex !== null) {
+            $conflict = $this->candidateKeys->findConflict($row, $existingRows);
+            if ($conflict !== null) {
+                $existingIndex = $conflict->rowIndex;
                 $updatedRow = $existingRows[$existingIndex];
                 foreach ($this->updateColumns as $col) {
                     if (isset($this->updateValues[$col])) {
@@ -116,32 +127,4 @@ final class UpsertMutation implements ShadowMutation
         return $this->tableName;
     }
 
-    /**
-     * Find the index of a duplicate row based on primary keys.
-     *
-     * @param array<string, mixed> $row Row to check.
-     * @param array<int, array<string, mixed>> $existingRows Existing rows in the store.
-     * @return int|null Index of duplicate row, or null if no duplicate.
-     */
-    private function findDuplicateIndex(array $row, array $existingRows): ?int
-    {
-        foreach ($existingRows as $index => $existing) {
-            $match = true;
-            foreach ($this->primaryKeys as $key) {
-                if (!isset($row[$key]) || !isset($existing[$key])) {
-                    $match = false;
-                    break;
-                }
-                if ($row[$key] !== $existing[$key]) {
-                    $match = false;
-                    break;
-                }
-            }
-            if ($match) {
-                return $index;
-            }
-        }
-
-        return null;
-    }
 }

--- a/packages/ztd-query-core/tests/Unit/Rewrite/RewritePlanTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/RewritePlanTest.php
@@ -6,12 +6,14 @@ namespace Tests\Unit\Rewrite;
 
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[UsesClass(InsertMutation::class)]
+#[UsesClass(CandidateKeySet::class)]
 #[CoversClass(RewritePlan::class)]
 final class RewritePlanTest extends TestCase
 {

--- a/packages/ztd-query-core/tests/Unit/Schema/CandidateKeyConflictTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/CandidateKeyConflictTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\CandidateKeyConflict;
+
+#[CoversClass(CandidateKeyConflict::class)]
+final class CandidateKeyConflictTest extends TestCase
+{
+    public function testCarriesConflictIdentity(): void
+    {
+        $conflict = new CandidateKeyConflict(3, 'users_email', ['email' => 'alice@example.com']);
+
+        self::assertSame(3, $conflict->rowIndex);
+        self::assertSame('users_email', $conflict->keyName);
+        self::assertSame(['email' => 'alice@example.com'], $conflict->values);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/CandidateKeySetTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/CandidateKeySetTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\CandidateKeyConflict;
+use ZtdQuery\Schema\CandidateKeySet;
+
+#[CoversClass(CandidateKeySet::class)]
+#[UsesClass(CandidateKeyConflict::class)]
+final class CandidateKeySetTest extends TestCase
+{
+    public function testFindsConflictAcrossPrimaryAndUniqueCandidateKeys(): void
+    {
+        $keys = CandidateKeySet::fromSchema(['id'], ['users_email' => ['email']]);
+        $rows = [
+            ['id' => 1, 'email' => 'alice@example.com'],
+            ['id' => 2, 'email' => 'bob@example.com'],
+        ];
+
+        $primaryConflict = $keys->findConflict(['id' => 1, 'email' => 'new@example.com'], $rows);
+        $uniqueConflict = $keys->findConflict(['id' => 3, 'email' => 'bob@example.com'], $rows);
+
+        self::assertInstanceOf(CandidateKeyConflict::class, $primaryConflict);
+        self::assertSame('PRIMARY', $primaryConflict->keyName);
+        self::assertSame(0, $primaryConflict->rowIndex);
+        self::assertInstanceOf(CandidateKeyConflict::class, $uniqueConflict);
+        self::assertSame('users_email', $uniqueConflict->keyName);
+        self::assertSame(1, $uniqueConflict->rowIndex);
+    }
+
+    public function testNullDoesNotConflictOnCompositeUniqueKey(): void
+    {
+        $keys = CandidateKeySet::fromSchema([], ['tenant_slug' => ['tenant_id', 'slug']]);
+        $rows = [['tenant_id' => 1, 'slug' => null]];
+
+        self::assertNull($keys->findConflict(['tenant_id' => 1, 'slug' => null], $rows));
+    }
+
+    public function testEmptyKeySetNeverTreatsEqualRowsAsConflicting(): void
+    {
+        $keys = CandidateKeySet::fromSchema([]);
+        $row = ['name' => 'same'];
+
+        self::assertNull($keys->findConflict($row, [$row]));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/CandidateKeySetTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/CandidateKeySetTest.php
@@ -41,6 +41,32 @@ final class CandidateKeySetTest extends TestCase
         self::assertNull($keys->findConflict(['tenant_id' => 1, 'slug' => null], $rows));
     }
 
+    public function testIncompletePrimaryKeyDoesNotPreventUniqueKeyConflictDetection(): void
+    {
+        $keys = CandidateKeySet::fromSchema(['id'], ['users_email' => ['email']]);
+        $rows = [['id' => 1, 'email' => 'alice@example.com']];
+
+        $conflict = $keys->findConflict(['id' => null, 'email' => 'alice@example.com'], $rows);
+
+        self::assertInstanceOf(CandidateKeyConflict::class, $conflict);
+        self::assertSame('users_email', $conflict->keyName);
+    }
+
+    public function testMissingCandidateKeyValueDoesNotConflictWithStoredNull(): void
+    {
+        $keys = CandidateKeySet::fromSchema([], ['tenant_slug' => ['tenant_id', 'slug']]);
+        $rows = [['tenant_id' => 1, 'slug' => null]];
+
+        self::assertNull($keys->findConflict(['tenant_id' => 1], $rows));
+    }
+
+    public function testMissingStoredKeyValueDoesNotConflict(): void
+    {
+        $keys = CandidateKeySet::fromSchema([], ['users_email' => ['email']]);
+
+        self::assertNull($keys->findConflict(['email' => 'alice@example.com'], [['id' => 1]]));
+    }
+
     public function testEmptyKeySetNeverTreatsEqualRowsAsConflicting(): void
     {
         $keys = CandidateKeySet::fromSchema([]);

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/InsertMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/InsertMutationTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\Shadow\Mutation;
 
 use ZtdQuery\Exception\DuplicateKeyException;
 use ZtdQuery\Exception\NotNullViolationException;
+use ZtdQuery\Schema\CandidateKeyConflict;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
@@ -17,6 +19,8 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(NotNullViolationException::class)]
 #[UsesClass(TableDefinition::class)]
 #[UsesClass(ShadowStore::class)]
+#[UsesClass(CandidateKeyConflict::class)]
+#[UsesClass(CandidateKeySet::class)]
 #[CoversClass(InsertMutation::class)]
 final class InsertMutationTest extends TestCase
 {
@@ -43,6 +47,35 @@ final class InsertMutationTest extends TestCase
         self::assertCount(2, $store->get('users'));
         self::assertSame('Alice', $store->get('users')[0]['name']);
         self::assertSame('Carol', $store->get('users')[1]['name']);
+    }
+
+    public function testInsertIgnoreSkipsUniqueKeyConflict(): void
+    {
+        $definition = new TableDefinition(
+            ['id', 'email'],
+            ['id' => 'INT', 'email' => 'VARCHAR(255)'],
+            ['id'],
+            ['id'],
+            ['users_email' => ['email']],
+        );
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1, 'email' => 'alice@example.com']]);
+
+        $mutation = new InsertMutation(
+            'users',
+            ['id'],
+            true,
+            candidateKeys: $definition->candidateKeys(),
+        );
+        $mutation->apply($store, [
+            ['id' => 2, 'email' => 'alice@example.com'],
+            ['id' => 3, 'email' => 'bob@example.com'],
+        ]);
+
+        self::assertSame([
+            ['id' => 1, 'email' => 'alice@example.com'],
+            ['id' => 3, 'email' => 'bob@example.com'],
+        ], $store->get('users'));
     }
 
     public function testValidatePrimaryKeyDuplicateThrowsException(): void

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/ReplaceMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/ReplaceMutationTest.php
@@ -5,12 +5,18 @@ declare(strict_types=1);
 namespace Tests\Unit\Shadow\Mutation;
 
 use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\CandidateKeyConflict;
+use ZtdQuery\Schema\CandidateKeySet;
+use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\Mutation\ReplaceMutation;
 use ZtdQuery\Shadow\ShadowStore;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[UsesClass(ShadowStore::class)]
+#[UsesClass(CandidateKeyConflict::class)]
+#[UsesClass(CandidateKeySet::class)]
+#[UsesClass(TableDefinition::class)]
 #[CoversClass(ReplaceMutation::class)]
 final class ReplaceMutationTest extends TestCase
 {
@@ -54,7 +60,7 @@ final class ReplaceMutationTest extends TestCase
         self::assertSame('users', $mutation->tableName());
     }
 
-    public function testApplyWithoutPrimaryKeysComparesAllColumns(): void
+    public function testApplyWithoutCandidateKeysDoesNotReplaceEqualRows(): void
     {
         $store = new ShadowStore();
         $store->set('users', [
@@ -66,7 +72,30 @@ final class ReplaceMutationTest extends TestCase
         $mutation->apply($store, [['id' => 1, 'name' => 'Alice']]);
 
         $rows = $store->get('users');
-        self::assertCount(2, $rows);
+        self::assertCount(3, $rows);
+    }
+
+    public function testApplyRemovesEveryRowConflictingWithAnyCandidateKey(): void
+    {
+        $definition = new TableDefinition(
+            ['id', 'email', 'name'],
+            ['id' => 'INT', 'email' => 'TEXT', 'name' => 'TEXT'],
+            ['id'],
+            ['id'],
+            ['users_email' => ['email']],
+        );
+        $store = new ShadowStore();
+        $store->set('users', [
+            ['id' => 1, 'email' => 'alice@example.com', 'name' => 'Alice'],
+            ['id' => 2, 'email' => 'bob@example.com', 'name' => 'Bob'],
+        ]);
+
+        $mutation = new ReplaceMutation('users', ['id'], $definition->candidateKeys());
+        $mutation->apply($store, [['id' => 1, 'email' => 'bob@example.com', 'name' => 'Replacement']]);
+
+        self::assertSame([
+            ['id' => 1, 'email' => 'bob@example.com', 'name' => 'Replacement'],
+        ], $store->get('users'));
     }
 
     public function testApplyReplacesMultipleRows(): void

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/ShadowMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/ShadowMutationTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Shadow\Mutation;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\MutationContractTest;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
@@ -20,6 +21,7 @@ use ZtdQuery\Shadow\ShadowStore;
 #[CoversClass(TruncateMutation::class)]
 #[UsesClass(ShadowStore::class)]
 #[UsesClass(MutationRowIdentity::class)]
+#[UsesClass(CandidateKeySet::class)]
 final class ShadowMutationTest extends MutationContractTest
 {
     protected function initialRows(): array

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertMutationTest.php
@@ -5,12 +5,18 @@ declare(strict_types=1);
 namespace Tests\Unit\Shadow\Mutation;
 
 use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\CandidateKeyConflict;
+use ZtdQuery\Schema\CandidateKeySet;
+use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[UsesClass(ShadowStore::class)]
+#[UsesClass(CandidateKeyConflict::class)]
+#[UsesClass(CandidateKeySet::class)]
+#[UsesClass(TableDefinition::class)]
 #[CoversClass(UpsertMutation::class)]
 final class UpsertMutationTest extends TestCase
 {
@@ -42,6 +48,32 @@ final class UpsertMutationTest extends TestCase
         $rows = $store->get('users');
         self::assertCount(1, $rows);
         self::assertSame(11, $rows[0]['visits']);
+    }
+
+    public function testApplyUpdatesExistingRowOnUniqueKeyConflict(): void
+    {
+        $definition = new TableDefinition(
+            ['id', 'email', 'name'],
+            ['id' => 'INT', 'email' => 'TEXT', 'name' => 'TEXT'],
+            ['id'],
+            ['id'],
+            ['users_email' => ['email']],
+        );
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1, 'email' => 'alice@example.com', 'name' => 'Alice']]);
+
+        $mutation = new UpsertMutation(
+            'users',
+            ['id'],
+            ['name'],
+            ['name' => 'EXCLUDED.name'],
+            $definition->candidateKeys(),
+        );
+        $mutation->apply($store, [['id' => 2, 'email' => 'alice@example.com', 'name' => 'Updated']]);
+
+        self::assertSame([
+            ['id' => 1, 'email' => 'alice@example.com', 'name' => 'Updated'],
+        ], $store->get('users'));
     }
 
     public function testTableNameReturnsTableName(): void

--- a/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Simulator\StatementSimulator;
@@ -28,6 +29,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(RewritePlan::class)]
 #[UsesClass(ResultSelectRunner::class)]
 #[UsesClass(InsertMutation::class)]
+#[UsesClass(CandidateKeySet::class)]
 #[UsesClass(ShadowStore::class)]
 #[UsesClass(Session::class)]
 #[CoversClass(StatementSimulator::class)]

--- a/packages/ztd-query-mysql/src/MySqlMutationResolver.php
+++ b/packages/ztd-query-mysql/src/MySqlMutationResolver.php
@@ -234,12 +234,23 @@ final class MySqlMutationResolver
         if ($isOnDuplicateKeyUpdate) {
             $definition = $this->registry->get($tableName);
             $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
-            return new UpsertMutation($tableName, $primaryKeys, $updateColumns, $updateValues);
+            return new UpsertMutation(
+                $tableName,
+                $primaryKeys,
+                $updateColumns,
+                $updateValues,
+                $definition?->candidateKeys(),
+            );
         }
 
         $definition = $this->registry->get($tableName);
         $primaryKeys = $isIgnore ? ($definition !== null ? $definition->primaryKeys : []) : [];
-        return new InsertMutation($tableName, $primaryKeys, $isIgnore);
+        return new InsertMutation(
+            $tableName,
+            $primaryKeys,
+            $isIgnore,
+            candidateKeys: $definition?->candidateKeys(),
+        );
     }
 
     private function resolveTruncate(TruncateStatement $statement, string $sql): ShadowMutation
@@ -261,7 +272,7 @@ final class MySqlMutationResolver
 
         $definition = $this->registry->get($tableName);
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
-        return new ReplaceMutation($tableName, $primaryKeys);
+        return new ReplaceMutation($tableName, $primaryKeys, $definition?->candidateKeys());
     }
 
     /**

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -159,6 +159,24 @@ final class MySqlMutationResolverTest extends TestCase
         self::assertSame('users', $mutation->tableName());
     }
 
+    public function testResolveInsertOnDuplicateKeyWithoutRegisteredSchema(): void
+    {
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $selectTransformer = new SelectTransformer();
+        $updateTransformer = new UpdateTransformer($parser, $selectTransformer);
+        $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
+        $resolver = new MySqlMutationResolver($shadowStore, $registry, $schemaParser, $updateTransformer, $deleteTransformer);
+        $sql = "INSERT INTO users (id, name) VALUES (1, 'Alice') ON DUPLICATE KEY UPDATE name = VALUES(name)";
+        $statements = $parser->parse($sql);
+
+        $mutation = $resolver->resolve($sql, $statements[0], QueryKind::WRITE_SIMULATED);
+
+        self::assertInstanceOf(UpsertMutation::class, $mutation);
+    }
+
     public function testResolveUpdateReturnsUpdateMutation(): void
     {
         $parser = new MySqlParser();
@@ -228,6 +246,24 @@ final class MySqlMutationResolverTest extends TestCase
 
         self::assertInstanceOf(ReplaceMutation::class, $mutation);
         self::assertSame('users', $mutation->tableName());
+    }
+
+    public function testResolveReplaceWithoutRegisteredSchema(): void
+    {
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $selectTransformer = new SelectTransformer();
+        $updateTransformer = new UpdateTransformer($parser, $selectTransformer);
+        $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
+        $resolver = new MySqlMutationResolver($shadowStore, $registry, $schemaParser, $updateTransformer, $deleteTransformer);
+        $sql = "REPLACE INTO users (id, name) VALUES (1, 'Alice')";
+        $statements = $parser->parse($sql);
+
+        $mutation = $resolver->resolve($sql, $statements[0], QueryKind::WRITE_SIMULATED);
+
+        self::assertInstanceOf(ReplaceMutation::class, $mutation);
     }
 
     public function testResolveUpdateMultiTableReturnsMultiUpdateMutation(): void

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/InsertOrIgnoreTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/InsertOrIgnoreTest.php
@@ -71,4 +71,33 @@ final class InsertOrIgnoreTest extends TestCase
 
         self::assertSame($rawRows, $ztdRows);
     }
+
+    public function testInsertOrIgnoreUsesUniqueCandidateKeyAndNullSemantics(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT UNIQUE)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        $insert = "INSERT INTO users (id, email) VALUES (1, 'alice@example.com')";
+        $uniqueConflict = "INSERT OR IGNORE INTO users (id, email) VALUES (2, 'alice@example.com')";
+        $firstNull = 'INSERT OR IGNORE INTO users (id, email) VALUES (3, NULL)';
+        $secondNull = 'INSERT OR IGNORE INTO users (id, email) VALUES (4, NULL)';
+        $rawPdo->exec($insert);
+        $ztdPdo->exec($insert);
+        $rawPdo->exec($uniqueConflict);
+        $ztdPdo->exec($uniqueConflict);
+        $rawPdo->exec($firstNull);
+        $ztdPdo->exec($firstNull);
+        $rawPdo->exec($secondNull);
+        $ztdPdo->exec($secondNull);
+
+        $rawStatement = $rawPdo->query('SELECT * FROM users ORDER BY id');
+        $ztdStatement = $ztdPdo->query('SELECT * FROM users ORDER BY id');
+        self::assertNotFalse($rawStatement);
+        self::assertNotFalse($ztdStatement);
+        self::assertSame($rawStatement->fetchAll(), $ztdStatement->fetchAll());
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/InsertOrReplaceTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/InsertOrReplaceTest.php
@@ -71,4 +71,30 @@ final class InsertOrReplaceTest extends TestCase
 
         self::assertSame($rawRows, $ztdRows);
     }
+
+    public function testReplaceRemovesRowsConflictingWithPrimaryAndUniqueKeys(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT UNIQUE, name TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        $firstInsert = "INSERT INTO users VALUES (1, 'alice@example.com', 'Alice')";
+        $secondInsert = "INSERT INTO users VALUES (2, 'bob@example.com', 'Bob')";
+        $replace = "REPLACE INTO users VALUES (1, 'bob@example.com', 'Replacement')";
+        $rawPdo->exec($firstInsert);
+        $ztdPdo->exec($firstInsert);
+        $rawPdo->exec($secondInsert);
+        $ztdPdo->exec($secondInsert);
+        $rawPdo->exec($replace);
+        $ztdPdo->exec($replace);
+
+        $rawStatement = $rawPdo->query('SELECT * FROM users ORDER BY id');
+        $ztdStatement = $ztdPdo->query('SELECT * FROM users ORDER BY id');
+        self::assertNotFalse($rawStatement);
+        self::assertNotFalse($ztdStatement);
+        self::assertSame($rawStatement->fetchAll(), $ztdStatement->fetchAll());
+    }
 }

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -85,13 +85,29 @@ final class PgSqlMutationResolver
                     $resolvedValues[$col] = $value;
                 }
 
-                return new UpsertMutation($tableName, $primaryKeys, $updateColumns, $resolvedValues);
+                return new UpsertMutation(
+                    $tableName,
+                    $primaryKeys,
+                    $updateColumns,
+                    $resolvedValues,
+                    $definition?->candidateKeys(),
+                );
             }
 
-            return new InsertMutation($tableName, $primaryKeys, true);
+            return new InsertMutation(
+                $tableName,
+                $primaryKeys,
+                true,
+                candidateKeys: $definition?->candidateKeys(),
+            );
         }
 
-        return new InsertMutation($tableName, $primaryKeys, false);
+        return new InsertMutation(
+            $tableName,
+            $primaryKeys,
+            false,
+            candidateKeys: $definition?->candidateKeys(),
+        );
     }
 
     private function resolveUpdate(string $sql): ShadowMutation

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -50,6 +50,7 @@ final class PgSqlMutationResolverTest extends TestCase
             [],
             []
         ));
+        $shadowStore->set('users', [['id' => 1, 'name' => 'Existing']]);
         $mutation = $resolver->resolve(
             "INSERT INTO users (id, name) VALUES (1, 'Alice')",
             'INSERT',
@@ -57,6 +58,8 @@ final class PgSqlMutationResolverTest extends TestCase
         );
 
         self::assertInstanceOf(InsertMutation::class, $mutation);
+        $mutation->apply($shadowStore, [['id' => 1, 'name' => 'Inserted']]);
+        self::assertCount(2, $shadowStore->get('users'));
     }
 
     public function testResolveInsertWithOnConflictDoUpdateReturnsUpsertMutation(): void
@@ -102,6 +105,47 @@ final class PgSqlMutationResolverTest extends TestCase
             [],
             []
         ));
+        $shadowStore->set('users', [['id' => 1, 'name' => 'Existing']]);
+        $mutation = $resolver->resolve(
+            "INSERT INTO users (id, name) VALUES (1, 'Alice') ON CONFLICT DO NOTHING",
+            'INSERT',
+            QueryKind::WRITE_SIMULATED
+        );
+
+        self::assertInstanceOf(InsertMutation::class, $mutation);
+        $mutation->apply($shadowStore, [['id' => 1, 'name' => 'Ignored']]);
+        self::assertSame([['id' => 1, 'name' => 'Existing']], $shadowStore->get('users'));
+    }
+
+    public function testResolveOnConflictDoUpdateWithoutRegisteredSchema(): void
+    {
+        $shadowStore = new ShadowStore();
+        $resolver = new PgSqlMutationResolver(
+            $shadowStore,
+            new TableDefinitionRegistry(),
+            new PgSqlSchemaParser(),
+            new PgSqlParser()
+        );
+
+        $mutation = $resolver->resolve(
+            "INSERT INTO users (id, name) VALUES (1, 'Alice') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name",
+            'INSERT',
+            QueryKind::WRITE_SIMULATED
+        );
+
+        self::assertInstanceOf(UpsertMutation::class, $mutation);
+    }
+
+    public function testResolveOnConflictDoNothingWithoutRegisteredSchema(): void
+    {
+        $shadowStore = new ShadowStore();
+        $resolver = new PgSqlMutationResolver(
+            $shadowStore,
+            new TableDefinitionRegistry(),
+            new PgSqlSchemaParser(),
+            new PgSqlParser()
+        );
+
         $mutation = $resolver->resolve(
             "INSERT INTO users (id, name) VALUES (1, 'Alice') ON CONFLICT DO NOTHING",
             'INSERT',

--- a/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
+++ b/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
@@ -121,7 +121,7 @@ final class SqliteMutationResolver
             $definition = $this->registry->get($tableName);
             $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
-            return new ReplaceMutation($tableName, $primaryKeys);
+            return new ReplaceMutation($tableName, $primaryKeys, $definition?->candidateKeys());
         }
 
         if ($this->parser->hasOnConflict($sql)) {
@@ -138,8 +138,24 @@ final class SqliteMutationResolver
                 $definition = $this->registry->get($tableName);
                 $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
-                return new UpsertMutation($tableName, $primaryKeys, $updateColumns, $updateValues);
+                return new UpsertMutation(
+                    $tableName,
+                    $primaryKeys,
+                    $updateColumns,
+                    $updateValues,
+                    $definition?->candidateKeys(),
+                );
             }
+
+            $definition = $this->registry->get($tableName);
+            $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
+
+            return new InsertMutation(
+                $tableName,
+                $primaryKeys,
+                true,
+                candidateKeys: $definition?->candidateKeys(),
+            );
         }
 
         $isIgnore = $this->parser->isInsertIgnore($sql);
@@ -147,7 +163,12 @@ final class SqliteMutationResolver
         $definition = $this->registry->get($tableName);
         $primaryKeys = $isIgnore ? ($definition !== null ? $definition->primaryKeys : []) : [];
 
-        return new InsertMutation($tableName, $primaryKeys, $isIgnore);
+        return new InsertMutation(
+            $tableName,
+            $primaryKeys,
+            $isIgnore,
+            candidateKeys: $definition?->candidateKeys(),
+        );
     }
 
     private function resolveCreateTable(string $sql): ShadowMutation

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
@@ -1571,6 +1571,7 @@ final class SqliteMutationResolverTest extends TestCase
     public function testResolveInsertOnConflictDoNothingIsIgnore(): void
     {
         $store = new ShadowStore();
+        $store->set('users', [['id' => 1, 'name' => 'existing']]);
         $registry = new TableDefinitionRegistry();
         $registry->register('users', new TableDefinition(
             ['id', 'name'],
@@ -1582,6 +1583,8 @@ final class SqliteMutationResolverTest extends TestCase
         $resolver = new SqliteMutationResolver($store, $registry, new SqliteSchemaParser(), new SqliteParser());
         $mutation = $resolver->resolve("INSERT INTO users (id, name) VALUES (1, 'a') ON CONFLICT DO NOTHING", QueryKind::WRITE_SIMULATED);
         self::assertInstanceOf(InsertMutation::class, $mutation);
+        $mutation->apply($store, [['id' => 1, 'name' => 'ignored']]);
+        self::assertSame([['id' => 1, 'name' => 'existing']], $store->get('users'));
     }
 
     public function testResolveAlterAddColumnTypeDefaultKeywordExcluded(): void


### PR DESCRIPTION
## Root problem

Shadow mutations modeled conflicts as primary-key equality. That allowed non-PK UNIQUE conflicts to create duplicate shadow rows and made INSERT IGNORE, REPLACE, and UPSERT disagree.

## Changes

- add a typed candidate-key set derived from primary and UNIQUE constraints
- centralize conflict lookup and SQL NULL semantics
- use the same matcher for INSERT IGNORE / DO NOTHING, REPLACE, and UPSERT across MySQL, PostgreSQL, and SQLite
- handle SQLite `ON CONFLICT DO NOTHING` as an ignore mutation
- add core unit tests and SQLite differential integration tests against native PDO

## Verification

- core: 331 tests, 648 assertions
- mysql: 907 tests, 2257 assertions
- postgres: 1315 tests, 2101 assertions
- sqlite: 1193 tests, 2090 assertions
- targeted PDO SQLite integration: 7 tests, 21 assertions
- PHP-CS-Fixer and PHPStan pass in all changed packages

The full PDO suite was also run; 465 tests completed successfully and five PostgreSQL Testcontainers cases hit host-port allocation collisions under parallel execution. The targeted SQLite integration suite and all package suites are green.

Fixes #41
Fixes #91
Fixes #153