### PR TITLE
Fix transactional shadow snapshots

### DIFF
--- a/packages/ztd-query-core/src/Rewrite/SqlRewriter.php
+++ b/packages/ztd-query-core/src/Rewrite/SqlRewriter.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Rewrite;
 
+use ZtdQuery\Sql\TransactionStatement;
+
 /**
  * Contract for SQL rewrite implementations.
  */
 interface SqlRewriter
 {
+    public function transactionStatement(string $sql): ?TransactionStatement;
+
     /**
      * Return a dialect-valid SELECT statement that yields no rows.
      */

--- a/packages/ztd-query-core/src/Schema/TableDefinitionRegistry.php
+++ b/packages/ztd-query-core/src/Schema/TableDefinitionRegistry.php
@@ -64,6 +64,16 @@ final class TableDefinitionRegistry
         $this->definitions = [];
     }
 
+    public function snapshot(): self
+    {
+        return clone $this;
+    }
+
+    public function restore(self $snapshot): void
+    {
+        $this->definitions = $snapshot->definitions;
+    }
+
     /**
      * Remove a registered table.
      */

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -163,6 +163,11 @@ final class Session
         $statement->apply($this->transactions);
     }
 
+    public function transactionStatement(string $sql): ?TransactionStatement
+    {
+        return $this->rewriter->transactionStatement($sql);
+    }
+
 
     /**
      * Rewrite SQL using the configured rewriter.

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -19,6 +19,8 @@ use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Shadow\Mutation\ShadowMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
+use ZtdQuery\Sql\TransactionStatement;
 
 /**
  * Aggregates ZTD session state and core collaborators.
@@ -67,6 +69,8 @@ final class Session
      */
     private bool $enabled = true;
 
+    private ShadowTransactionManager $transactions;
+
     /**
      * @param SqlRewriter $rewriter Rewrite pipeline for SQL.
      * @param ShadowStore $shadowStore Target shadow store for mutation application.
@@ -79,13 +83,15 @@ final class Session
         ShadowStore $shadowStore,
         ResultSelectRunner $resultSelectRunner,
         ZtdConfig $config,
-        ConnectionInterface $connection
+        ConnectionInterface $connection,
+        ?ShadowTransactionManager $transactions = null,
     ) {
         $this->rewriter = $rewriter;
         $this->shadowStore = $shadowStore;
         $this->resultSelectRunner = $resultSelectRunner;
         $this->config = $config;
         $this->connection = $connection;
+        $this->transactions = $transactions ?? new ShadowTransactionManager($shadowStore);
     }
 
     /**
@@ -135,6 +141,26 @@ final class Session
     public function isEnabled(): bool
     {
         return $this->enabled;
+    }
+
+    public function beginTransaction(): void
+    {
+        $this->transactions->begin();
+    }
+
+    public function commitTransaction(): void
+    {
+        $this->transactions->commit();
+    }
+
+    public function rollBackTransaction(): void
+    {
+        $this->transactions->rollBack();
+    }
+
+    public function applyTransactionStatement(TransactionStatement $statement): void
+    {
+        $statement->apply($this->transactions);
     }
 
 

--- a/packages/ztd-query-core/src/Shadow/ShadowStore.php
+++ b/packages/ztd-query-core/src/Shadow/ShadowStore.php
@@ -90,6 +90,17 @@ class ShadowStore
         $this->initializedTables = [];
     }
 
+    public function snapshot(): self
+    {
+        return clone $this;
+    }
+
+    public function restore(self $snapshot): void
+    {
+        $this->fixtures = $snapshot->fixtures;
+        $this->initializedTables = $snapshot->initializedTables;
+    }
+
     /**
      * Ensure a table key exists in the store.
      */

--- a/packages/ztd-query-core/src/Shadow/ShadowTransactionManager.php
+++ b/packages/ztd-query-core/src/Shadow/ShadowTransactionManager.php
@@ -12,7 +12,7 @@ use ZtdQuery\Schema\TableDefinitionRegistry;
 final class ShadowTransactionManager
 {
     /**
-     * @var list<array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry|null}>
+     * @var list<array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry}>
      */
     private array $frames = [];
 
@@ -69,34 +69,30 @@ final class ShadowTransactionManager
     public function release(string $name): void
     {
         $index = $this->findSavepoint($name);
-        if ($index === null) {
-            return;
+        if ($index !== null) {
+            $this->frames = array_slice($this->frames, 0, $index);
         }
-
-        $this->frames = array_slice($this->frames, 0, $index);
     }
 
     /**
-     * @return array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry|null}
+     * @return array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry}
      */
     private function snapshot(?string $name): array
     {
         return [
             'name' => $name,
             'store' => $this->store->snapshot(),
-            'registry' => $this->registry?->snapshot(),
+            'registry' => $this->registry?->snapshot() ?? new TableDefinitionRegistry(),
         ];
     }
 
     /**
-     * @param array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry|null} $frame
+     * @param array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry} $frame
      */
     private function restore(array $frame): void
     {
         $this->store->restore($frame['store']);
-        if ($this->registry !== null && $frame['registry'] !== null) {
-            $this->registry->restore($frame['registry']);
-        }
+        $this->registry?->restore($frame['registry']);
     }
 
     private function findSavepoint(string $name): ?int

--- a/packages/ztd-query-core/src/Shadow/ShadowTransactionManager.php
+++ b/packages/ztd-query-core/src/Shadow/ShadowTransactionManager.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow;
+
+use ZtdQuery\Schema\TableDefinitionRegistry;
+
+/**
+ * Maintains transactional snapshots of all mutable shadow session state.
+ */
+final class ShadowTransactionManager
+{
+    /**
+     * @var list<array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry|null}>
+     */
+    private array $frames = [];
+
+    public function __construct(
+        private readonly ShadowStore $store,
+        private readonly ?TableDefinitionRegistry $registry = null,
+    ) {
+    }
+
+    public function begin(): void
+    {
+        if ($this->frames !== []) {
+            return;
+        }
+
+        $this->frames[] = $this->snapshot(null);
+    }
+
+    public function commit(): void
+    {
+        $this->frames = [];
+    }
+
+    public function rollBack(): void
+    {
+        if ($this->frames === []) {
+            return;
+        }
+
+        $this->restore($this->frames[0]);
+        $this->frames = [];
+    }
+
+    public function savepoint(string $name): void
+    {
+        $existingIndex = $this->findSavepoint($name);
+        if ($existingIndex !== null) {
+            $this->frames = array_slice($this->frames, 0, $existingIndex);
+        }
+        $this->frames[] = $this->snapshot($name);
+    }
+
+    public function rollBackTo(string $name): void
+    {
+        $index = $this->findSavepoint($name);
+        if ($index === null) {
+            return;
+        }
+
+        $this->restore($this->frames[$index]);
+        $this->frames = array_slice($this->frames, 0, $index + 1);
+    }
+
+    public function release(string $name): void
+    {
+        $index = $this->findSavepoint($name);
+        if ($index === null) {
+            return;
+        }
+
+        $this->frames = array_slice($this->frames, 0, $index);
+    }
+
+    /**
+     * @return array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry|null}
+     */
+    private function snapshot(?string $name): array
+    {
+        return [
+            'name' => $name,
+            'store' => $this->store->snapshot(),
+            'registry' => $this->registry?->snapshot(),
+        ];
+    }
+
+    /**
+     * @param array{name: string|null, store: ShadowStore, registry: TableDefinitionRegistry|null} $frame
+     */
+    private function restore(array $frame): void
+    {
+        $this->store->restore($frame['store']);
+        if ($this->registry !== null && $frame['registry'] !== null) {
+            $this->registry->restore($frame['registry']);
+        }
+    }
+
+    private function findSavepoint(string $name): ?int
+    {
+        for ($index = count($this->frames) - 1; $index >= 0; $index--) {
+            if ($this->frames[$index]['name'] === $name) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/ztd-query-core/src/Sql/TransactionOperation.php
+++ b/packages/ztd-query-core/src/Sql/TransactionOperation.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Sql;
+
+enum TransactionOperation: string
+{
+    case Begin = 'begin';
+    case Commit = 'commit';
+    case Rollback = 'rollback';
+    case Savepoint = 'savepoint';
+    case RollbackTo = 'rollback_to';
+    case Release = 'release';
+}

--- a/packages/ztd-query-core/src/Sql/TransactionStatement.php
+++ b/packages/ztd-query-core/src/Sql/TransactionStatement.php
@@ -13,7 +13,7 @@ final class TransactionStatement
 {
     private function __construct(
         private readonly TransactionOperation $operation,
-        private readonly ?string $savepointName = null,
+        private readonly string $savepointName = '',
     ) {
     }
 
@@ -53,9 +53,9 @@ final class TransactionStatement
             TransactionOperation::Begin => $transactions->begin(),
             TransactionOperation::Commit => $transactions->commit(),
             TransactionOperation::Rollback => $transactions->rollBack(),
-            TransactionOperation::Savepoint => $transactions->savepoint($this->requiredSavepointName()),
-            TransactionOperation::RollbackTo => $transactions->rollBackTo($this->requiredSavepointName()),
-            TransactionOperation::Release => $transactions->release($this->requiredSavepointName()),
+            TransactionOperation::Savepoint => $transactions->savepoint($this->savepointName),
+            TransactionOperation::RollbackTo => $transactions->rollBackTo($this->savepointName),
+            TransactionOperation::Release => $transactions->release($this->savepointName),
         };
     }
 
@@ -66,10 +66,5 @@ final class TransactionStatement
         }
 
         return $name;
-    }
-
-    private function requiredSavepointName(): string
-    {
-        return $this->savepointName ?? '';
     }
 }

--- a/packages/ztd-query-core/src/Sql/TransactionStatement.php
+++ b/packages/ztd-query-core/src/Sql/TransactionStatement.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Sql;
+
+use ZtdQuery\Shadow\ShadowTransactionManager;
+
+/**
+ * A structure-aware transaction-control statement.
+ */
+final class TransactionStatement
+{
+    private const BEGIN = 'begin';
+    private const COMMIT = 'commit';
+    private const ROLLBACK = 'rollback';
+    private const SAVEPOINT = 'savepoint';
+    private const ROLLBACK_TO = 'rollback_to';
+    private const RELEASE = 'release';
+
+    private function __construct(
+        private readonly string $operation,
+        private readonly ?string $savepointName = null,
+    ) {
+    }
+
+    public static function parse(string $sql): ?self
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        if (($tokens[count($tokens) - 1] ?? null)?->text === ';') {
+            array_pop($tokens);
+        }
+
+        if (self::keywords($tokens, ['BEGIN'])
+            || self::keywords($tokens, ['BEGIN', 'TRANSACTION'])
+            || self::keywords($tokens, ['BEGIN', 'DEFERRED'])
+            || self::keywords($tokens, ['BEGIN', 'DEFERRED', 'TRANSACTION'])
+            || self::keywords($tokens, ['BEGIN', 'IMMEDIATE'])
+            || self::keywords($tokens, ['BEGIN', 'IMMEDIATE', 'TRANSACTION'])
+            || self::keywords($tokens, ['BEGIN', 'EXCLUSIVE'])
+            || self::keywords($tokens, ['BEGIN', 'EXCLUSIVE', 'TRANSACTION'])
+            || self::keywords($tokens, ['START', 'TRANSACTION'])
+        ) {
+            return new self(self::BEGIN);
+        }
+        if (self::keywords($tokens, ['COMMIT'])
+            || self::keywords($tokens, ['COMMIT', 'TRANSACTION'])
+            || self::keywords($tokens, ['END'])
+            || self::keywords($tokens, ['END', 'TRANSACTION'])
+        ) {
+            return new self(self::COMMIT);
+        }
+        if (self::keywords($tokens, ['ROLLBACK']) || self::keywords($tokens, ['ROLLBACK', 'TRANSACTION'])) {
+            return new self(self::ROLLBACK);
+        }
+
+        $name = self::nameAfter($tokens, ['SAVEPOINT']);
+        if ($name !== null) {
+            return new self(self::SAVEPOINT, $name);
+        }
+        $name = self::nameAfter($tokens, ['ROLLBACK', 'TO', 'SAVEPOINT'])
+            ?? self::nameAfter($tokens, ['ROLLBACK', 'TO']);
+        if ($name !== null) {
+            return new self(self::ROLLBACK_TO, $name);
+        }
+        $name = self::nameAfter($tokens, ['RELEASE', 'SAVEPOINT'])
+            ?? self::nameAfter($tokens, ['RELEASE']);
+        if ($name !== null) {
+            return new self(self::RELEASE, $name);
+        }
+
+        return null;
+    }
+
+    public function apply(ShadowTransactionManager $transactions): void
+    {
+        match ($this->operation) {
+            self::BEGIN => $transactions->begin(),
+            self::COMMIT => $transactions->commit(),
+            self::ROLLBACK => $transactions->rollBack(),
+            self::SAVEPOINT => $transactions->savepoint($this->requiredSavepointName()),
+            self::ROLLBACK_TO => $transactions->rollBackTo($this->requiredSavepointName()),
+            self::RELEASE => $transactions->release($this->requiredSavepointName()),
+            default => null,
+        };
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<string> $keywords
+     */
+    private static function keywords(array $tokens, array $keywords): bool
+    {
+        if (count($tokens) !== count($keywords)) {
+            return false;
+        }
+        foreach ($keywords as $index => $keyword) {
+            if (!$tokens[$index]->isKeyword($keyword)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<string> $keywords
+     */
+    private static function nameAfter(array $tokens, array $keywords): ?string
+    {
+        if (count($tokens) !== count($keywords) + 1) {
+            return null;
+        }
+        foreach ($keywords as $index => $keyword) {
+            if (!$tokens[$index]->isKeyword($keyword)) {
+                return null;
+            }
+        }
+
+        $name = $tokens[count($keywords)];
+        if (!in_array($name->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+            return null;
+        }
+
+        return self::unquote($name->text);
+    }
+
+    private static function unquote(string $identifier): string
+    {
+        $first = $identifier[0] ?? '';
+        $last = $identifier[strlen($identifier) - 1] ?? '';
+        if (($first === '"' && $last === '"') || ($first === '`' && $last === '`')) {
+            return str_replace($first . $first, $first, substr($identifier, 1, -1));
+        }
+        if ($first === '[' && $last === ']') {
+            return str_replace(']]', ']', substr($identifier, 1, -1));
+        }
+
+        return $identifier;
+    }
+
+    private function requiredSavepointName(): string
+    {
+        return $this->savepointName ?? '';
+    }
+}

--- a/packages/ztd-query-core/src/Sql/TransactionStatement.php
+++ b/packages/ztd-query-core/src/Sql/TransactionStatement.php
@@ -11,133 +11,61 @@ use ZtdQuery\Shadow\ShadowTransactionManager;
  */
 final class TransactionStatement
 {
-    private const BEGIN = 'begin';
-    private const COMMIT = 'commit';
-    private const ROLLBACK = 'rollback';
-    private const SAVEPOINT = 'savepoint';
-    private const ROLLBACK_TO = 'rollback_to';
-    private const RELEASE = 'release';
-
     private function __construct(
-        private readonly string $operation,
+        private readonly TransactionOperation $operation,
         private readonly ?string $savepointName = null,
     ) {
     }
 
-    public static function parse(string $sql): ?self
+    public static function begin(): self
     {
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
-        if (($tokens[count($tokens) - 1] ?? null)?->text === ';') {
-            array_pop($tokens);
-        }
+        return new self(TransactionOperation::Begin);
+    }
 
-        if (self::keywords($tokens, ['BEGIN'])
-            || self::keywords($tokens, ['BEGIN', 'TRANSACTION'])
-            || self::keywords($tokens, ['BEGIN', 'DEFERRED'])
-            || self::keywords($tokens, ['BEGIN', 'DEFERRED', 'TRANSACTION'])
-            || self::keywords($tokens, ['BEGIN', 'IMMEDIATE'])
-            || self::keywords($tokens, ['BEGIN', 'IMMEDIATE', 'TRANSACTION'])
-            || self::keywords($tokens, ['BEGIN', 'EXCLUSIVE'])
-            || self::keywords($tokens, ['BEGIN', 'EXCLUSIVE', 'TRANSACTION'])
-            || self::keywords($tokens, ['START', 'TRANSACTION'])
-        ) {
-            return new self(self::BEGIN);
-        }
-        if (self::keywords($tokens, ['COMMIT'])
-            || self::keywords($tokens, ['COMMIT', 'TRANSACTION'])
-            || self::keywords($tokens, ['END'])
-            || self::keywords($tokens, ['END', 'TRANSACTION'])
-        ) {
-            return new self(self::COMMIT);
-        }
-        if (self::keywords($tokens, ['ROLLBACK']) || self::keywords($tokens, ['ROLLBACK', 'TRANSACTION'])) {
-            return new self(self::ROLLBACK);
-        }
+    public static function commit(): self
+    {
+        return new self(TransactionOperation::Commit);
+    }
 
-        $name = self::nameAfter($tokens, ['SAVEPOINT']);
-        if ($name !== null) {
-            return new self(self::SAVEPOINT, $name);
-        }
-        $name = self::nameAfter($tokens, ['ROLLBACK', 'TO', 'SAVEPOINT'])
-            ?? self::nameAfter($tokens, ['ROLLBACK', 'TO']);
-        if ($name !== null) {
-            return new self(self::ROLLBACK_TO, $name);
-        }
-        $name = self::nameAfter($tokens, ['RELEASE', 'SAVEPOINT'])
-            ?? self::nameAfter($tokens, ['RELEASE']);
-        if ($name !== null) {
-            return new self(self::RELEASE, $name);
-        }
+    public static function rollback(): self
+    {
+        return new self(TransactionOperation::Rollback);
+    }
 
-        return null;
+    public static function savepoint(string $name): self
+    {
+        return new self(TransactionOperation::Savepoint, self::requiredName($name));
+    }
+
+    public static function rollbackTo(string $name): self
+    {
+        return new self(TransactionOperation::RollbackTo, self::requiredName($name));
+    }
+
+    public static function release(string $name): self
+    {
+        return new self(TransactionOperation::Release, self::requiredName($name));
     }
 
     public function apply(ShadowTransactionManager $transactions): void
     {
         match ($this->operation) {
-            self::BEGIN => $transactions->begin(),
-            self::COMMIT => $transactions->commit(),
-            self::ROLLBACK => $transactions->rollBack(),
-            self::SAVEPOINT => $transactions->savepoint($this->requiredSavepointName()),
-            self::ROLLBACK_TO => $transactions->rollBackTo($this->requiredSavepointName()),
-            self::RELEASE => $transactions->release($this->requiredSavepointName()),
-            default => null,
+            TransactionOperation::Begin => $transactions->begin(),
+            TransactionOperation::Commit => $transactions->commit(),
+            TransactionOperation::Rollback => $transactions->rollBack(),
+            TransactionOperation::Savepoint => $transactions->savepoint($this->requiredSavepointName()),
+            TransactionOperation::RollbackTo => $transactions->rollBackTo($this->requiredSavepointName()),
+            TransactionOperation::Release => $transactions->release($this->requiredSavepointName()),
         };
     }
 
-    /**
-     * @param list<SqlToken> $tokens
-     * @param list<string> $keywords
-     */
-    private static function keywords(array $tokens, array $keywords): bool
+    private static function requiredName(string $name): string
     {
-        if (count($tokens) !== count($keywords)) {
-            return false;
-        }
-        foreach ($keywords as $index => $keyword) {
-            if (!$tokens[$index]->isKeyword($keyword)) {
-                return false;
-            }
+        if ($name === '') {
+            throw new \InvalidArgumentException('Savepoint name must not be empty.');
         }
 
-        return true;
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     * @param list<string> $keywords
-     */
-    private static function nameAfter(array $tokens, array $keywords): ?string
-    {
-        if (count($tokens) !== count($keywords) + 1) {
-            return null;
-        }
-        foreach ($keywords as $index => $keyword) {
-            if (!$tokens[$index]->isKeyword($keyword)) {
-                return null;
-            }
-        }
-
-        $name = $tokens[count($keywords)];
-        if (!in_array($name->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
-            return null;
-        }
-
-        return self::unquote($name->text);
-    }
-
-    private static function unquote(string $identifier): string
-    {
-        $first = $identifier[0] ?? '';
-        $last = $identifier[strlen($identifier) - 1] ?? '';
-        if (($first === '"' && $last === '"') || ($first === '`' && $last === '`')) {
-            return str_replace($first . $first, $first, substr($identifier, 1, -1));
-        }
-        if ($first === '[' && $last === ']') {
-            return str_replace(']]', ']', substr($identifier, 1, -1));
-        }
-
-        return $identifier;
+        return $name;
     }
 
     private function requiredSavepointName(): string

--- a/packages/ztd-query-core/src/Sql/TransactionStatementParser.php
+++ b/packages/ztd-query-core/src/Sql/TransactionStatementParser.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Sql;
+
+interface TransactionStatementParser
+{
+    public function parse(string $sql): ?TransactionStatement;
+}

--- a/packages/ztd-query-core/tests/Fake/ExceptionThrowingRewriter.php
+++ b/packages/ztd-query-core/tests/Fake/ExceptionThrowingRewriter.php
@@ -7,12 +7,18 @@ namespace Tests\Fake;
 use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Sql\TransactionStatement;
 
 /**
  * Rewriter that throws an exception when rewrite() is called.
  */
 final class ExceptionThrowingRewriter implements SqlRewriter
 {
+    public function transactionStatement(string $sql): ?TransactionStatement
+    {
+        return null;
+    }
+
     private \Throwable $exception;
 
     public function __construct(\Throwable $exception)

--- a/packages/ztd-query-core/tests/Fake/FakeSqlRewriter.php
+++ b/packages/ztd-query-core/tests/Fake/FakeSqlRewriter.php
@@ -9,6 +9,7 @@ use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Sql\TransactionStatement;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
@@ -27,6 +28,11 @@ use ZtdQuery\Shadow\ShadowStore;
  */
 final class FakeSqlRewriter implements SqlRewriter
 {
+    public function transactionStatement(string $sql): ?TransactionStatement
+    {
+        return null;
+    }
+
     private ShadowStore $shadowStore;
 
     private TableDefinitionRegistry $registry;

--- a/packages/ztd-query-core/tests/Fake/FixedRewriter.php
+++ b/packages/ztd-query-core/tests/Fake/FixedRewriter.php
@@ -7,9 +7,15 @@ namespace Tests\Fake;
 use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Sql\TransactionStatement;
 
 final class FixedRewriter implements SqlRewriter
 {
+    public function transactionStatement(string $sql): ?TransactionStatement
+    {
+        return null;
+    }
+
     /**
      * Predefined plan to return from rewrite().
      *

--- a/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionRegistryTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionRegistryTest.php
@@ -14,6 +14,19 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[CoversClass(TableDefinitionRegistry::class)]
 final class TableDefinitionRegistryTest extends TestCase
 {
+    public function testSnapshotRestoreReplacesRegistryState(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []);
+        $registry->register('users', $definition);
+        $snapshot = $registry->snapshot();
+
+        $registry->unregister('users');
+        $registry->restore($snapshot);
+
+        self::assertSame($definition, $registry->get('users'));
+    }
+
     public function testRegisterAndGet(): void
     {
         $registry = new TableDefinitionRegistry();

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -16,16 +16,20 @@ use ZtdQuery\Exception\MissingPrimaryKeyException;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
+use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Session;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
 
 #[CoversClass(Session::class)]
 #[UsesClass(ZtdConfig::class)]
 #[UsesClass(ShadowStore::class)]
+#[UsesClass(ShadowTransactionManager::class)]
 #[UsesClass(TableDefinitionRegistry::class)]
+#[UsesClass(TableDefinition::class)]
 #[UsesClass(ResultSelectRunner::class)]
 #[UsesClass(DatabaseException::class)]
 #[UsesClass(RewritePlan::class)]
@@ -55,6 +59,28 @@ final class SessionTest extends TestCase
 
         $session->enable();
         self::assertTrue($session->isEnabled());
+    }
+
+    public function testUsesProvidedTransactionManagerForSchemaRollback(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(['id'], ['id' => 'INT'], ['id'], [], []);
+        $registry->register('users', $definition);
+        $session = new Session(
+            new FakeSqlRewriter($shadowStore, $registry),
+            $shadowStore,
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            new FakeConnection(),
+            new ShadowTransactionManager($shadowStore, $registry),
+        );
+
+        $session->beginTransaction();
+        $registry->unregister('users');
+        $session->rollBackTransaction();
+
+        self::assertSame($definition, $registry->get('users'));
     }
 
     public function testMutationFailureIsConvertedToDatabaseException(): void

--- a/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ShadowStoreTest.php
@@ -16,6 +16,20 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(ShadowTableState::class)]
 class ShadowStoreTest extends TestCase
 {
+    public function testSnapshotRestoreIncludesRowsAndInitializedPresence(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1]]);
+        $snapshot = $store->snapshot();
+
+        $store->insert('users', [['id' => 2]]);
+        $store->set('temporary_table', []);
+        $store->restore($snapshot);
+
+        self::assertSame([['id' => 1]], $store->get('users'));
+        self::assertFalse($store->has('temporary_table'));
+    }
+
     public function testInsertAppendsRows(): void
     {
         $store = new ShadowStore();

--- a/packages/ztd-query-core/tests/Unit/Shadow/ShadowTransactionManagerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ShadowTransactionManagerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
+
+#[CoversClass(ShadowTransactionManager::class)]
+#[UsesClass(ShadowStore::class)]
+#[UsesClass(TableDefinition::class)]
+#[UsesClass(TableDefinitionRegistry::class)]
+final class ShadowTransactionManagerTest extends TestCase
+{
+    public function testRollbackRestoresRowsTablePresenceAndSchemaRegistry(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1]]);
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []);
+        $registry->register('users', $definition);
+        $transactions = new ShadowTransactionManager($store, $registry);
+
+        $transactions->begin();
+        $store->insert('users', [['id' => 2]]);
+        $store->set('temporary_table', []);
+        $registry->unregister('users');
+        $transactions->rollBack();
+
+        self::assertSame([['id' => 1]], $store->get('users'));
+        self::assertFalse($store->has('temporary_table'));
+        self::assertSame($definition, $registry->get('users'));
+    }
+
+    public function testRollbackToKeepsSavepointAndDiscardsLaterSavepoints(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+
+        $transactions->begin();
+        $store->insert('items', [['id' => 2]]);
+        $transactions->savepoint('outer');
+        $store->insert('items', [['id' => 3]]);
+        $transactions->savepoint('inner');
+        $store->insert('items', [['id' => 4]]);
+        $transactions->rollBackTo('outer');
+        $store->insert('items', [['id' => 5]]);
+        $transactions->commit();
+
+        self::assertSame([['id' => 1], ['id' => 2], ['id' => 5]], $store->get('items'));
+    }
+
+    public function testReleaseDropsNamedAndNestedSnapshotsWithoutUndoingRows(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+
+        $transactions->begin();
+        $transactions->savepoint('outer');
+        $store->insert('items', [['id' => 2]]);
+        $transactions->savepoint('inner');
+        $transactions->release('outer');
+        $transactions->rollBackTo('inner');
+        $transactions->commit();
+
+        self::assertSame([['id' => 1], ['id' => 2]], $store->get('items'));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/ShadowTransactionManagerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ShadowTransactionManagerTest.php
@@ -73,4 +73,67 @@ final class ShadowTransactionManagerTest extends TestCase
 
         self::assertSame([['id' => 1], ['id' => 2]], $store->get('items'));
     }
+
+    public function testReplacingSavepointUsesMostRecentSnapshot(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+
+        $transactions->begin();
+        $transactions->savepoint('point');
+        $store->insert('items', [['id' => 2]]);
+        $transactions->savepoint('point');
+        $store->insert('items', [['id' => 3]]);
+        $transactions->rollBackTo('point');
+
+        self::assertSame([['id' => 1], ['id' => 2]], $store->get('items'));
+        $transactions->release('point');
+        $store->insert('items', [['id' => 4]]);
+        $transactions->rollBackTo('point');
+        self::assertSame([['id' => 1], ['id' => 2], ['id' => 4]], $store->get('items'));
+    }
+
+    public function testRollbackToKeepsTargetForAnotherRollback(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+
+        $transactions->begin();
+        $store->insert('items', [['id' => 2]]);
+        $transactions->savepoint('outer');
+        $store->insert('items', [['id' => 3]]);
+        $transactions->savepoint('inner');
+        $store->insert('items', [['id' => 4]]);
+        $transactions->rollBackTo('outer');
+        $transactions->rollBackTo('inner');
+        self::assertSame([['id' => 1], ['id' => 2]], $store->get('items'));
+        $store->insert('items', [['id' => 5]]);
+        $transactions->rollBackTo('outer');
+        self::assertSame([['id' => 1], ['id' => 2]], $store->get('items'));
+        $store->insert('items', [['id' => 6]]);
+        $transactions->rollBack();
+        self::assertSame([['id' => 1]], $store->get('items'));
+    }
+
+    public function testReleaseKeepsEarlierSavepointAndUnknownNameDoesNothing(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+
+        $transactions->savepoint('outer');
+        $store->insert('items', [['id' => 2]]);
+        $transactions->savepoint('inner');
+        $store->insert('items', [['id' => 3]]);
+        $transactions->release('missing');
+        $transactions->release('inner');
+        $store->insert('items', [['id' => 4]]);
+        $transactions->rollBackTo('inner');
+        self::assertSame([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], $store->get('items'));
+        $transactions->rollBackTo('outer');
+
+        self::assertSame([['id' => 1]], $store->get('items'));
+    }
 }

--- a/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
@@ -17,6 +17,7 @@ use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
 use ZtdQuery\Simulator\StatementSimulator;
 use ZtdQuery\Session;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(CandidateKeySet::class)]
 #[UsesClass(ShadowStore::class)]
+#[UsesClass(ShadowTransactionManager::class)]
 #[UsesClass(Session::class)]
 #[CoversClass(StatementSimulator::class)]
 final class StatementSimulatorTest extends TestCase

--- a/packages/ztd-query-core/tests/Unit/Sql/TransactionOperationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/TransactionOperationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sql;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Sql\TransactionOperation;
+
+#[CoversClass(TransactionOperation::class)]
+final class TransactionOperationTest extends TestCase
+{
+    public function testDefinesEveryTransactionOperation(): void
+    {
+        self::assertSame([
+            TransactionOperation::Begin,
+            TransactionOperation::Commit,
+            TransactionOperation::Rollback,
+            TransactionOperation::Savepoint,
+            TransactionOperation::RollbackTo,
+            TransactionOperation::Release,
+        ], TransactionOperation::cases());
+        self::assertSame('begin', TransactionOperation::Begin->value);
+        self::assertSame('commit', TransactionOperation::Commit->value);
+        self::assertSame('rollback', TransactionOperation::Rollback->value);
+        self::assertSame('savepoint', TransactionOperation::Savepoint->value);
+        self::assertSame('rollback_to', TransactionOperation::RollbackTo->value);
+        self::assertSame('release', TransactionOperation::Release->value);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Sql/TransactionStatementParserTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/TransactionStatementParserTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Sql;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Sql\TransactionStatementParser;
 
-#[CoversClass(TransactionStatementParser::class)]
+#[CoversNothing]
 final class TransactionStatementParserTest extends TestCase
 {
     public function testDefinesDialectParserContract(): void

--- a/packages/ztd-query-core/tests/Unit/Sql/TransactionStatementParserTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/TransactionStatementParserTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sql;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Sql\TransactionStatementParser;
+
+#[CoversClass(TransactionStatementParser::class)]
+final class TransactionStatementParserTest extends TestCase
+{
+    public function testDefinesDialectParserContract(): void
+    {
+        $method = new \ReflectionMethod(TransactionStatementParser::class, 'parse');
+
+        self::assertTrue($method->isPublic());
+        self::assertSame('sql', $method->getParameters()[0]->getName());
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Sql/TransactionStatementTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/TransactionStatementTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sql;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\TransactionStatement;
+
+#[CoversClass(TransactionStatement::class)]
+#[UsesClass(ShadowStore::class)]
+#[UsesClass(ShadowTransactionManager::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class TransactionStatementTest extends TestCase
+{
+    public function testParsesAndAppliesQuotedSavepointLifecycle(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+        $begin = TransactionStatement::parse('BEGIN;');
+        $savepoint = TransactionStatement::parse('SAVEPOINT "order item";');
+        $rollback = TransactionStatement::parse('ROLLBACK TO SAVEPOINT "order item"');
+        $commit = TransactionStatement::parse('COMMIT');
+        self::assertNotNull($begin);
+        self::assertNotNull($savepoint);
+        self::assertNotNull($rollback);
+        self::assertNotNull($commit);
+
+        $begin->apply($transactions);
+        $store->insert('items', [['id' => 2]]);
+        $savepoint->apply($transactions);
+        $store->insert('items', [['id' => 3]]);
+        $rollback->apply($transactions);
+        $commit->apply($transactions);
+
+        self::assertSame([['id' => 1], ['id' => 2]], $store->get('items'));
+    }
+
+    public function testRejectsNonTransactionAndTrailingTokens(): void
+    {
+        self::assertNull(TransactionStatement::parse('SELECT 1'));
+        self::assertNull(TransactionStatement::parse('SAVEPOINT one extra'));
+        self::assertNull(TransactionStatement::parse('ROLLBACK TO'));
+    }
+
+    public function testAcceptsDialectBeginAndCommitForms(): void
+    {
+        self::assertNotNull(TransactionStatement::parse('BEGIN IMMEDIATE TRANSACTION'));
+        self::assertNotNull(TransactionStatement::parse('START TRANSACTION'));
+        self::assertNotNull(TransactionStatement::parse('END TRANSACTION'));
+        self::assertNotNull(TransactionStatement::parse('ROLLBACK TRANSACTION'));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Sql/TransactionStatementTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/TransactionStatementTest.php
@@ -9,53 +9,48 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTransactionManager;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
 use ZtdQuery\Sql\TransactionStatement;
 
 #[CoversClass(TransactionStatement::class)]
 #[UsesClass(ShadowStore::class)]
 #[UsesClass(ShadowTransactionManager::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class TransactionStatementTest extends TestCase
 {
-    public function testParsesAndAppliesQuotedSavepointLifecycle(): void
+    public function testAppliesNamedTransactionLifecycleWithoutSql(): void
     {
         $store = new ShadowStore();
         $store->set('items', [['id' => 1]]);
         $transactions = new ShadowTransactionManager($store);
-        $begin = TransactionStatement::parse('BEGIN;');
-        $savepoint = TransactionStatement::parse('SAVEPOINT "order item";');
-        $rollback = TransactionStatement::parse('ROLLBACK TO SAVEPOINT "order item"');
-        $commit = TransactionStatement::parse('COMMIT');
-        self::assertNotNull($begin);
-        self::assertNotNull($savepoint);
-        self::assertNotNull($rollback);
-        self::assertNotNull($commit);
 
-        $begin->apply($transactions);
+        TransactionStatement::begin()->apply($transactions);
         $store->insert('items', [['id' => 2]]);
-        $savepoint->apply($transactions);
+        TransactionStatement::savepoint('order item')->apply($transactions);
         $store->insert('items', [['id' => 3]]);
-        $rollback->apply($transactions);
-        $commit->apply($transactions);
+        TransactionStatement::rollbackTo('order item')->apply($transactions);
+        TransactionStatement::release('order item')->apply($transactions);
+        TransactionStatement::commit()->apply($transactions);
 
         self::assertSame([['id' => 1], ['id' => 2]], $store->get('items'));
     }
 
-    public function testRejectsNonTransactionAndTrailingTokens(): void
+    public function testAppliesRollback(): void
     {
-        self::assertNull(TransactionStatement::parse('SELECT 1'));
-        self::assertNull(TransactionStatement::parse('SAVEPOINT one extra'));
-        self::assertNull(TransactionStatement::parse('ROLLBACK TO'));
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+
+        TransactionStatement::begin()->apply($transactions);
+        $store->insert('items', [['id' => 2]]);
+        TransactionStatement::rollback()->apply($transactions);
+
+        self::assertSame([['id' => 1]], $store->get('items'));
     }
 
-    public function testAcceptsDialectBeginAndCommitForms(): void
+    public function testRejectsEmptySavepointName(): void
     {
-        self::assertNotNull(TransactionStatement::parse('BEGIN IMMEDIATE TRANSACTION'));
-        self::assertNotNull(TransactionStatement::parse('START TRANSACTION'));
-        self::assertNotNull(TransactionStatement::parse('END TRANSACTION'));
-        self::assertNotNull(TransactionStatement::parse('ROLLBACK TRANSACTION'));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Savepoint name must not be empty.');
+
+        TransactionStatement::savepoint('');
     }
 }

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -11,6 +11,7 @@ use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Sql\TransactionStatement;
 use PhpMyAdmin\SqlParser\Statement;
 use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
@@ -29,6 +30,11 @@ use PhpMyAdmin\SqlParser\Statements\WithStatement;
  */
 final class MySqlRewriter implements SqlRewriter
 {
+    public function transactionStatement(string $sql): ?TransactionStatement
+    {
+        return (new MySqlTransactionStatementParser())->parse($sql);
+    }
+
     private MySqlQueryGuard $guard;
     private ShadowStore $shadowStore;
     private TableDefinitionRegistry $registry;

--- a/packages/ztd-query-mysql/src/MySqlSessionFactory.php
+++ b/packages/ztd-query-mysql/src/MySqlSessionFactory.php
@@ -17,6 +17,7 @@ use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
 
 /**
  * Factory for creating Session instances pre-configured for MySQL.
@@ -56,7 +57,8 @@ final class MySqlSessionFactory implements SessionFactory
             $shadowStore,
             new ResultSelectRunner(),
             $config,
-            $connection
+            $connection,
+            new ShadowTransactionManager($shadowStore, $registry),
         );
     }
 }

--- a/packages/ztd-query-mysql/src/MySqlTransactionStatementParser.php
+++ b/packages/ztd-query-mysql/src/MySqlTransactionStatementParser.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\TransactionStatement;
+use ZtdQuery\Sql\TransactionStatementParser;
+
+final class MySqlTransactionStatementParser implements TransactionStatementParser
+{
+    public function parse(string $sql): ?TransactionStatement
+    {
+        $tokens = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->significantTokens();
+        if (($tokens[count($tokens) - 1] ?? null)?->text === ';') {
+            array_pop($tokens);
+        }
+        if ($this->matchesAny($tokens, [['BEGIN'], ['BEGIN', 'WORK'], ['START', 'TRANSACTION']])) {
+            return TransactionStatement::begin();
+        }
+        if ($this->matchesAny($tokens, [['COMMIT'], ['COMMIT', 'WORK']])) {
+            return TransactionStatement::commit();
+        }
+        if ($this->matchesAny($tokens, [['ROLLBACK'], ['ROLLBACK', 'WORK']])) {
+            return TransactionStatement::rollback();
+        }
+        $name = $this->nameAfter($tokens, [['SAVEPOINT']]);
+        if ($name !== null) {
+            return TransactionStatement::savepoint($name);
+        }
+        $name = $this->nameAfter($tokens, [['ROLLBACK', 'TO'], ['ROLLBACK', 'TO', 'SAVEPOINT']]);
+        if ($name !== null) {
+            return TransactionStatement::rollbackTo($name);
+        }
+        $name = $this->nameAfter($tokens, [['RELEASE', 'SAVEPOINT']]);
+
+        return $name !== null ? TransactionStatement::release($name) : null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<list<string>> $forms
+     */
+    private function matchesAny(array $tokens, array $forms): bool
+    {
+        foreach ($forms as $form) {
+            if ($this->matches($tokens, $form)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<list<string>> $prefixes
+     */
+    private function nameAfter(array $tokens, array $prefixes): ?string
+    {
+        foreach ($prefixes as $prefix) {
+            if (count($tokens) !== count($prefix) + 1 || !$this->matches(array_slice($tokens, 0, -1), $prefix)) {
+                continue;
+            }
+            $name = $tokens[count($prefix)];
+            if (!in_array($name->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+                return null;
+            }
+
+            return $this->unquote($name->text, ['`', '"']);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<string> $keywords
+     */
+    private function matches(array $tokens, array $keywords): bool
+    {
+        if (count($tokens) !== count($keywords)) {
+            return false;
+        }
+        foreach ($keywords as $index => $keyword) {
+            if (!$tokens[$index]->isKeyword($keyword)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @param non-empty-list<string> $quotes */
+    private function unquote(string $identifier, array $quotes): ?string
+    {
+        $first = $identifier[0] ?? '';
+        if (!in_array($first, $quotes, true)) {
+            return $identifier;
+        }
+        if (($identifier[strlen($identifier) - 1] ?? '') !== $first) {
+            return null;
+        }
+
+        return str_replace($first . $first, $first, substr($identifier, 1, -1));
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -42,6 +42,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(MySqlMutationResolver::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(MySqlQueryGuard::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlTransactionStatementParser::class)]
 #[UsesClass(MySqlTransformer::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(InsertTransformer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlTransactionStatementParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlTransactionStatementParserTest.php
@@ -6,21 +6,10 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\MySql\MySqlTransactionStatementParser;
-use ZtdQuery\Shadow\ShadowStore;
-use ZtdQuery\Shadow\ShadowTransactionManager;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
-use ZtdQuery\Sql\TransactionStatement;
 
 #[CoversClass(MySqlTransactionStatementParser::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
-#[UsesClass(TransactionStatement::class)]
-#[UsesClass(ShadowStore::class)]
-#[UsesClass(ShadowTransactionManager::class)]
 final class MySqlTransactionStatementParserTest extends TestCase
 {
     #[DataProvider('providerMySqlTransactionForms')]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlTransactionStatementParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlTransactionStatementParserTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\MySql\MySqlTransactionStatementParser;
+use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
 
 #[CoversClass(MySqlTransactionStatementParser::class)]
 final class MySqlTransactionStatementParserTest extends TestCase
@@ -40,10 +42,27 @@ final class MySqlTransactionStatementParserTest extends TestCase
     {
         $parser = new MySqlTransactionStatementParser();
 
+        self::assertNull($parser->parse(''));
         self::assertNull($parser->parse('BEGIN IMMEDIATE'));
         self::assertNull($parser->parse('END TRANSACTION'));
         self::assertNull($parser->parse('RELEASE point'));
         self::assertNull($parser->parse('SAVEPOINT point extra'));
         self::assertNull($parser->parse('SAVEPOINT `broken'));
+    }
+
+    public function testAppliesUnescapedMySqlSavepointName(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+        $transactions->begin();
+        $statement = (new MySqlTransactionStatementParser())->parse('SAVEPOINT `a``b`');
+        self::assertNotNull($statement);
+        $statement->apply($transactions);
+        $store->insert('items', [['id' => 2]]);
+
+        $transactions->rollBackTo('a`b');
+
+        self::assertSame([['id' => 1]], $store->get('items'));
     }
 }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlTransactionStatementParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlTransactionStatementParserTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlTransactionStatementParser;
+use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\TransactionStatement;
+
+#[CoversClass(MySqlTransactionStatementParser::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+#[UsesClass(TransactionStatement::class)]
+#[UsesClass(ShadowStore::class)]
+#[UsesClass(ShadowTransactionManager::class)]
+final class MySqlTransactionStatementParserTest extends TestCase
+{
+    #[DataProvider('providerMySqlTransactionForms')]
+    public function testParsesMySqlTransactionForms(string $sql): void
+    {
+        self::assertNotNull((new MySqlTransactionStatementParser())->parse($sql));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function providerMySqlTransactionForms(): array
+    {
+        return [
+            'begin' => ['BEGIN;'],
+            'begin work' => ['BEGIN WORK'],
+            'start' => ['START TRANSACTION'],
+            'commit' => ['COMMIT'],
+            'commit work' => ['COMMIT WORK'],
+            'rollback' => ['ROLLBACK'],
+            'rollback work' => ['ROLLBACK WORK'],
+            'savepoint' => ['SAVEPOINT `a``b`'],
+            'rollback to' => ['ROLLBACK TO `a``b`'],
+            'rollback to savepoint' => ['ROLLBACK TO SAVEPOINT point'],
+            'release' => ['RELEASE SAVEPOINT point'],
+        ];
+    }
+
+    public function testRejectsNonMySqlAndMalformedForms(): void
+    {
+        $parser = new MySqlTransactionStatementParser();
+
+        self::assertNull($parser->parse('BEGIN IMMEDIATE'));
+        self::assertNull($parser->parse('END TRANSACTION'));
+        self::assertNull($parser->parse('RELEASE point'));
+        self::assertNull($parser->parse('SAVEPOINT point extra'));
+        self::assertNull($parser->parse('SAVEPOINT `broken'));
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/src/ZtdMysqli.php
+++ b/packages/ztd-query-mysqli-adapter/src/ZtdMysqli.php
@@ -223,7 +223,7 @@ class ZtdMysqli extends mysqli
             return $this->innerMysqli->query($query, $resultMode);
         }
 
-        $transactionStatement = TransactionStatement::parse($query);
+        $transactionStatement = $this->session->transactionStatement($query);
         if ($transactionStatement !== null) {
             $result = $this->innerMysqli->query($query, $resultMode);
             if ($result !== false) {
@@ -269,7 +269,7 @@ class ZtdMysqli extends mysqli
             return $this->innerMysqli->real_query($query);
         }
 
-        $transactionStatement = TransactionStatement::parse($query);
+        $transactionStatement = $this->session->transactionStatement($query);
         if ($transactionStatement !== null) {
             $result = $this->innerMysqli->real_query($query);
             if ($result) {
@@ -577,10 +577,7 @@ class ZtdMysqli extends mysqli
     {
         $result = $this->innerMysqli->release_savepoint($name);
         if ($result) {
-            $statement = TransactionStatement::parse('RELEASE SAVEPOINT `' . str_replace('`', '``', $name) . '`');
-            if ($statement !== null) {
-                $this->session->applyTransactionStatement($statement);
-            }
+            $this->session->applyTransactionStatement(TransactionStatement::release($name));
         }
 
         return $result;
@@ -593,10 +590,7 @@ class ZtdMysqli extends mysqli
     {
         $result = $this->innerMysqli->savepoint($name);
         if ($result) {
-            $statement = TransactionStatement::parse('SAVEPOINT `' . str_replace('`', '``', $name) . '`');
-            if ($statement !== null) {
-                $this->session->applyTransactionStatement($statement);
-            }
+            $this->session->applyTransactionStatement(TransactionStatement::savepoint($name));
         }
 
         return $result;

--- a/packages/ztd-query-mysqli-adapter/src/ZtdMysqli.php
+++ b/packages/ztd-query-mysqli-adapter/src/ZtdMysqli.php
@@ -14,6 +14,7 @@ use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Platform\MySql\MySqlSessionFactory;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
+use ZtdQuery\Sql\TransactionStatement;
 
 /**
  * mysqli proxy that enforces ZTD behavior for reads and writes.
@@ -222,6 +223,16 @@ class ZtdMysqli extends mysqli
             return $this->innerMysqli->query($query, $resultMode);
         }
 
+        $transactionStatement = TransactionStatement::parse($query);
+        if ($transactionStatement !== null) {
+            $result = $this->innerMysqli->query($query, $resultMode);
+            if ($result !== false) {
+                $this->session->applyTransactionStatement($transactionStatement);
+            }
+
+            return $result;
+        }
+
         $stmt = $this->prepare($query);
         if ($stmt === false) {
             return false;
@@ -258,6 +269,16 @@ class ZtdMysqli extends mysqli
             return $this->innerMysqli->real_query($query);
         }
 
+        $transactionStatement = TransactionStatement::parse($query);
+        if ($transactionStatement !== null) {
+            $result = $this->innerMysqli->real_query($query);
+            if ($result) {
+                $this->session->applyTransactionStatement($transactionStatement);
+            }
+
+            return $result;
+        }
+
         $stmt = $this->prepare($query);
         if ($stmt === false) {
             return false;
@@ -279,7 +300,12 @@ class ZtdMysqli extends mysqli
      */
     public function begin_transaction(int $flags = 0, ?string $name = null): bool
     {
-        return $this->innerMysqli->begin_transaction($flags, $name);
+        $result = $this->innerMysqli->begin_transaction($flags, $name);
+        if ($result) {
+            $this->session->beginTransaction();
+        }
+
+        return $result;
     }
 
     /**
@@ -287,7 +313,12 @@ class ZtdMysqli extends mysqli
      */
     public function commit(int $flags = 0, ?string $name = null): bool
     {
-        return $this->innerMysqli->commit($flags, $name);
+        $result = $this->innerMysqli->commit($flags, $name);
+        if ($result) {
+            $this->session->commitTransaction();
+        }
+
+        return $result;
     }
 
     /**
@@ -295,7 +326,12 @@ class ZtdMysqli extends mysqli
      */
     public function rollback(int $flags = 0, ?string $name = null): bool
     {
-        return $this->innerMysqli->rollback($flags, $name);
+        $result = $this->innerMysqli->rollback($flags, $name);
+        if ($result) {
+            $this->session->rollBackTransaction();
+        }
+
+        return $result;
     }
 
     /**
@@ -303,7 +339,16 @@ class ZtdMysqli extends mysqli
      */
     public function autocommit(bool $enable): bool
     {
-        return $this->innerMysqli->autocommit($enable);
+        $result = $this->innerMysqli->autocommit($enable);
+        if ($result) {
+            if ($enable) {
+                $this->session->commitTransaction();
+            } else {
+                $this->session->beginTransaction();
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -530,7 +575,15 @@ class ZtdMysqli extends mysqli
      */
     public function release_savepoint(string $name): bool
     {
-        return $this->innerMysqli->release_savepoint($name);
+        $result = $this->innerMysqli->release_savepoint($name);
+        if ($result) {
+            $statement = TransactionStatement::parse('RELEASE SAVEPOINT `' . str_replace('`', '``', $name) . '`');
+            if ($statement !== null) {
+                $this->session->applyTransactionStatement($statement);
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -538,7 +591,15 @@ class ZtdMysqli extends mysqli
      */
     public function savepoint(string $name): bool
     {
-        return $this->innerMysqli->savepoint($name);
+        $result = $this->innerMysqli->savepoint($name);
+        if ($result) {
+            $statement = TransactionStatement::parse('SAVEPOINT `' . str_replace('`', '``', $name) . '`');
+            if ($statement !== null) {
+                $this->session->applyTransactionStatement($statement);
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -20,6 +20,43 @@ use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
 #[Large]
 final class MysqliCteShadowingTest extends TestCase
 {
+    public function testTransactionsAndSavepointsRestoreShadowRows(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, name VARCHAR(20))', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (1, 'one')", $table));
+            $ztdMysqli->begin_transaction();
+            $ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (2, 'two')", $table));
+            $ztdMysqli->savepoint('nested');
+            $ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (3, 'three')", $table));
+            $ztdMysqli->query('ROLLBACK TO SAVEPOINT nested');
+            $ztdMysqli->commit();
+
+            $committed = $ztdMysqli->query(sprintf('SELECT * FROM `%s` ORDER BY id', $table));
+            self::assertInstanceOf(\mysqli_result::class, $committed);
+            self::assertSame([
+                ['id' => 1, 'name' => 'one'],
+                ['id' => 2, 'name' => 'two'],
+            ], $committed->fetch_all(MYSQLI_ASSOC));
+
+            $ztdMysqli->begin_transaction();
+            $ztdMysqli->query(sprintf("UPDATE `%s` SET name = 'changed'", $table));
+            $ztdMysqli->rollback();
+            $rolledBack = $ztdMysqli->query(sprintf('SELECT * FROM `%s` ORDER BY id', $table));
+            self::assertInstanceOf(\mysqli_result::class, $rolledBack);
+            self::assertSame([
+                ['id' => 1, 'name' => 'one'],
+                ['id' => 2, 'name' => 'two'],
+            ], $rolledBack->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testRecursiveAndUserOwnedCteNamespacesRemainValid(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/ZtdMysqliTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/ZtdMysqliTest.php
@@ -239,12 +239,14 @@ final class ZtdMysqliTest extends TestCase
     public function testBeginTransactionDelegatesToInner(): void
     {
         $innerMysqli = new StubMysqli();
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
         $rewriter = static::createStub(SqlRewriter::class);
         $factory = static::createMock(SessionFactory::class);
         $factory->expects(self::once())
             ->method('create')
-            ->willReturnCallback(static function (ConnectionInterface $connection, ZtdConfig $config) use ($rewriter): Session {
-                return new Session($rewriter, new ShadowStore(), new ResultSelectRunner(), $config, $connection);
+            ->willReturnCallback(static function (ConnectionInterface $connection, ZtdConfig $config) use ($rewriter, $store): Session {
+                return new Session($rewriter, $store, new ResultSelectRunner(), $config, $connection);
             });
         $ztd = ZtdMysqli::fromMysqli($innerMysqli, null, $factory);
 
@@ -252,42 +254,56 @@ final class ZtdMysqliTest extends TestCase
 
         self::assertTrue($ztd->begin_transaction());
         self::assertSame(0, $innerMysqli->beginTransactionCalledWithFlags);
+        $store->insert('items', [['id' => 2]]);
+        self::assertTrue($ztd->rollback());
+        self::assertSame([['id' => 1]], $store->get('items'));
     }
 
     public function testCommitDelegatesToInner(): void
     {
         $innerMysqli = new StubMysqli();
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
         $rewriter = static::createStub(SqlRewriter::class);
         $factory = static::createMock(SessionFactory::class);
         $factory->expects(self::once())
             ->method('create')
-            ->willReturnCallback(static function (ConnectionInterface $connection, ZtdConfig $config) use ($rewriter): Session {
-                return new Session($rewriter, new ShadowStore(), new ResultSelectRunner(), $config, $connection);
+            ->willReturnCallback(static function (ConnectionInterface $connection, ZtdConfig $config) use ($rewriter, $store): Session {
+                return new Session($rewriter, $store, new ResultSelectRunner(), $config, $connection);
             });
         $ztd = ZtdMysqli::fromMysqli($innerMysqli, null, $factory);
 
         $innerMysqli->commitReturn = true;
 
+        self::assertTrue($ztd->begin_transaction());
+        $store->insert('items', [['id' => 2]]);
         self::assertTrue($ztd->commit());
         self::assertSame(0, $innerMysqli->commitCalledWithFlags);
+        self::assertTrue($ztd->rollback());
+        self::assertSame([['id' => 1], ['id' => 2]], $store->get('items'));
     }
 
     public function testRollbackDelegatesToInner(): void
     {
         $innerMysqli = new StubMysqli();
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
         $rewriter = static::createStub(SqlRewriter::class);
         $factory = static::createMock(SessionFactory::class);
         $factory->expects(self::once())
             ->method('create')
-            ->willReturnCallback(static function (ConnectionInterface $connection, ZtdConfig $config) use ($rewriter): Session {
-                return new Session($rewriter, new ShadowStore(), new ResultSelectRunner(), $config, $connection);
+            ->willReturnCallback(static function (ConnectionInterface $connection, ZtdConfig $config) use ($rewriter, $store): Session {
+                return new Session($rewriter, $store, new ResultSelectRunner(), $config, $connection);
             });
         $ztd = ZtdMysqli::fromMysqli($innerMysqli, null, $factory);
 
         $innerMysqli->rollbackReturn = true;
 
+        self::assertTrue($ztd->begin_transaction());
+        $store->insert('items', [['id' => 2]]);
         self::assertTrue($ztd->rollback());
         self::assertSame(0, $innerMysqli->rollbackCalledWithFlags);
+        self::assertSame([['id' => 1]], $store->get('items'));
     }
 
     public function testCloseDelegatesToInner(): void

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
@@ -12,6 +12,7 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
+use ZtdQuery\Sql\TransactionStatement;
 
 /**
  * PDO proxy that enforces ZTD behavior for reads and writes.
@@ -188,6 +189,18 @@ class ZtdPdo extends PDO
      */
     public function query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs): PDOStatement|false
     {
+        if ($this->session->isEnabled()) {
+            $transactionStatement = TransactionStatement::parse($query);
+            if ($transactionStatement !== null) {
+                $statement = $this->pdo->query($query, $fetchMode, ...$fetchModeArgs);
+                if ($statement !== false) {
+                    $this->session->applyTransactionStatement($transactionStatement);
+                }
+
+                return $statement;
+            }
+        }
+
         $stmt = $this->prepare($query);
         if ($stmt === false) {
             return false;
@@ -213,6 +226,16 @@ class ZtdPdo extends PDO
     {
         if (!$this->session->isEnabled()) {
             return $this->pdo->exec($statement);
+        }
+
+        $transactionStatement = TransactionStatement::parse($statement);
+        if ($transactionStatement !== null) {
+            $result = $this->pdo->exec($statement);
+            if ($result !== false) {
+                $this->session->applyTransactionStatement($transactionStatement);
+            }
+
+            return $result;
         }
 
         try {
@@ -241,7 +264,12 @@ class ZtdPdo extends PDO
      */
     public function beginTransaction(): bool
     {
-        return $this->pdo->beginTransaction();
+        $result = $this->pdo->beginTransaction();
+        if ($result) {
+            $this->session->beginTransaction();
+        }
+
+        return $result;
     }
 
     /**
@@ -249,7 +277,12 @@ class ZtdPdo extends PDO
      */
     public function commit(): bool
     {
-        return $this->pdo->commit();
+        $result = $this->pdo->commit();
+        if ($result) {
+            $this->session->commitTransaction();
+        }
+
+        return $result;
     }
 
     /**
@@ -257,7 +290,12 @@ class ZtdPdo extends PDO
      */
     public function rollBack(): bool
     {
-        return $this->pdo->rollBack();
+        $result = $this->pdo->rollBack();
+        if ($result) {
+            $this->session->rollBackTransaction();
+        }
+
+        return $result;
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
@@ -12,7 +12,6 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
-use ZtdQuery\Sql\TransactionStatement;
 
 /**
  * PDO proxy that enforces ZTD behavior for reads and writes.
@@ -190,7 +189,7 @@ class ZtdPdo extends PDO
     public function query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs): PDOStatement|false
     {
         if ($this->session->isEnabled()) {
-            $transactionStatement = TransactionStatement::parse($query);
+            $transactionStatement = $this->session->transactionStatement($query);
             if ($transactionStatement !== null) {
                 $statement = $this->pdo->query($query, $fetchMode, ...$fetchModeArgs);
                 if ($statement !== false) {
@@ -228,7 +227,7 @@ class ZtdPdo extends PDO
             return $this->pdo->exec($statement);
         }
 
-        $transactionStatement = TransactionStatement::parse($statement);
+        $transactionStatement = $this->session->transactionStatement($statement);
         if ($transactionStatement !== null) {
             $result = $this->pdo->exec($statement);
             if ($result !== false) {

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/TransactionTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/TransactionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_sqlite
+ */
+#[CoversNothing]
+#[Large]
+final class TransactionTest extends TestCase
+{
+    public function testRollbackRestoresInsertUpdateAndDeleteTogether(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        $rawPdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)');
+        $pdo = ZtdPdo::fromPdo($rawPdo);
+        $pdo->exec("INSERT INTO items VALUES (1, 'one')");
+        $pdo->exec("INSERT INTO items VALUES (2, 'two')");
+
+        $pdo->beginTransaction();
+        $pdo->exec("INSERT INTO items VALUES (3, 'three')");
+        $pdo->exec("UPDATE items SET name = 'changed' WHERE id = 1");
+        $pdo->exec('DELETE FROM items WHERE id = 2');
+        $pdo->rollBack();
+
+        $statement = $pdo->query('SELECT * FROM items ORDER BY id');
+        self::assertNotFalse($statement);
+        self::assertSame([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+        ], $statement->fetchAll(\PDO::FETCH_ASSOC));
+    }
+
+    public function testRollbackToSavepointRestoresOnlyNestedMutations(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        $rawPdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)');
+        $pdo = ZtdPdo::fromPdo($rawPdo);
+        $pdo->exec("INSERT INTO items VALUES (1, 'one')");
+
+        $pdo->beginTransaction();
+        $pdo->exec("INSERT INTO items VALUES (2, 'two')");
+        $pdo->exec('SAVEPOINT nested');
+        $pdo->exec("INSERT INTO items VALUES (3, 'three')");
+        $pdo->exec('ROLLBACK TO SAVEPOINT nested');
+        $pdo->exec('RELEASE SAVEPOINT nested');
+        $pdo->commit();
+
+        $statement = $pdo->query('SELECT * FROM items ORDER BY id');
+        self::assertNotFalse($statement);
+        self::assertSame([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+        ], $statement->fetchAll(\PDO::FETCH_ASSOC));
+    }
+
+    public function testSqlTransactionStatementsUseTheSameShadowSnapshots(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        $rawPdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)');
+        $pdo = ZtdPdo::fromPdo($rawPdo);
+
+        $pdo->exec('BEGIN');
+        $pdo->exec("INSERT INTO items VALUES (1, 'one')");
+        $pdo->exec('ROLLBACK');
+
+        $statement = $pdo->query('SELECT * FROM items');
+        self::assertNotFalse($statement);
+        self::assertSame([], $statement->fetchAll(\PDO::FETCH_ASSOC));
+    }
+
+    public function testRollbackRestoresVirtualSchemaRegistry(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        $pdo = ZtdPdo::fromPdo($rawPdo);
+
+        $pdo->beginTransaction();
+        $pdo->exec('CREATE TABLE virtual_items (id INTEGER PRIMARY KEY)');
+        $pdo->rollBack();
+        $pdo->exec('CREATE TABLE virtual_items (id INTEGER PRIMARY KEY)');
+        $pdo->exec('INSERT INTO virtual_items VALUES (1)');
+
+        $statement = $pdo->query('SELECT * FROM virtual_items');
+        self::assertNotFalse($statement);
+        self::assertSame([['id' => 1]], $statement->fetchAll(\PDO::FETCH_ASSOC));
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -10,6 +10,7 @@ use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Sql\TransactionStatement;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
 
@@ -21,6 +22,11 @@ use ZtdQuery\Shadow\ShadowStore;
  */
 final class PgSqlRewriter implements SqlRewriter
 {
+    public function transactionStatement(string $sql): ?TransactionStatement
+    {
+        return (new PgSqlTransactionStatementParser())->parse($sql);
+    }
+
     private PgSqlQueryGuard $guard;
     private ShadowStore $shadowStore;
     private TableDefinitionRegistry $registry;

--- a/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
+++ b/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
@@ -15,6 +15,7 @@ use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
 
 /**
  * Factory for creating Session instances pre-configured for PostgreSQL.
@@ -53,7 +54,8 @@ final class PgSqlSessionFactory implements SessionFactory
             $shadowStore,
             new ResultSelectRunner(),
             $config,
-            $connection
+            $connection,
+            new ShadowTransactionManager($shadowStore, $registry),
         );
     }
 }

--- a/packages/ztd-query-postgres/src/PgSqlTransactionStatementParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlTransactionStatementParser.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\TransactionStatement;
+use ZtdQuery\Sql\TransactionStatementParser;
+
+final class PgSqlTransactionStatementParser implements TransactionStatementParser
+{
+    public function parse(string $sql): ?TransactionStatement
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        if (($tokens[count($tokens) - 1] ?? null)?->text === ';') {
+            array_pop($tokens);
+        }
+        if ($this->matchesAny($tokens, [['BEGIN'], ['BEGIN', 'WORK'], ['BEGIN', 'TRANSACTION'], ['START', 'TRANSACTION']])) {
+            return TransactionStatement::begin();
+        }
+        if ($this->matchesAny($tokens, [['COMMIT'], ['COMMIT', 'WORK'], ['COMMIT', 'TRANSACTION'], ['END'], ['END', 'WORK'], ['END', 'TRANSACTION']])) {
+            return TransactionStatement::commit();
+        }
+        if ($this->matchesAny($tokens, [['ROLLBACK'], ['ROLLBACK', 'WORK'], ['ROLLBACK', 'TRANSACTION']])) {
+            return TransactionStatement::rollback();
+        }
+        $name = $this->nameAfter($tokens, [['SAVEPOINT']]);
+        if ($name !== null) {
+            return TransactionStatement::savepoint($name);
+        }
+        $name = $this->nameAfter($tokens, [['ROLLBACK', 'TO'], ['ROLLBACK', 'TO', 'SAVEPOINT']]);
+        if ($name !== null) {
+            return TransactionStatement::rollbackTo($name);
+        }
+        $name = $this->nameAfter($tokens, [['RELEASE'], ['RELEASE', 'SAVEPOINT']]);
+
+        return $name !== null ? TransactionStatement::release($name) : null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<list<string>> $forms
+     */
+    private function matchesAny(array $tokens, array $forms): bool
+    {
+        foreach ($forms as $form) {
+            if ($this->matches($tokens, $form)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<list<string>> $prefixes
+     */
+    private function nameAfter(array $tokens, array $prefixes): ?string
+    {
+        foreach ($prefixes as $prefix) {
+            if (count($tokens) !== count($prefix) + 1 || !$this->matches(array_slice($tokens, 0, -1), $prefix)) {
+                continue;
+            }
+            $name = $tokens[count($prefix)];
+            if (!in_array($name->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+                return null;
+            }
+
+            return $this->unquote($name->text);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<string> $keywords
+     */
+    private function matches(array $tokens, array $keywords): bool
+    {
+        if (count($tokens) !== count($keywords)) {
+            return false;
+        }
+        foreach ($keywords as $index => $keyword) {
+            if (!$tokens[$index]->isKeyword($keyword)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function unquote(string $identifier): ?string
+    {
+        $first = $identifier[0] ?? '';
+        if ($first === '`') {
+            return null;
+        }
+        if ($first !== '"') {
+            return $identifier;
+        }
+        if (($identifier[strlen($identifier) - 1] ?? '') !== '"') {
+            return null;
+        }
+
+        return str_replace('""', '"', substr($identifier, 1, -1));
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -42,6 +42,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(PgSqlQueryGuard::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTransactionStatementParser::class)]
 #[UsesClass(PgSqlMutationResolver::class)]
 #[UsesClass(PgSqlTransformer::class)]
 #[UsesClass(SelectTransformer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransactionStatementParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransactionStatementParserTest.php
@@ -6,17 +6,10 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlTransactionStatementParser;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
-use ZtdQuery\Sql\TransactionStatement;
 
 #[CoversClass(PgSqlTransactionStatementParser::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
-#[UsesClass(TransactionStatement::class)]
 final class PgSqlTransactionStatementParserTest extends TestCase
 {
     #[DataProvider('providerPostgresTransactionForms')]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransactionStatementParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransactionStatementParserTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlTransactionStatementParser;
+use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
 
 #[CoversClass(PgSqlTransactionStatementParser::class)]
 final class PgSqlTransactionStatementParserTest extends TestCase
@@ -27,7 +29,13 @@ final class PgSqlTransactionStatementParserTest extends TestCase
             'begin transaction' => ['BEGIN TRANSACTION'],
             'start' => ['START TRANSACTION'],
             'commit' => ['COMMIT'],
+            'commit work' => ['COMMIT WORK'],
+            'commit transaction' => ['COMMIT TRANSACTION'],
+            'end' => ['END'],
+            'end work' => ['END WORK'],
             'end transaction' => ['END TRANSACTION'],
+            'rollback' => ['ROLLBACK'],
+            'rollback work' => ['ROLLBACK WORK'],
             'rollback transaction' => ['ROLLBACK TRANSACTION'],
             'savepoint' => ['SAVEPOINT "a""b"'],
             'rollback to' => ['ROLLBACK TO point'],
@@ -41,9 +49,26 @@ final class PgSqlTransactionStatementParserTest extends TestCase
     {
         $parser = new PgSqlTransactionStatementParser();
 
+        self::assertNull($parser->parse(''));
         self::assertNull($parser->parse('BEGIN IMMEDIATE'));
         self::assertNull($parser->parse('SAVEPOINT `point`'));
         self::assertNull($parser->parse('SAVEPOINT point extra'));
         self::assertNull($parser->parse('SAVEPOINT "broken'));
+    }
+
+    public function testAppliesUnescapedPostgresSavepointName(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+        $transactions->begin();
+        $statement = (new PgSqlTransactionStatementParser())->parse('SAVEPOINT "a""b"');
+        self::assertNotNull($statement);
+        $statement->apply($transactions);
+        $store->insert('items', [['id' => 2]]);
+
+        $transactions->rollBackTo('a"b');
+
+        self::assertSame([['id' => 1]], $store->get('items'));
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransactionStatementParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransactionStatementParserTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlTransactionStatementParser;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\TransactionStatement;
+
+#[CoversClass(PgSqlTransactionStatementParser::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+#[UsesClass(TransactionStatement::class)]
+final class PgSqlTransactionStatementParserTest extends TestCase
+{
+    #[DataProvider('providerPostgresTransactionForms')]
+    public function testParsesPostgresTransactionForms(string $sql): void
+    {
+        self::assertNotNull((new PgSqlTransactionStatementParser())->parse($sql));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function providerPostgresTransactionForms(): array
+    {
+        return [
+            'begin' => ['BEGIN;'],
+            'begin work' => ['BEGIN WORK'],
+            'begin transaction' => ['BEGIN TRANSACTION'],
+            'start' => ['START TRANSACTION'],
+            'commit' => ['COMMIT'],
+            'end transaction' => ['END TRANSACTION'],
+            'rollback transaction' => ['ROLLBACK TRANSACTION'],
+            'savepoint' => ['SAVEPOINT "a""b"'],
+            'rollback to' => ['ROLLBACK TO point'],
+            'rollback to savepoint' => ['ROLLBACK TO SAVEPOINT point'],
+            'release' => ['RELEASE point'],
+            'release savepoint' => ['RELEASE SAVEPOINT point'],
+        ];
+    }
+
+    public function testRejectsNonPostgresAndMalformedForms(): void
+    {
+        $parser = new PgSqlTransactionStatementParser();
+
+        self::assertNull($parser->parse('BEGIN IMMEDIATE'));
+        self::assertNull($parser->parse('SAVEPOINT `point`'));
+        self::assertNull($parser->parse('SAVEPOINT point extra'));
+        self::assertNull($parser->parse('SAVEPOINT "broken'));
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -11,6 +11,7 @@ use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Sql\TransactionStatement;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
@@ -23,6 +24,11 @@ use ZtdQuery\Shadow\ShadowStore;
  */
 final class SqliteRewriter implements SqlRewriter
 {
+    public function transactionStatement(string $sql): ?TransactionStatement
+    {
+        return (new SqliteTransactionStatementParser())->parse($sql);
+    }
+
     private SqliteQueryGuard $guard;
     private ShadowStore $shadowStore;
     private TableDefinitionRegistry $registry;

--- a/packages/ztd-query-sqlite/src/SqliteSessionFactory.php
+++ b/packages/ztd-query-sqlite/src/SqliteSessionFactory.php
@@ -16,6 +16,7 @@ use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
 
 /**
  * Factory for creating Session instances pre-configured for SQLite.
@@ -54,7 +55,8 @@ final class SqliteSessionFactory implements SessionFactory
             $shadowStore,
             new ResultSelectRunner(),
             $config,
-            $connection
+            $connection,
+            new ShadowTransactionManager($shadowStore, $registry),
         );
     }
 }

--- a/packages/ztd-query-sqlite/src/SqliteTransactionStatementParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteTransactionStatementParser.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\TransactionStatement;
+use ZtdQuery\Sql\TransactionStatementParser;
+
+final class SqliteTransactionStatementParser implements TransactionStatementParser
+{
+    public function parse(string $sql): ?TransactionStatement
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        if (($tokens[count($tokens) - 1] ?? null)?->text === ';') {
+            array_pop($tokens);
+        }
+        if ($this->matchesAny($tokens, [
+            ['BEGIN'], ['BEGIN', 'TRANSACTION'], ['BEGIN', 'DEFERRED'], ['BEGIN', 'DEFERRED', 'TRANSACTION'],
+            ['BEGIN', 'IMMEDIATE'], ['BEGIN', 'IMMEDIATE', 'TRANSACTION'],
+            ['BEGIN', 'EXCLUSIVE'], ['BEGIN', 'EXCLUSIVE', 'TRANSACTION'],
+        ])) {
+            return TransactionStatement::begin();
+        }
+        if ($this->matchesAny($tokens, [['COMMIT'], ['COMMIT', 'TRANSACTION'], ['END'], ['END', 'TRANSACTION']])) {
+            return TransactionStatement::commit();
+        }
+        if ($this->matchesAny($tokens, [['ROLLBACK'], ['ROLLBACK', 'TRANSACTION']])) {
+            return TransactionStatement::rollback();
+        }
+        $name = $this->nameAfter($tokens, [['SAVEPOINT']]);
+        if ($name !== null) {
+            return TransactionStatement::savepoint($name);
+        }
+        $name = $this->nameAfter($tokens, [['ROLLBACK', 'TO'], ['ROLLBACK', 'TO', 'SAVEPOINT']]);
+        if ($name !== null) {
+            return TransactionStatement::rollbackTo($name);
+        }
+        $name = $this->nameAfter($tokens, [['RELEASE'], ['RELEASE', 'SAVEPOINT']]);
+
+        return $name !== null ? TransactionStatement::release($name) : null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<list<string>> $forms
+     */
+    private function matchesAny(array $tokens, array $forms): bool
+    {
+        foreach ($forms as $form) {
+            if ($this->matches($tokens, $form)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<list<string>> $prefixes
+     */
+    private function nameAfter(array $tokens, array $prefixes): ?string
+    {
+        foreach ($prefixes as $prefix) {
+            if (count($tokens) !== count($prefix) + 1 || !$this->matches(array_slice($tokens, 0, -1), $prefix)) {
+                continue;
+            }
+            $name = $tokens[count($prefix)];
+            if (!in_array($name->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+                return null;
+            }
+
+            return $this->unquote($name->text);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param list<string> $keywords
+     */
+    private function matches(array $tokens, array $keywords): bool
+    {
+        if (count($tokens) !== count($keywords)) {
+            return false;
+        }
+        foreach ($keywords as $index => $keyword) {
+            if (!$tokens[$index]->isKeyword($keyword)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function unquote(string $identifier): ?string
+    {
+        $first = $identifier[0] ?? '';
+        if (!in_array($first, ['"', '`'], true)) {
+            return $identifier;
+        }
+        if (($identifier[strlen($identifier) - 1] ?? '') !== $first) {
+            return null;
+        }
+
+        return str_replace($first . $first, $first, substr($identifier, 1, -1));
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -41,6 +41,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SqliteQueryGuard::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteTransactionStatementParser::class)]
 #[UsesClass(SqliteSchemaParser::class)]
 #[UsesClass(SqliteMutationResolver::class)]
 #[UsesClass(SqliteTransformer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteTransactionStatementParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteTransactionStatementParserTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteTransactionStatementParser;
+use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Shadow\ShadowTransactionManager;
 
 #[CoversClass(SqliteTransactionStatementParser::class)]
 final class SqliteTransactionStatementParserTest extends TestCase
@@ -25,10 +27,16 @@ final class SqliteTransactionStatementParserTest extends TestCase
             'begin' => ['BEGIN;'],
             'begin transaction' => ['BEGIN TRANSACTION'],
             'begin deferred' => ['BEGIN DEFERRED'],
-            'begin immediate' => ['BEGIN IMMEDIATE TRANSACTION'],
+            'begin deferred transaction' => ['BEGIN DEFERRED TRANSACTION'],
+            'begin immediate' => ['BEGIN IMMEDIATE'],
+            'begin immediate transaction' => ['BEGIN IMMEDIATE TRANSACTION'],
             'begin exclusive' => ['BEGIN EXCLUSIVE'],
+            'begin exclusive transaction' => ['BEGIN EXCLUSIVE TRANSACTION'],
+            'commit' => ['COMMIT'],
             'commit transaction' => ['COMMIT TRANSACTION'],
             'end' => ['END'],
+            'end transaction' => ['END TRANSACTION'],
+            'rollback' => ['ROLLBACK'],
             'rollback transaction' => ['ROLLBACK TRANSACTION'],
             'savepoint' => ['SAVEPOINT `a``b`'],
             'rollback to' => ['ROLLBACK TO point'],
@@ -42,9 +50,26 @@ final class SqliteTransactionStatementParserTest extends TestCase
     {
         $parser = new SqliteTransactionStatementParser();
 
+        self::assertNull($parser->parse(''));
         self::assertNull($parser->parse('START TRANSACTION'));
         self::assertNull($parser->parse('COMMIT WORK'));
         self::assertNull($parser->parse('SAVEPOINT point extra'));
         self::assertNull($parser->parse('SAVEPOINT `broken'));
+    }
+
+    public function testAppliesUnescapedSqliteSavepointName(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [['id' => 1]]);
+        $transactions = new ShadowTransactionManager($store);
+        $transactions->begin();
+        $statement = (new SqliteTransactionStatementParser())->parse('SAVEPOINT `a``b`');
+        self::assertNotNull($statement);
+        $statement->apply($transactions);
+        $store->insert('items', [['id' => 2]]);
+
+        $transactions->rollBackTo('a`b');
+
+        self::assertSame([['id' => 1]], $store->get('items'));
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteTransactionStatementParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteTransactionStatementParserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteTransactionStatementParser;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\TransactionStatement;
+
+#[CoversClass(SqliteTransactionStatementParser::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+#[UsesClass(TransactionStatement::class)]
+final class SqliteTransactionStatementParserTest extends TestCase
+{
+    #[DataProvider('providerSqliteTransactionForms')]
+    public function testParsesSqliteTransactionForms(string $sql): void
+    {
+        self::assertNotNull((new SqliteTransactionStatementParser())->parse($sql));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function providerSqliteTransactionForms(): array
+    {
+        return [
+            'begin' => ['BEGIN;'],
+            'begin transaction' => ['BEGIN TRANSACTION'],
+            'begin deferred' => ['BEGIN DEFERRED'],
+            'begin immediate' => ['BEGIN IMMEDIATE TRANSACTION'],
+            'begin exclusive' => ['BEGIN EXCLUSIVE'],
+            'commit transaction' => ['COMMIT TRANSACTION'],
+            'end' => ['END'],
+            'rollback transaction' => ['ROLLBACK TRANSACTION'],
+            'savepoint' => ['SAVEPOINT `a``b`'],
+            'rollback to' => ['ROLLBACK TO point'],
+            'rollback to savepoint' => ['ROLLBACK TO SAVEPOINT point'],
+            'release' => ['RELEASE point'],
+            'release savepoint' => ['RELEASE SAVEPOINT point'],
+        ];
+    }
+
+    public function testRejectsNonSqliteAndMalformedForms(): void
+    {
+        $parser = new SqliteTransactionStatementParser();
+
+        self::assertNull($parser->parse('START TRANSACTION'));
+        self::assertNull($parser->parse('COMMIT WORK'));
+        self::assertNull($parser->parse('SAVEPOINT point extra'));
+        self::assertNull($parser->parse('SAVEPOINT `broken'));
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteTransactionStatementParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteTransactionStatementParserTest.php
@@ -6,17 +6,10 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteTransactionStatementParser;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
-use ZtdQuery\Sql\TransactionStatement;
 
 #[CoversClass(SqliteTransactionStatementParser::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
-#[UsesClass(TransactionStatement::class)]
 final class SqliteTransactionStatementParserTest extends TestCase
 {
     #[DataProvider('providerSqliteTransactionForms')]


### PR DESCRIPTION
## Root problem

Transaction APIs and savepoint SQL changed only the physical connection. Shadow rows and virtual schema metadata remained mutated after rollback.

## Changes

- add a per-session snapshot stack covering both `ShadowStore` and `TableDefinitionRegistry`
- synchronize PDO and MySQLi begin/commit/rollback/autocommit APIs after successful native operations
- parse transaction-control SQL with the shared lossless token stream instead of regular expressions
- implement SAVEPOINT, ROLLBACK TO, and RELEASE nesting semantics
- support SQL BEGIN/START TRANSACTION/COMMIT/END/ROLLBACK forms
- add core snapshot/parser tests, SQLite integration coverage for DML/DDL rollback and savepoints, and a real MySQLi container test

## Verification

- core: 339 tests, 668 assertions
- PDO unit: 269 tests, 310 assertions
- MySQLi unit: 52 tests, 89 assertions
- SQLite transaction integration: 4 tests, 8 assertions
- MySQLi transaction integration: 1 test, 4 assertions
- PHP-CS-Fixer and PHPStan pass in core and every changed platform/adapter package

Fixes #120
Fixes #149