### PR TITLE
Fix simulated execution result metadata

### DIFF
--- a/packages/ztd-query-core/src/GenericExecuteResult.php
+++ b/packages/ztd-query-core/src/GenericExecuteResult.php
@@ -40,6 +40,8 @@ final class GenericExecuteResult implements ExecuteResult
      */
     private ?int $rowCountOverride;
 
+    private bool $resultSet;
+
     /**
      * @param array<int, array<string, mixed>>|null $bufferedRows
      */
@@ -49,7 +51,8 @@ final class GenericExecuteResult implements ExecuteResult
         QueryKind $kind,
         ?StatementInterface $rewrittenStatement = null,
         ?array $bufferedRows = null,
-        ?int $rowCountOverride = null
+        ?int $rowCountOverride = null,
+        bool $resultSet = false,
     ) {
         $this->passthrough = $passthrough;
         $this->success = $success;
@@ -57,6 +60,7 @@ final class GenericExecuteResult implements ExecuteResult
         $this->rewrittenStatement = $rewrittenStatement;
         $this->bufferedRows = $bufferedRows;
         $this->rowCountOverride = $rowCountOverride;
+        $this->resultSet = $resultSet;
     }
 
     /**
@@ -101,15 +105,20 @@ final class GenericExecuteResult implements ExecuteResult
      *
      * @param array<int, array<string, mixed>> $rows
      */
-    public static function fromBufferedRows(array $rows, QueryKind $kind = QueryKind::WRITE_SIMULATED): self
-    {
+    public static function fromBufferedRows(
+        array $rows,
+        QueryKind $kind = QueryKind::WRITE_SIMULATED,
+        ?int $affectedRowCount = null,
+        bool $hasResultSet = false,
+    ): self {
         return new self(
             passthrough: false,
             success: true,
             kind: $kind,
             rewrittenStatement: null,
             bufferedRows: $rows,
-            rowCountOverride: count($rows)
+            rowCountOverride: $affectedRowCount ?? count($rows),
+            resultSet: $hasResultSet,
         );
     }
 
@@ -226,7 +235,7 @@ final class GenericExecuteResult implements ExecuteResult
      */
     public function hasResultSet(): bool
     {
-        return $this->kind === QueryKind::READ;
+        return $this->kind === QueryKind::READ || $this->resultSet;
     }
 
     /**

--- a/packages/ztd-query-core/src/Rewrite/AffectedRowsMode.php
+++ b/packages/ztd-query-core/src/Rewrite/AffectedRowsMode.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Rewrite;
+
+/**
+ * Native UPDATE row-count convention for a database connection.
+ */
+enum AffectedRowsMode: string
+{
+    case Changed = 'changed';
+    case Matched = 'matched';
+}

--- a/packages/ztd-query-core/src/Rewrite/ReturningProjection.php
+++ b/packages/ztd-query-core/src/Rewrite/ReturningProjection.php
@@ -4,13 +4,8 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Rewrite;
 
-use ZtdQuery\Exception\UnsupportedSqlException;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
-
 /**
- * A validated projection for simple SQL RETURNING column lists.
+ * A dialect-neutral projection of mutation rows returned to the client.
  */
 final class ReturningProjection
 {
@@ -21,27 +16,21 @@ final class ReturningProjection
     {
     }
 
-    public static function parse(string $sql): ?self
+    /**
+     * @param list<array{source: string|null, output: string|null}> $items
+     */
+    public static function fromItems(array $items): self
     {
-        $clause = SqlTokenStream::tokenize($sql)->topLevelClause(['RETURNING']);
-        if ($clause === null) {
-            return null;
-        }
-
-        $items = [];
-        foreach (SqlTokenStream::tokenize(rtrim($clause, "; \t\n\r\0\x0B"))->splitTopLevel() as $expression) {
-            $item = self::parseItem($expression);
-            if ($item === null) {
-                throw new UnsupportedSqlException(
-                    $sql,
-                    'RETURNING supports columns, qualified columns, aliases, and wildcard projections',
-                );
-            }
-            $items[] = $item;
-        }
-
         if ($items === []) {
-            throw new UnsupportedSqlException($sql, 'RETURNING requires a projection');
+            throw new \InvalidArgumentException('Returning projection requires at least one item.');
+        }
+        foreach ($items as $item) {
+            if ($item['source'] === null && $item['output'] !== null) {
+                throw new \InvalidArgumentException('Wildcard returning projections cannot have an output name.');
+            }
+            if ($item['source'] === '' || $item['output'] === '') {
+                throw new \InvalidArgumentException('Returning projection names must not be empty.');
+            }
         }
 
         return new self($items);
@@ -68,94 +57,5 @@ final class ReturningProjection
         }
 
         return $projectedRows;
-    }
-
-    /**
-     * @return array{source: string|null, output: string|null}|null
-     */
-    private static function parseItem(string $expression): ?array
-    {
-        $tokens = SqlTokenStream::tokenize($expression)->significantTokens();
-        $alias = null;
-        $asIndex = self::asIndex($tokens);
-        if ($asIndex !== null) {
-            $aliasToken = $tokens[$asIndex + 1];
-            if (!self::isIdentifier($aliasToken) || $asIndex + 2 !== count($tokens)) {
-                return null;
-            }
-            $alias = self::unquote($aliasToken->text);
-            $tokens = array_slice($tokens, 0, $asIndex);
-        }
-
-        if (count($tokens) === 1 && $tokens[0]->kind === SqlTokenKind::Symbol && $tokens[0]->text === '*') {
-            return ['source' => null, 'output' => null];
-        }
-
-        if (!self::isIdentifierPath($tokens)) {
-            return null;
-        }
-        $last = $tokens[count($tokens) - 1];
-        if ($last->kind === SqlTokenKind::Symbol && $last->text === '*') {
-            return ['source' => null, 'output' => null];
-        }
-
-        $source = self::unquote($last->text);
-
-        return ['source' => $source, 'output' => $alias];
-    }
-
-    /** @param list<SqlToken> $tokens */
-    private static function asIndex(array $tokens): ?int
-    {
-        foreach ($tokens as $index => $token) {
-            if ($token->isKeyword('AS')) {
-                return $index;
-            }
-        }
-
-        return null;
-    }
-
-    /** @param list<SqlToken> $tokens */
-    private static function isIdentifierPath(array $tokens): bool
-    {
-        if ($tokens === []) {
-            return false;
-        }
-        foreach ($tokens as $index => $token) {
-            if ($index % 2 === 0) {
-                $isTrailingWildcard = $index === count($tokens) - 1
-                    && $token->kind === SqlTokenKind::Symbol
-                    && $token->text === '*';
-                if (!self::isIdentifier($token) && !$isTrailingWildcard) {
-                    return false;
-                }
-                continue;
-            }
-            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '.') {
-                return false;
-            }
-        }
-
-        return count($tokens) % 2 === 1;
-    }
-
-    private static function isIdentifier(SqlToken $token): bool
-    {
-        return in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true);
-    }
-
-    private static function unquote(string $identifier): string
-    {
-        $first = $identifier[0] ?? '';
-        $last = $identifier[strlen($identifier) - 1] ?? '';
-        if (($first === '"' && $last === '"') || ($first === '`' && $last === '`')) {
-            return str_replace($first . $first, $first, substr($identifier, 1, -1));
-        }
-        if ($first === '[' && $last === ']') {
-            return str_replace(']]', ']', substr($identifier, 1, -1));
-        }
-
-        return $identifier;
     }
 }

--- a/packages/ztd-query-core/src/Rewrite/ReturningProjection.php
+++ b/packages/ztd-query-core/src/Rewrite/ReturningProjection.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Rewrite;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+/**
+ * A validated projection for simple SQL RETURNING column lists.
+ */
+final class ReturningProjection
+{
+    /**
+     * @param list<array{source: string|null, output: string|null}> $items
+     */
+    private function __construct(private readonly array $items)
+    {
+    }
+
+    public static function parse(string $sql): ?self
+    {
+        $clause = SqlTokenStream::tokenize($sql)->topLevelClause(['RETURNING']);
+        if ($clause === null) {
+            return null;
+        }
+
+        $items = [];
+        foreach (SqlTokenStream::tokenize(rtrim($clause, "; \t\n\r\0\x0B"))->splitTopLevel() as $expression) {
+            $item = self::parseItem($expression);
+            if ($item === null) {
+                throw new UnsupportedSqlException(
+                    $sql,
+                    'RETURNING supports columns, qualified columns, aliases, and wildcard projections',
+                );
+            }
+            $items[] = $item;
+        }
+
+        if ($items === []) {
+            throw new UnsupportedSqlException($sql, 'RETURNING requires a projection');
+        }
+
+        return new self($items);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<string, mixed>>
+     */
+    public function project(array $rows): array
+    {
+        $projectedRows = [];
+        foreach ($rows as $row) {
+            $projected = [];
+            foreach ($this->items as $item) {
+                if ($item['source'] === null) {
+                    $projected = array_merge($projected, $row);
+                    continue;
+                }
+                $output = $item['output'] ?? $item['source'];
+                $projected[$output] = $row[$item['source']] ?? null;
+            }
+            $projectedRows[] = $projected;
+        }
+
+        return $projectedRows;
+    }
+
+    /**
+     * @return array{source: string|null, output: string|null}|null
+     */
+    private static function parseItem(string $expression): ?array
+    {
+        $tokens = SqlTokenStream::tokenize($expression)->significantTokens();
+        $alias = null;
+        $asIndex = self::asIndex($tokens);
+        if ($asIndex !== null) {
+            $aliasToken = $tokens[$asIndex + 1];
+            if (!self::isIdentifier($aliasToken) || $asIndex + 2 !== count($tokens)) {
+                return null;
+            }
+            $alias = self::unquote($aliasToken->text);
+            $tokens = array_slice($tokens, 0, $asIndex);
+        }
+
+        if (count($tokens) === 1 && $tokens[0]->kind === SqlTokenKind::Symbol && $tokens[0]->text === '*') {
+            return ['source' => null, 'output' => null];
+        }
+
+        if (!self::isIdentifierPath($tokens)) {
+            return null;
+        }
+        $last = $tokens[count($tokens) - 1];
+        if ($last->kind === SqlTokenKind::Symbol && $last->text === '*') {
+            return ['source' => null, 'output' => null];
+        }
+
+        $source = self::unquote($last->text);
+
+        return ['source' => $source, 'output' => $alias];
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private static function asIndex(array $tokens): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isKeyword('AS')) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private static function isIdentifierPath(array $tokens): bool
+    {
+        if ($tokens === []) {
+            return false;
+        }
+        foreach ($tokens as $index => $token) {
+            if ($index % 2 === 0) {
+                $isTrailingWildcard = $index === count($tokens) - 1
+                    && $token->kind === SqlTokenKind::Symbol
+                    && $token->text === '*';
+                if (!self::isIdentifier($token) && !$isTrailingWildcard) {
+                    return false;
+                }
+                continue;
+            }
+            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '.') {
+                return false;
+            }
+        }
+
+        return count($tokens) % 2 === 1;
+    }
+
+    private static function isIdentifier(SqlToken $token): bool
+    {
+        return in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true);
+    }
+
+    private static function unquote(string $identifier): string
+    {
+        $first = $identifier[0] ?? '';
+        $last = $identifier[strlen($identifier) - 1] ?? '';
+        if (($first === '"' && $last === '"') || ($first === '`' && $last === '`')) {
+            return str_replace($first . $first, $first, substr($identifier, 1, -1));
+        }
+        if ($first === '[' && $last === ']') {
+            return str_replace(']]', ']', substr($identifier, 1, -1));
+        }
+
+        return $identifier;
+    }
+}

--- a/packages/ztd-query-core/src/Rewrite/ReturningProjection.php
+++ b/packages/ztd-query-core/src/Rewrite/ReturningProjection.php
@@ -58,4 +58,10 @@ final class ReturningProjection
 
         return $projectedRows;
     }
+
+    /** @return list<array{source: string|null, output: string|null}> */
+    public function items(): array
+    {
+        return $this->items;
+    }
 }

--- a/packages/ztd-query-core/src/Rewrite/RewritePlan.php
+++ b/packages/ztd-query-core/src/Rewrite/RewritePlan.php
@@ -32,19 +32,29 @@ final class RewritePlan
      */
     private ?ShadowMutation $mutation;
 
+    private ?ReturningProjection $returningProjection;
+
+    private AffectedRowsMode $affectedRowsMode;
+
     /**
      * @param string $sql Rewritten SQL.
      * @param QueryKind $kind Classified kind of the statement.
      * @param ShadowMutation|null $mutation Optional mutation to apply after execution.
+     * @param ReturningProjection|null $returningProjection Optional client-visible write projection.
+     * @param AffectedRowsMode $affectedRowsMode Native affected-row convention.
      */
     public function __construct(
         string $sql,
         QueryKind $kind,
-        ?ShadowMutation $mutation = null
+        ?ShadowMutation $mutation = null,
+        ?ReturningProjection $returningProjection = null,
+        AffectedRowsMode $affectedRowsMode = AffectedRowsMode::Changed,
     ) {
         $this->sql = $sql;
         $this->kind = $kind;
         $this->mutation = $mutation;
+        $this->returningProjection = $returningProjection;
+        $this->affectedRowsMode = $affectedRowsMode;
     }
 
     /**
@@ -69,5 +79,15 @@ final class RewritePlan
     public function mutation(): ?ShadowMutation
     {
         return $this->mutation;
+    }
+
+    public function returningProjection(): ?ReturningProjection
+    {
+        return $this->returningProjection;
+    }
+
+    public function affectedRowsMode(): AffectedRowsMode
+    {
+        return $this->affectedRowsMode;
     }
 }

--- a/packages/ztd-query-core/src/Rewrite/RewriteStateCommitter.php
+++ b/packages/ztd-query-core/src/Rewrite/RewriteStateCommitter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Rewrite;
+
+/**
+ * Commits rewrite-time reservations only after simulated execution succeeds.
+ */
+interface RewriteStateCommitter
+{
+    public function commitRewriteState(): void;
+}

--- a/packages/ztd-query-core/src/Rewrite/ShadowIdentityAllocator.php
+++ b/packages/ztd-query-core/src/Rewrite/ShadowIdentityAllocator.php
@@ -9,7 +9,20 @@ use ZtdQuery\Schema\IdentityGenerationStrategy;
 final class ShadowIdentityAllocator
 {
     /** @var array<string, array<string, int>> */
-    private array $nextValues = [];
+    private array $committedNextValues = [];
+
+    /** @var array<string, array<string, int>> */
+    private array $projectionNextValues = [];
+
+    public function beginProjection(): void
+    {
+        $this->projectionNextValues = $this->committedNextValues;
+    }
+
+    public function commitProjection(): void
+    {
+        $this->committedNextValues = $this->projectionNextValues;
+    }
 
     /**
      * @param array<string, IdentityGenerationStrategy> $strategies
@@ -31,7 +44,7 @@ final class ShadowIdentityAllocator
 
             $next = $this->nextValue($table, $column, $strategy, $existingRows);
             $allocated[$column] = $next;
-            $this->nextValues[$table][$column] = $next + 1;
+            $this->projectionNextValues[$table][$column] = $next + 1;
         }
 
         return $allocated;
@@ -55,7 +68,7 @@ final class ShadowIdentityAllocator
                 continue;
             }
             $next = $this->nextValue($table, $column, $strategy, $existingRows);
-            $this->nextValues[$table][$column] = $next;
+            $this->projectionNextValues[$table][$column] = $next;
             $starts[$column] = $next;
         }
 
@@ -69,11 +82,11 @@ final class ShadowIdentityAllocator
         IdentityGenerationStrategy $strategy,
         array $existingRows,
     ): int {
-        $next = $this->nextValues[$table][$column] ?? 1;
+        $next = $this->projectionNextValues[$table][$column] ?? 1;
         if ($strategy === IdentityGenerationStrategy::MaxValue) {
             return $this->nextAfterExistingRows($column, $existingRows, $next);
         }
-        if (isset($this->nextValues[$table][$column])) {
+        if (isset($this->projectionNextValues[$table][$column])) {
             return $this->nextAfterExistingRows($column, $existingRows, $next);
         }
 

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -17,6 +17,9 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Rewrite\RewriteStateCommitter;
+use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Shadow\Mutation\MutationImpact;
 use ZtdQuery\Shadow\Mutation\ShadowMutation;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTransactionManager;
@@ -71,6 +74,10 @@ final class Session
 
     private ShadowTransactionManager $transactions;
 
+    private ?TableDefinitionRegistry $registry;
+
+    private ?string $lastInsertId = null;
+
     /**
      * @param SqlRewriter $rewriter Rewrite pipeline for SQL.
      * @param ShadowStore $shadowStore Target shadow store for mutation application.
@@ -85,6 +92,7 @@ final class Session
         ZtdConfig $config,
         ConnectionInterface $connection,
         ?ShadowTransactionManager $transactions = null,
+        ?TableDefinitionRegistry $registry = null,
     ) {
         $this->rewriter = $rewriter;
         $this->shadowStore = $shadowStore;
@@ -92,6 +100,7 @@ final class Session
         $this->config = $config;
         $this->connection = $connection;
         $this->transactions = $transactions ?? new ShadowTransactionManager($shadowStore);
+        $this->registry = $registry;
     }
 
     /**
@@ -168,6 +177,11 @@ final class Session
         return $this->rewriter->transactionStatement($sql);
     }
 
+    public function lastInsertId(): string|false
+    {
+        return $this->lastInsertId ?? false;
+    }
+
 
     /**
      * Rewrite SQL using the configured rewriter.
@@ -240,9 +254,18 @@ final class Session
         if ($mutation === null) {
             throw new RuntimeException('ZTD Write Protection: Missing shadow mutation for write simulation.');
         }
-        $this->applyMutation($mutation, $rows);
+        $impact = $this->applyMutation($mutation, $rows);
+        $returningProjection = $plan->returningProjection();
+        $resultRows = $returningProjection !== null
+            ? $returningProjection->project($impact->returningRows())
+            : $rows;
 
-        return GenericExecuteResult::fromBufferedRows($rows, QueryKind::WRITE_SIMULATED);
+        return GenericExecuteResult::fromBufferedRows(
+            $resultRows,
+            QueryKind::WRITE_SIMULATED,
+            $impact->affectedRowCount($plan->affectedRowsMode()),
+            $returningProjection !== null,
+        );
     }
 
     /**
@@ -298,9 +321,9 @@ final class Session
         }
 
         $rows = $this->resultSelectRunner->run($plan->sql(), fn (string $s) => $this->connection->query($s));
-        $this->applyMutation($mutation, $rows);
+        $impact = $this->applyMutation($mutation, $rows);
 
-        return count($rows);
+        return $impact->affectedRowCount($plan->affectedRowsMode());
     }
 
     /**
@@ -310,12 +333,47 @@ final class Session
      * @param array<int, array<string, mixed>> $rows
      * @throws DatabaseException When shadow mutation application fails.
      */
-    private function applyMutation(ShadowMutation $mutation, array $rows): void
+    private function applyMutation(ShadowMutation $mutation, array $rows): MutationImpact
     {
+        $before = $this->shadowStore->get($mutation->tableName());
         try {
             $mutation->apply($this->shadowStore, $rows);
         } catch (SimulationException $e) {
             throw new DatabaseException($e->getMessage(), null, 0, $e);
+        }
+        $impact = new MutationImpact(
+            $mutation,
+            $before,
+            $rows,
+            $this->shadowStore->get($mutation->tableName()),
+        );
+        if ($impact->isInsertLike() && $this->rewriter instanceof RewriteStateCommitter) {
+            $this->rewriter->commitRewriteState();
+        }
+        $this->captureLastInsertId($mutation, $impact);
+
+        return $impact;
+    }
+
+    private function captureLastInsertId(ShadowMutation $mutation, MutationImpact $impact): void
+    {
+        if (!$impact->isInsertLike()) {
+            return;
+        }
+
+        $definition = $this->registry?->get($mutation->tableName());
+        $identityColumns = $definition !== null ? array_keys($definition->identityStrategies) : [];
+        if ($identityColumns === [] && $definition !== null && count($definition->primaryKeys) === 1) {
+            $identityColumns = $definition->primaryKeys;
+        }
+        $identityColumn = $identityColumns[0] ?? null;
+        $returningRows = $impact->returningRows();
+        $lastRow = $returningRows[count($returningRows) - 1] ?? null;
+        $identityValue = $identityColumn !== null && $lastRow !== null
+            ? ($lastRow[$identityColumn] ?? null)
+            : null;
+        if (is_int($identityValue) || is_string($identityValue)) {
+            $this->lastInsertId = (string) $identityValue;
         }
     }
 }

--- a/packages/ztd-query-core/src/Shadow/Mutation/MutationImpact.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MutationImpact.php
@@ -71,14 +71,13 @@ final class MutationImpact
      */
     private function difference(array $left, array $right): array
     {
-        $remaining = array_values($right);
+        $remaining = $right;
         $difference = [];
         foreach ($left as $row) {
             $match = null;
             foreach ($remaining as $index => $candidate) {
                 if ($this->rowsEqual($row, $candidate)) {
                     $match = $index;
-                    break;
                 }
             }
             if ($match === null) {

--- a/packages/ztd-query-core/src/Shadow/Mutation/MutationImpact.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MutationImpact.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+use ZtdQuery\Rewrite\AffectedRowsMode;
+
+/**
+ * Derives observable execution metadata from a shadow-state transition.
+ */
+final class MutationImpact
+{
+    /**
+     * @param array<int, array<string, mixed>> $before
+     * @param array<int, array<string, mixed>> $input
+     * @param array<int, array<string, mixed>> $after
+     */
+    public function __construct(
+        private readonly ShadowMutation $mutation,
+        private readonly array $before,
+        private readonly array $input,
+        private readonly array $after,
+    ) {
+    }
+
+    public function affectedRowCount(AffectedRowsMode $mode): int
+    {
+        if ($mode === AffectedRowsMode::Matched && $this->mutation instanceof UpdateMutation) {
+            return count($this->input);
+        }
+
+        return max(
+            count($this->difference($this->before, $this->after)),
+            count($this->difference($this->after, $this->before)),
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function returningRows(): array
+    {
+        if ($this->mutation instanceof UpdateMutation || $this->mutation instanceof DeleteMutation) {
+            return $this->clean($this->input);
+        }
+
+        $added = $this->difference($this->after, $this->before);
+        if ($added !== []) {
+            return $added;
+        }
+
+        if ($this->mutation instanceof UpsertMutation) {
+            return $this->clean($this->input);
+        }
+
+        return [];
+    }
+
+    public function isInsertLike(): bool
+    {
+        return $this->mutation instanceof InsertMutation
+            || $this->mutation instanceof ReplaceMutation
+            || $this->mutation instanceof UpsertMutation;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $left
+     * @param array<int, array<string, mixed>> $right
+     * @return array<int, array<string, mixed>>
+     */
+    private function difference(array $left, array $right): array
+    {
+        $remaining = array_values($right);
+        $difference = [];
+        foreach ($left as $row) {
+            $match = null;
+            foreach ($remaining as $index => $candidate) {
+                if ($this->rowsEqual($row, $candidate)) {
+                    $match = $index;
+                    break;
+                }
+            }
+            if ($match === null) {
+                $difference[] = $row;
+                continue;
+            }
+            unset($remaining[$match]);
+        }
+
+        return $difference;
+    }
+
+    /**
+     * @param array<string, mixed> $left
+     * @param array<string, mixed> $right
+     */
+    private function rowsEqual(array $left, array $right): bool
+    {
+        if (count($left) !== count($right)) {
+            return false;
+        }
+        foreach ($left as $column => $value) {
+            if (!array_key_exists($column, $right) || $right[$column] !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function clean(array $rows): array
+    {
+        $identity = new MutationRowIdentity();
+
+        return array_map($identity->strip(...), $rows);
+    }
+}

--- a/packages/ztd-query-core/src/Shadow/Mutation/MutationRowIdentity.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MutationRowIdentity.php
@@ -15,6 +15,21 @@ final class MutationRowIdentity
 
     /**
      * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    public function strip(array $row): array
+    {
+        foreach (array_keys($row) as $column) {
+            if (str_starts_with($column, self::PREFIX)) {
+                unset($row[$column]);
+            }
+        }
+
+        return $row;
+    }
+
+    /**
+     * @param array<string, mixed> $row
      * @param array<int, string> $primaryKeys
      * @return array{row: array<string, mixed>, identity: array<string, mixed>}
      */

--- a/packages/ztd-query-core/tests/Unit/GenericExecuteResultTest.php
+++ b/packages/ztd-query-core/tests/Unit/GenericExecuteResultTest.php
@@ -163,6 +163,19 @@ final class GenericExecuteResultTest extends TestCase
         self::assertFalse($result->hasResultSet());
     }
 
+    public function testBufferedReturningUsesIndependentAffectedCount(): void
+    {
+        $result = GenericExecuteResult::fromBufferedRows(
+            [['id' => 1]],
+            affectedRowCount: 3,
+            hasResultSet: true,
+        );
+
+        self::assertTrue($result->hasResultSet());
+        self::assertSame(3, $result->rowCount());
+        self::assertSame([['id' => 1]], $result->fetchAll());
+    }
+
     public function testPassthroughFetchReturnsFalse(): void
     {
         $result = GenericExecuteResult::passthrough();

--- a/packages/ztd-query-core/tests/Unit/GenericExecuteResultTest.php
+++ b/packages/ztd-query-core/tests/Unit/GenericExecuteResultTest.php
@@ -30,6 +30,7 @@ final class GenericExecuteResultTest extends TestCase
         self::assertFalse($result->isPassthrough());
         self::assertFalse($result->isSuccess());
         self::assertSame(QueryKind::WRITE_SIMULATED, $result->kind());
+        self::assertFalse($result->hasResultSet());
     }
 
     public function testFromBufferedRows(): void

--- a/packages/ztd-query-core/tests/Unit/Rewrite/AffectedRowsModeTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/AffectedRowsModeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rewrite;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Rewrite\AffectedRowsMode;
+
+#[CoversClass(AffectedRowsMode::class)]
+final class AffectedRowsModeTest extends TestCase
+{
+    public function testDefinesNativeUpdateCountingConventions(): void
+    {
+        self::assertSame('changed', AffectedRowsMode::Changed->value);
+        self::assertSame('matched', AffectedRowsMode::Matched->value);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Rewrite/ReturningProjectionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/ReturningProjectionTest.php
@@ -5,50 +5,59 @@ declare(strict_types=1);
 namespace Tests\Unit\Rewrite;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
-use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Rewrite\ReturningProjection;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(ReturningProjection::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
-#[UsesClass(UnsupportedSqlException::class)]
 final class ReturningProjectionTest extends TestCase
 {
-    public function testProjectsQualifiedQuotedColumnsAndAliases(): void
+    public function testProjectsNamedWildcardAndAliasedItemsForEveryRow(): void
     {
-        $projection = ReturningProjection::parse(
-            'UPDATE users SET name = \'x\' RETURNING users.id, "name" AS display_name',
-        );
-        self::assertNotNull($projection);
+        $projection = ReturningProjection::fromItems([
+            ['source' => 'id', 'output' => 'original_id'],
+            ['source' => null, 'output' => null],
+            ['source' => 'name', 'output' => 'display_name'],
+            ['source' => 'missing', 'output' => null],
+        ]);
 
         self::assertSame([
-            ['id' => 1, 'display_name' => 'Alice'],
-        ], $projection->project([['id' => 1, 'name' => 'Alice', 'ignored' => true]]));
-    }
-
-    public function testWildcardPreservesTheWholeMutationRow(): void
-    {
-        $projection = ReturningProjection::parse('DELETE FROM users RETURNING users.*');
-        self::assertNotNull($projection);
-
-        self::assertSame([['id' => 1, 'name' => 'Alice']], $projection->project([
+            ['original_id' => 1, 'id' => 1, 'name' => 'Alice', 'display_name' => 'Alice', 'missing' => null],
+            ['original_id' => 2, 'id' => 2, 'name' => 'Bob', 'display_name' => 'Bob', 'missing' => null],
+        ], $projection->project([
             ['id' => 1, 'name' => 'Alice'],
+            ['id' => 2, 'name' => 'Bob'],
         ]));
     }
 
-    public function testReturnsNullWhenStatementHasNoReturningClause(): void
+    public function testRejectsEmptyProjection(): void
     {
-        self::assertNull(ReturningProjection::parse('INSERT INTO users VALUES (1)'));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Returning projection requires at least one item.');
+
+        ReturningProjection::fromItems([]);
     }
 
-    public function testRejectsExpressionsInsteadOfReturningWrongValues(): void
+    public function testRejectsWildcardOutputName(): void
     {
-        $this->expectException(UnsupportedSqlException::class);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Wildcard returning projections cannot have an output name.');
 
-        ReturningProjection::parse('INSERT INTO users VALUES (1) RETURNING id + 1');
+        ReturningProjection::fromItems([['source' => null, 'output' => 'all']]);
+    }
+
+    public function testRejectsEmptySourceName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Returning projection names must not be empty.');
+
+        ReturningProjection::fromItems([['source' => '', 'output' => null]]);
+    }
+
+    public function testRejectsEmptyOutputName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Returning projection names must not be empty.');
+
+        ReturningProjection::fromItems([['source' => 'id', 'output' => '']]);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Rewrite/ReturningProjectionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/ReturningProjectionTest.php
@@ -21,6 +21,13 @@ final class ReturningProjectionTest extends TestCase
         ]);
 
         self::assertSame([
+            ['source' => 'id', 'output' => 'original_id'],
+            ['source' => null, 'output' => null],
+            ['source' => 'name', 'output' => 'display_name'],
+            ['source' => 'missing', 'output' => null],
+        ], $projection->items());
+
+        self::assertSame([
             ['original_id' => 1, 'id' => 1, 'name' => 'Alice', 'display_name' => 'Alice', 'missing' => null],
             ['original_id' => 2, 'id' => 2, 'name' => 'Bob', 'display_name' => 'Bob', 'missing' => null],
         ], $projection->project([

--- a/packages/ztd-query-core/tests/Unit/Rewrite/ReturningProjectionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/ReturningProjectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rewrite;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Rewrite\ReturningProjection;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(ReturningProjection::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+#[UsesClass(UnsupportedSqlException::class)]
+final class ReturningProjectionTest extends TestCase
+{
+    public function testProjectsQualifiedQuotedColumnsAndAliases(): void
+    {
+        $projection = ReturningProjection::parse(
+            'UPDATE users SET name = \'x\' RETURNING users.id, "name" AS display_name',
+        );
+        self::assertNotNull($projection);
+
+        self::assertSame([
+            ['id' => 1, 'display_name' => 'Alice'],
+        ], $projection->project([['id' => 1, 'name' => 'Alice', 'ignored' => true]]));
+    }
+
+    public function testWildcardPreservesTheWholeMutationRow(): void
+    {
+        $projection = ReturningProjection::parse('DELETE FROM users RETURNING users.*');
+        self::assertNotNull($projection);
+
+        self::assertSame([['id' => 1, 'name' => 'Alice']], $projection->project([
+            ['id' => 1, 'name' => 'Alice'],
+        ]));
+    }
+
+    public function testReturnsNullWhenStatementHasNoReturningClause(): void
+    {
+        self::assertNull(ReturningProjection::parse('INSERT INTO users VALUES (1)'));
+    }
+
+    public function testRejectsExpressionsInsteadOfReturningWrongValues(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        ReturningProjection::parse('INSERT INTO users VALUES (1) RETURNING id + 1');
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Rewrite/RewritePlanTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/RewritePlanTest.php
@@ -10,8 +10,6 @@ use ZtdQuery\Rewrite\ReturningProjection;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -19,8 +17,6 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(CandidateKeySet::class)]
 #[UsesClass(ReturningProjection::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
 #[CoversClass(RewritePlan::class)]
 final class RewritePlanTest extends TestCase
 {
@@ -43,7 +39,7 @@ final class RewritePlanTest extends TestCase
 
     public function testPlanCarriesReturningAndAffectedRowsMetadata(): void
     {
-        $projection = ReturningProjection::parse('INSERT INTO users VALUES (1) RETURNING id');
+        $projection = ReturningProjection::fromItems([['source' => 'id', 'output' => null]]);
         $plan = new RewritePlan(
             'SELECT 1 AS id',
             QueryKind::WRITE_SIMULATED,

--- a/packages/ztd-query-core/tests/Unit/Rewrite/RewritePlanTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/RewritePlanTest.php
@@ -5,15 +5,22 @@ declare(strict_types=1);
 namespace Tests\Unit\Rewrite;
 
 use ZtdQuery\Rewrite\QueryKind;
+use ZtdQuery\Rewrite\AffectedRowsMode;
+use ZtdQuery\Rewrite\ReturningProjection;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(CandidateKeySet::class)]
+#[UsesClass(ReturningProjection::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
 #[CoversClass(RewritePlan::class)]
 final class RewritePlanTest extends TestCase
 {
@@ -32,5 +39,20 @@ final class RewritePlanTest extends TestCase
         $plan = new RewritePlan('SELECT 1', QueryKind::READ);
 
         self::assertNull($plan->mutation());
+    }
+
+    public function testPlanCarriesReturningAndAffectedRowsMetadata(): void
+    {
+        $projection = ReturningProjection::parse('INSERT INTO users VALUES (1) RETURNING id');
+        $plan = new RewritePlan(
+            'SELECT 1 AS id',
+            QueryKind::WRITE_SIMULATED,
+            new InsertMutation('users'),
+            $projection,
+            AffectedRowsMode::Matched,
+        );
+
+        self::assertSame($projection, $plan->returningProjection());
+        self::assertSame(AffectedRowsMode::Matched, $plan->affectedRowsMode());
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Rewrite/RewriteStateCommitterTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/RewriteStateCommitterTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Rewrite;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Rewrite\RewriteStateCommitter;
 
-#[CoversClass(RewriteStateCommitter::class)]
+#[CoversNothing]
 final class RewriteStateCommitterTest extends TestCase
 {
     public function testDefinesSuccessfulExecutionCommitBoundary(): void

--- a/packages/ztd-query-core/tests/Unit/Rewrite/RewriteStateCommitterTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/RewriteStateCommitterTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rewrite;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Rewrite\RewriteStateCommitter;
+
+#[CoversClass(RewriteStateCommitter::class)]
+final class RewriteStateCommitterTest extends TestCase
+{
+    public function testDefinesSuccessfulExecutionCommitBoundary(): void
+    {
+        $committer = new class () implements RewriteStateCommitter {
+            public bool $committed = false;
+
+            public function commitRewriteState(): void
+            {
+                $this->committed = true;
+            }
+        };
+
+        $committer->commitRewriteState();
+
+        self::assertTrue($committer->committed);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Rewrite/ShadowIdentityAllocatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/ShadowIdentityAllocatorTest.php
@@ -187,11 +187,11 @@ final class ShadowIdentityAllocatorTest extends TestCase
         $strategies = ['id' => IdentityGenerationStrategy::Sequence];
 
         $allocator->beginProjection();
-        self::assertSame(['id' => '1'], $allocator->allocateMissing('users', $strategies, ['name'], ["'preview'"], []));
+        self::assertSame(['id' => 1], $allocator->allocateMissing('users', $strategies, ['name'], []));
         $allocator->beginProjection();
-        self::assertSame(['id' => '1'], $allocator->allocateMissing('users', $strategies, ['name'], ["'execute'"], []));
+        self::assertSame(['id' => 1], $allocator->allocateMissing('users', $strategies, ['name'], []));
         $allocator->commitProjection();
         $allocator->beginProjection();
-        self::assertSame(['id' => '2'], $allocator->allocateMissing('users', $strategies, ['name'], ["'next'"], [['id' => 1]]));
+        self::assertSame(['id' => 2], $allocator->allocateMissing('users', $strategies, ['name'], [['id' => 1]]));
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Rewrite/ShadowIdentityAllocatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/ShadowIdentityAllocatorTest.php
@@ -180,4 +180,18 @@ final class ShadowIdentityAllocatorTest extends TestCase
             ),
         );
     }
+
+    public function testUncommittedPreparationDoesNotConsumeIdentity(): void
+    {
+        $allocator = new ShadowIdentityAllocator();
+        $strategies = ['id' => IdentityGenerationStrategy::Sequence];
+
+        $allocator->beginProjection();
+        self::assertSame(['id' => '1'], $allocator->allocateMissing('users', $strategies, ['name'], ["'preview'"], []));
+        $allocator->beginProjection();
+        self::assertSame(['id' => '1'], $allocator->allocateMissing('users', $strategies, ['name'], ["'execute'"], []));
+        $allocator->commitProjection();
+        $allocator->beginProjection();
+        self::assertSame(['id' => '2'], $allocator->allocateMissing('users', $strategies, ['name'], ["'next'"], [['id' => 1]]));
+    }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Rewrite\AffectedRowsMode;
+use ZtdQuery\Shadow\Mutation\DeleteMutation;
+use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\MutationImpact;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
+use ZtdQuery\Shadow\Mutation\UpdateMutation;
+
+#[CoversClass(MutationImpact::class)]
+#[UsesClass(DeleteMutation::class)]
+#[UsesClass(InsertMutation::class)]
+#[UsesClass(MutationRowIdentity::class)]
+#[UsesClass(UpdateMutation::class)]
+final class MutationImpactTest extends TestCase
+{
+    public function testInsertImpactContainsOnlyRowsActuallyAdded(): void
+    {
+        $before = [['id' => 1]];
+        $after = [['id' => 1], ['id' => 2]];
+        $impact = new MutationImpact(new InsertMutation('items'), $before, [['id' => 2]], $after);
+
+        self::assertSame(1, $impact->affectedRowCount(AffectedRowsMode::Changed));
+        self::assertSame([['id' => 2]], $impact->returningRows());
+        self::assertTrue($impact->isInsertLike());
+    }
+
+    public function testNoOpUpdateUsesPlatformRowCountMode(): void
+    {
+        $row = ['id' => 1, 'name' => 'same'];
+        $reordered = ['name' => 'same', 'id' => 1];
+        $impact = new MutationImpact(new UpdateMutation('items', ['id']), [$row], [$reordered], [$reordered]);
+
+        self::assertSame(0, $impact->affectedRowCount(AffectedRowsMode::Changed));
+        self::assertSame(1, $impact->affectedRowCount(AffectedRowsMode::Matched));
+        self::assertFalse($impact->isInsertLike());
+    }
+
+    public function testReturningUpdateRowsExcludeInternalIdentityMetadata(): void
+    {
+        $impact = new MutationImpact(
+            new UpdateMutation('items', ['id']),
+            [['id' => 1, 'name' => 'before']],
+            [['id' => 2, 'name' => 'after', '__ztd_original_id' => 1]],
+            [['id' => 2, 'name' => 'after']],
+        );
+
+        self::assertSame([['id' => 2, 'name' => 'after']], $impact->returningRows());
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
@@ -8,16 +8,22 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Rewrite\AffectedRowsMode;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MutationImpact;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
+use ZtdQuery\Shadow\Mutation\ReplaceMutation;
+use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 
 #[CoversClass(MutationImpact::class)]
+#[UsesClass(CandidateKeySet::class)]
 #[UsesClass(DeleteMutation::class)]
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(MutationRowIdentity::class)]
+#[UsesClass(ReplaceMutation::class)]
+#[UsesClass(UpsertMutation::class)]
 #[UsesClass(UpdateMutation::class)]
 final class MutationImpactTest extends TestCase
 {
@@ -53,5 +59,75 @@ final class MutationImpactTest extends TestCase
         );
 
         self::assertSame([['id' => 2, 'name' => 'after']], $impact->returningRows());
+    }
+
+    public function testReturningDeleteRowsComeFromMutationInput(): void
+    {
+        $deleted = ['id' => 2, 'name' => 'deleted', '__ztd_original_id' => 2];
+        $impact = new MutationImpact(
+            new DeleteMutation('items', ['id']),
+            [['id' => 1], ['id' => 2, 'name' => 'deleted']],
+            [$deleted],
+            [['id' => 1]],
+        );
+
+        self::assertSame([['id' => 2, 'name' => 'deleted']], $impact->returningRows());
+        self::assertFalse($impact->isInsertLike());
+    }
+
+    public function testIgnoredInsertHasNoReturningRows(): void
+    {
+        $row = ['id' => 1];
+        $impact = new MutationImpact(new InsertMutation('items'), [$row], [$row], [$row]);
+
+        self::assertSame([], $impact->returningRows());
+    }
+
+    public function testUpsertFallsBackToInputAndIsInsertLike(): void
+    {
+        $row = ['id' => 1, 'name' => 'updated'];
+        $impact = new MutationImpact(new UpsertMutation('items', ['id']), [$row], [$row], [$row]);
+
+        self::assertSame([$row], $impact->returningRows());
+        self::assertTrue($impact->isInsertLike());
+    }
+
+    public function testReplaceIsInsertLike(): void
+    {
+        $before = [['id' => 1, 'name' => 'before']];
+        $after = [['id' => 1]];
+        $impact = new MutationImpact(new ReplaceMutation('items', ['id']), $before, $after, $after);
+
+        self::assertTrue($impact->isInsertLike());
+        self::assertSame($after, $impact->returningRows());
+    }
+
+    public function testImpactPreservesEveryChangedRowAndDuplicateMultiplicity(): void
+    {
+        $first = ['id' => 1];
+        $second = ['id' => 2];
+        $impact = new MutationImpact(new InsertMutation('items'), [], [$first, $second], [$first, $second]);
+        self::assertSame(2, $impact->affectedRowCount(AffectedRowsMode::Changed));
+        self::assertSame([$first, $second], $impact->returningRows());
+
+        $duplicateImpact = new MutationImpact(
+            new DeleteMutation('items', ['id']),
+            [$first, $first],
+            [$first],
+            [$first],
+        );
+        self::assertSame(1, $duplicateImpact->affectedRowCount(AffectedRowsMode::Changed));
+    }
+
+    public function testRowsWithDifferentColumnsOrValuesAreChanged(): void
+    {
+        $impact = new MutationImpact(
+            new UpdateMutation('items', ['id']),
+            [['id' => 1, 'name' => 'before'], ['id' => 2], ['id' => 3]],
+            [],
+            [['id' => 1, 'other' => 'before'], ['id' => 2, 'name' => null], ['id' => 4]],
+        );
+
+        self::assertSame(3, $impact->affectedRowCount(AffectedRowsMode::Changed));
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationRowIdentityTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationRowIdentityTest.php
@@ -40,4 +40,17 @@ final class MutationRowIdentityTest extends TestCase
             (new MutationRowIdentity())->extract(['id' => 1], ['id']),
         );
     }
+
+    public function testStripRemovesEveryInternalIdentityColumn(): void
+    {
+        self::assertSame(
+            ['id' => 2, 'name' => 'updated'],
+            (new MutationRowIdentity())->strip([
+                'id' => 2,
+                'name' => 'updated',
+                '__ztd_original_id' => 1,
+                '__ztd_original_tenant_id' => 10,
+            ]),
+        );
+    }
 }

--- a/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
@@ -16,6 +16,7 @@ use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\MutationImpact;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTransactionManager;
 use ZtdQuery\Simulator\StatementSimulator;
@@ -30,6 +31,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(RewritePlan::class)]
 #[UsesClass(ResultSelectRunner::class)]
 #[UsesClass(InsertMutation::class)]
+#[UsesClass(MutationImpact::class)]
 #[UsesClass(CandidateKeySet::class)]
 #[UsesClass(ShadowStore::class)]
 #[UsesClass(ShadowTransactionManager::class)]

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -10,6 +10,7 @@ use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
+use ZtdQuery\Rewrite\RewriteStateCommitter;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Sql\TransactionStatement;
 use PhpMyAdmin\SqlParser\Statement;
@@ -28,7 +29,7 @@ use PhpMyAdmin\SqlParser\Statements\WithStatement;
  *
  * Orchestrates parsing, classification, transformation, and mutation resolution.
  */
-final class MySqlRewriter implements SqlRewriter
+final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
 {
     public function transactionStatement(string $sql): ?TransactionStatement
     {
@@ -108,6 +109,11 @@ final class MySqlRewriter implements SqlRewriter
         }
 
         return new MultiRewritePlan($plans);
+    }
+
+    public function commitRewriteState(): void
+    {
+        $this->transformer->commitRewriteState();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/MySqlSessionFactory.php
+++ b/packages/ztd-query-mysql/src/MySqlSessionFactory.php
@@ -59,6 +59,7 @@ final class MySqlSessionFactory implements SessionFactory
             $config,
             $connection,
             new ShadowTransactionManager($shadowStore, $registry),
+            $registry,
         );
     }
 }

--- a/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
@@ -51,6 +51,7 @@ final class InsertTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
+        $this->identityAllocator->beginProjection();
         $statements = $this->parser->parse($sql);
         if (!isset($statements[0]) || !$statements[0] instanceof InsertStatement) {
             throw new UnsupportedSqlException($sql, 'Expected INSERT statement');
@@ -93,6 +94,11 @@ final class InsertTransformer implements SqlTransformer
             $this->cteComposer->carryPrefix($sql, $selectSql),
             $tables,
         );
+    }
+
+    public function commitRewriteState(): void
+    {
+        $this->identityAllocator->commitProjection();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/MySqlTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/MySqlTransformer.php
@@ -99,4 +99,9 @@ final class MySqlTransformer implements SqlTransformer
 
         throw new UnsupportedSqlException($sql, 'Statement type not supported by transformer');
     }
+
+    public function commitRewriteState(): void
+    {
+        $this->insertTransformer->commitRewriteState();
+    }
 }

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
@@ -858,6 +858,23 @@ final class InsertTransformerTest extends TestCase
         self::assertStringContainsString('3 AS `id`', $second);
     }
 
+    public function testUncommittedTransformDoesNotConsumeAutoIncrementValue(): void
+    {
+        $transformer = new InsertTransformer(new MySqlParser(), new SelectTransformer());
+        $tables = ['users' => [
+            'rows' => [],
+            'columns' => ['id', 'name'],
+            'columnTypes' => [],
+            'identityStrategies' => ['id' => IdentityGenerationStrategy::MaxValue],
+        ]];
+
+        $preview = $transformer->transform("INSERT INTO users (name) VALUES ('preview')", $tables);
+        $executed = $transformer->transform("INSERT INTO users (name) VALUES ('executed')", $tables);
+
+        self::assertStringContainsString('1 AS `id`', $preview);
+        self::assertStringContainsString('1 AS `id`', $executed);
+    }
+
     public function testTransformAllocatesAfterExistingAutoIncrementRows(): void
     {
         $transformer = new InsertTransformer(new MySqlParser(), new SelectTransformer());

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
@@ -850,6 +850,7 @@ final class InsertTransformerTest extends TestCase
         ]];
 
         $first = $transformer->transform("INSERT INTO users (name) VALUES ('Alice'), ('Bob')", $tables);
+        $transformer->commitRewriteState();
         $second = $transformer->transform("INSERT INTO users (name) VALUES ('Carol')", $tables);
 
         self::assertStringContainsString('1 AS `id`', $first);

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -20,6 +20,24 @@ use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
 #[Large]
 final class MysqliCteShadowingTest extends TestCase
 {
+    public function testAffectedRowsCountsOnlyChangedMySqlRows(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, score INT)', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $ztdMysqli->query(sprintf('INSERT INTO `%s` VALUES (1, 10)', $table));
+            $ztdMysqli->query(sprintf('UPDATE `%s` SET score = 10 WHERE id = 1', $table));
+            self::assertSame(0, $ztdMysqli->lastAffectedRows());
+            $ztdMysqli->query(sprintf('UPDATE `%s` SET score = 11 WHERE id = 1', $table));
+            self::assertSame(1, $ztdMysqli->lastAffectedRows());
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testTransactionsAndSavepointsRestoreShadowRows(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
@@ -173,11 +173,14 @@ class ZtdPdo extends PDO
             throw new ZtdPdoException($e->getMessage(), 0, $e);
         }
 
+        $defaultFetchMode = $this->pdo->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE);
+
         return new ZtdPdoStatement(
             $prepared['statement'],
             $this->session,
             $prepared['plan'],
             $execution,
+            is_int($defaultFetchMode) ? $defaultFetchMode : PDO::FETCH_BOTH,
         );
     }
 
@@ -310,6 +313,13 @@ class ZtdPdo extends PDO
      */
     public function lastInsertId(?string $name = null): string|false
     {
+        if ($this->session->isEnabled() && $name === null) {
+            $lastInsertId = $this->session->lastInsertId();
+            if ($lastInsertId !== false) {
+                return $lastInsertId;
+            }
+        }
+
         return $this->pdo->lastInsertId($name);
     }
 

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdoStatement.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdoStatement.php
@@ -49,6 +49,8 @@ final class ZtdPdoStatement extends NativePdoStatement
 
     private ?PdoPreparedExecution $preparedExecution;
 
+    private int $defaultFetchMode;
+
     /** @var array<int|string, array{value: mixed, type: int}> */
     private array $boundValues = [];
 
@@ -63,11 +65,13 @@ final class ZtdPdoStatement extends NativePdoStatement
         Session $session,
         ?RewritePlan $plan,
         ?PdoPreparedExecution $preparedExecution = null,
+        int $defaultFetchMode = PDO::FETCH_BOTH,
     ) {
         $this->statement = $statement;
         $this->session = $session;
         $this->plan = $plan;
         $this->preparedExecution = $preparedExecution;
+        $this->defaultFetchMode = $defaultFetchMode;
     }
 
     /**
@@ -203,6 +207,13 @@ final class ZtdPdoStatement extends NativePdoStatement
             if (!$this->result->hasResultSet()) {
                 return false;
             }
+
+            $row = $this->result->fetch();
+            if ($row === false) {
+                return false;
+            }
+
+            return $this->formatBufferedRow($row, $mode);
         }
 
         /** @see NativePdoStatement */
@@ -220,6 +231,18 @@ final class ZtdPdoStatement extends NativePdoStatement
             if (!$this->result->hasResultSet()) {
                 return [];
             }
+
+            $rows = $this->result->fetchAll();
+            if ($this->resolveFetchMode($mode) === PDO::FETCH_COLUMN) {
+                $column = is_int($args[0] ?? null) ? $args[0] : 0;
+
+                return array_map(
+                    static fn (array $row): mixed => array_values($row)[$column] ?? false,
+                    $rows,
+                );
+            }
+
+            return array_map(fn (array $row): mixed => $this->formatBufferedRow($row, $mode), $rows);
         }
 
         /** @see NativePdoStatement */
@@ -244,6 +267,10 @@ final class ZtdPdoStatement extends NativePdoStatement
             if (!$this->result->hasResultSet()) {
                 return false;
             }
+
+            $row = $this->result->fetch();
+
+            return $row === false ? false : (array_values($row)[$column] ?? false);
         }
 
         /** @see NativePdoStatement */
@@ -267,6 +294,27 @@ final class ZtdPdoStatement extends NativePdoStatement
             if (!$this->result->hasResultSet()) {
                 return false;
             }
+
+            $row = $this->result->fetch();
+            if ($row === false) {
+                return false;
+            }
+            $object = new $resolvedClass(...$constructorArgs);
+            if ($object instanceof \stdClass) {
+                foreach ($row as $property => $value) {
+                    $object->{$property} = $value;
+                }
+
+                return $object;
+            }
+            $reflection = new \ReflectionObject($object);
+            foreach ($row as $property => $value) {
+                if ($reflection->hasProperty($property)) {
+                    $reflection->getProperty($property)->setValue($object, $value);
+                }
+            }
+
+            return $object;
         }
 
         /** @see NativePdoStatement */
@@ -379,9 +427,56 @@ final class ZtdPdoStatement extends NativePdoStatement
      */
     public function getIterator(): Iterator
     {
+        if ($this->result !== null && !$this->result->isPassthrough() && $this->result->hasResultSet()) {
+            /** @var Iterator<mixed, array<int|string, mixed>> $iterator */
+            $iterator = new \ArrayIterator($this->fetchAll());
+
+            return $iterator;
+        }
+
         /** @var Iterator<mixed, array<int|string, mixed>> $iterator */
         $iterator = $this->statement->getIterator();
 
         return $iterator;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function formatBufferedRow(array $row, int $mode): mixed
+    {
+        return match ($this->resolveFetchMode($mode)) {
+            PDO::FETCH_ASSOC, PDO::FETCH_NAMED => $row,
+            PDO::FETCH_NUM => array_values($row),
+            PDO::FETCH_OBJ => (object) $row,
+            PDO::FETCH_COLUMN => array_values($row)[0] ?? false,
+            default => $this->both($row),
+        };
+    }
+
+    private function resolveFetchMode(int $mode): int
+    {
+        if ($mode !== PDO::FETCH_DEFAULT) {
+            return $mode;
+        }
+
+        return $this->fetchMode['mode'] ?? $this->defaultFetchMode;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<int|string, mixed>
+     */
+    private function both(array $row): array
+    {
+        $both = [];
+        $index = 0;
+        foreach ($row as $column => $value) {
+            $both[$column] = $value;
+            $both[$index] = $value;
+            $index++;
+        }
+
+        return $both;
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/ReturningTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/ReturningTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class ReturningTest extends TestCase
+{
+    public function testReturningAndLastInsertIdMatchPostgresDml(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$table} (id SERIAL PRIMARY KEY, name TEXT, score INTEGER)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+            $insert = "INSERT INTO {$table} (name, score) VALUES ('Alice', 90) RETURNING id, name";
+            $rawInsert = $rawPdo->query($insert);
+            $ztdInsert = $ztdPdo->query($insert);
+            self::assertNotFalse($rawInsert);
+            self::assertNotFalse($ztdInsert);
+            self::assertSame($rawInsert->fetchAll(), $ztdInsert->fetchAll());
+            self::assertSame('1', $ztdPdo->lastInsertId());
+
+            $update = "UPDATE {$table} SET score = 95 WHERE id = 1 RETURNING id, name, score";
+            $rawUpdate = $rawPdo->query($update);
+            $ztdUpdate = $ztdPdo->query($update);
+            self::assertNotFalse($rawUpdate);
+            self::assertNotFalse($ztdUpdate);
+            self::assertSame($rawUpdate->fetchAll(), $ztdUpdate->fetchAll());
+
+            $delete = "DELETE FROM {$table} WHERE id = 1 RETURNING *";
+            $rawDelete = $rawPdo->query($delete);
+            $ztdDelete = $ztdPdo->query($delete);
+            self::assertNotFalse($rawDelete);
+            self::assertNotFalse($ztdDelete);
+            self::assertSame($rawDelete->fetchAll(), $ztdDelete->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/ExecutionResultTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/ExecutionResultTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_sqlite
+ */
+#[CoversNothing]
+#[Large]
+final class ExecutionResultTest extends TestCase
+{
+    public function testReturningProjectsInsertUpdateAndDeleteRows(): void
+    {
+        $reference = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $underlying = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $schema = 'CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, score INTEGER)';
+        $reference->exec($schema);
+        $underlying->exec($schema);
+        $pdo = ZtdPdo::fromPdo($underlying);
+
+        $insert = "INSERT INTO items (name, score) VALUES ('Alice', 90), ('Bob', 80) RETURNING id, name";
+        $referenceInsert = $reference->query($insert);
+        $ztdInsert = $pdo->query($insert);
+        self::assertNotFalse($referenceInsert);
+        self::assertNotFalse($ztdInsert);
+        self::assertSame($referenceInsert->fetchAll(), $ztdInsert->fetchAll());
+
+        $update = 'UPDATE items SET score = score + 5 WHERE id = 1 RETURNING id, name, score';
+        $referenceUpdate = $reference->query($update);
+        $ztdUpdate = $pdo->query($update);
+        self::assertNotFalse($referenceUpdate);
+        self::assertNotFalse($ztdUpdate);
+        self::assertSame($referenceUpdate->fetchAll(), $ztdUpdate->fetchAll());
+
+        $delete = 'DELETE FROM items WHERE id = 2 RETURNING *';
+        $referenceDelete = $reference->query($delete);
+        $ztdDelete = $pdo->query($delete);
+        self::assertNotFalse($referenceDelete);
+        self::assertNotFalse($ztdDelete);
+        self::assertSame($referenceDelete->fetchAll(), $ztdDelete->fetchAll());
+    }
+
+    public function testPreparedReturningAndLastInsertIdTrackShadowIdentity(): void
+    {
+        $underlying = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $underlying->exec('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)');
+        $pdo = ZtdPdo::fromPdo($underlying);
+        $statement = $pdo->prepare('INSERT INTO items (name) VALUES (?) RETURNING id, name');
+        self::assertNotFalse($statement);
+
+        $statement->execute(['first']);
+        self::assertSame([['id' => 1, 'name' => 'first']], $statement->fetchAll());
+        self::assertSame('1', $pdo->lastInsertId());
+        $statement->execute(['second']);
+        self::assertSame(['id' => 2, 'name' => 'second'], $statement->fetch());
+        self::assertSame('2', $pdo->lastInsertId());
+
+        $pdo->exec("INSERT INTO items (id, name) VALUES (42, 'explicit')");
+        self::assertSame('42', $pdo->lastInsertId());
+    }
+
+    public function testRowCountUsesNativeMatchedRowConvention(): void
+    {
+        $reference = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        $underlying = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        $schema = 'CREATE TABLE items (id INTEGER PRIMARY KEY, score INTEGER)';
+        $reference->exec($schema);
+        $underlying->exec($schema);
+        $pdo = ZtdPdo::fromPdo($underlying);
+        $reference->exec('INSERT INTO items VALUES (1, 10)');
+        $pdo->exec('INSERT INTO items VALUES (1, 10)');
+
+        self::assertSame(
+            $reference->exec('UPDATE items SET score = 10 WHERE id = 1'),
+            $pdo->exec('UPDATE items SET score = 10 WHERE id = 1'),
+        );
+        $referenceStatement = $reference->prepare('UPDATE items SET score = ? WHERE id = ?');
+        $ztdStatement = $pdo->prepare('UPDATE items SET score = ? WHERE id = ?');
+        self::assertNotFalse($referenceStatement);
+        self::assertNotFalse($ztdStatement);
+        $referenceStatement->execute([10, 1]);
+        $ztdStatement->execute([10, 1]);
+        self::assertSame($referenceStatement->rowCount(), $ztdStatement->rowCount());
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlReturningProjectionParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlReturningProjectionParser.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Rewrite\ReturningProjection;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PgSqlReturningProjectionParser
+{
+    public function parse(string $sql): ?ReturningProjection
+    {
+        $clause = SqlTokenStream::tokenize($sql)->topLevelClause(['RETURNING']);
+        if ($clause === null) {
+            return null;
+        }
+
+        $items = [];
+        foreach (SqlTokenStream::tokenize(rtrim($clause, "; \t\n\r\0\x0B"))->splitTopLevel() as $expression) {
+            $item = $this->parseItem($expression);
+            if ($item === null) {
+                throw new UnsupportedSqlException(
+                    $sql,
+                    'RETURNING supports columns, qualified columns, aliases, and wildcard projections',
+                );
+            }
+            $items[] = $item;
+        }
+
+        if ($items === []) {
+            throw new UnsupportedSqlException($sql, 'RETURNING requires a projection');
+        }
+
+        return ReturningProjection::fromItems($items);
+    }
+
+    /** @return array{source: string|null, output: string|null}|null */
+    private function parseItem(string $expression): ?array
+    {
+        $tokens = SqlTokenStream::tokenize($expression)->significantTokens();
+        $alias = null;
+        $asIndex = $this->asIndex($tokens);
+        if ($asIndex !== null) {
+            if ($asIndex + 2 !== count($tokens)) {
+                return null;
+            }
+            $aliasToken = $tokens[$asIndex + 1] ?? null;
+            if ($aliasToken === null) {
+                return null;
+            }
+            $alias = $this->identifierName($aliasToken);
+            if ($alias === null) {
+                return null;
+            }
+            $tokens = array_slice($tokens, 0, $asIndex);
+        }
+
+        if (!$this->isIdentifierPath($tokens)) {
+            return null;
+        }
+        $last = $tokens[count($tokens) - 1];
+        if ($last->text === '*') {
+            return $alias === null ? ['source' => null, 'output' => null] : null;
+        }
+
+        $source = $this->identifierName($last);
+        if ($source === null) {
+            return null;
+        }
+
+        return ['source' => $source, 'output' => $alias];
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function asIndex(array $tokens): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isKeyword('AS')) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function isIdentifierPath(array $tokens): bool
+    {
+        $lastIndex = count($tokens) - 1;
+        foreach ($tokens as $index => $token) {
+            if ($index % 2 === 0) {
+                if ($this->identifierName($token) !== null) {
+                    continue;
+                }
+
+                return $index === $lastIndex
+                    && $token->kind === SqlTokenKind::Symbol
+                    && $token->text === '*';
+            }
+            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '.') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function identifierName(SqlToken $token): ?string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+        if ($token->kind !== SqlTokenKind::QuotedIdentifier || strlen($token->text) <= 2) {
+            return null;
+        }
+
+        $identifier = $token->text;
+        if ($identifier[0] !== '"' || $identifier[strlen($identifier) - 1] !== '"') {
+            return null;
+        }
+
+        return str_replace('""', '"', substr($identifier, 1, -1));
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -9,7 +9,6 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\AffectedRowsMode;
-use ZtdQuery\Rewrite\ReturningProjection;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Rewrite\RewriteStateCommitter;
@@ -36,6 +35,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
     private PgSqlTransformer $transformer;
     private PgSqlMutationResolver $mutationResolver;
     private PgSqlParser $parser;
+    private PgSqlReturningProjectionParser $returningProjectionParser;
 
     public function __construct(
         PgSqlQueryGuard $guard,
@@ -51,6 +51,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
         $this->transformer = $transformer;
         $this->mutationResolver = $mutationResolver;
         $this->parser = $parser;
+        $this->returningProjectionParser = new PgSqlReturningProjectionParser();
     }
 
     /**
@@ -165,7 +166,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             $transformedSql,
             QueryKind::WRITE_SIMULATED,
             $mutation,
-            ReturningProjection::parse($sql),
+            $this->returningProjectionParser->parse($sql),
             AffectedRowsMode::Matched,
         );
     }

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -8,11 +8,14 @@ use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\QueryKind;
+use ZtdQuery\Rewrite\AffectedRowsMode;
+use ZtdQuery\Rewrite\ReturningProjection;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
-use ZtdQuery\Sql\TransactionStatement;
+use ZtdQuery\Rewrite\RewriteStateCommitter;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Sql\TransactionStatement;
 
 /**
  * PostgreSQL rewrite implementation for ZTD.
@@ -20,7 +23,7 @@ use ZtdQuery\Shadow\ShadowStore;
  * Orchestrates parsing, classification, transformation, and mutation resolution.
  * Uses Result Select Query approach (not RETURNING) for consistency across platforms.
  */
-final class PgSqlRewriter implements SqlRewriter
+final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
 {
     public function transactionStatement(string $sql): ?TransactionStatement
     {
@@ -101,6 +104,11 @@ final class PgSqlRewriter implements SqlRewriter
         return new MultiRewritePlan($plans);
     }
 
+    public function commitRewriteState(): void
+    {
+        $this->transformer->commitRewriteState();
+    }
+
     private function rewriteStatement(string $sql): RewritePlan
     {
         $kind = $this->guard->classify($sql);
@@ -153,7 +161,13 @@ final class PgSqlRewriter implements SqlRewriter
 
         $transformedSql = $this->transformer->transform($sql, $tableContext);
 
-        return new RewritePlan($transformedSql, QueryKind::WRITE_SIMULATED, $mutation);
+        return new RewritePlan(
+            $transformedSql,
+            QueryKind::WRITE_SIMULATED,
+            $mutation,
+            ReturningProjection::parse($sql),
+            AffectedRowsMode::Matched,
+        );
     }
 
     /**

--- a/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
+++ b/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
@@ -56,6 +56,7 @@ final class PgSqlSessionFactory implements SessionFactory
             $config,
             $connection,
             new ShadowTransactionManager($shadowStore, $registry),
+            $registry,
         );
     }
 }

--- a/packages/ztd-query-postgres/src/PgSqlTransformer.php
+++ b/packages/ztd-query-postgres/src/PgSqlTransformer.php
@@ -54,4 +54,9 @@ final class PgSqlTransformer implements SqlTransformer
             default => throw new UnsupportedSqlException($sql, 'Statement type not supported by transformer'),
         };
     }
+
+    public function commitRewriteState(): void
+    {
+        $this->insertTransformer->commitRewriteState();
+    }
 }

--- a/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
@@ -48,6 +48,7 @@ final class InsertTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
+        $this->identityAllocator->beginProjection();
         $tableName = $this->parser->extractInsertTable($sql);
         if ($tableName === null) {
             throw new UnsupportedSqlException($sql, 'Cannot resolve INSERT target');
@@ -128,6 +129,11 @@ final class InsertTransformer implements SqlTransformer
             $this->cteComposer->carryPrefix($sql, $selectSql),
             $tables,
         );
+    }
+
+    public function commitRewriteState(): void
+    {
+        $this->identityAllocator->commitProjection();
     }
 
     /**

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlReturningProjectionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlReturningProjectionParserTest.php
@@ -19,6 +19,11 @@ final class PgSqlReturningProjectionParserTest extends TestCase
             'UPDATE users SET name = \'x\' RETURNING users.id AS original_id, *, "name" AS display_name',
         );
         self::assertNotNull($projection);
+        self::assertSame([
+            ['source' => 'id', 'output' => 'original_id'],
+            ['source' => null, 'output' => null],
+            ['source' => 'name', 'output' => 'display_name'],
+        ], $projection->items());
 
         self::assertSame([
             ['original_id' => 1, 'id' => 1, 'name' => 'Alice', 'display_name' => 'Alice'],

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlReturningProjectionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlReturningProjectionParserTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlReturningProjectionParser;
+use ZtdQuery\Rewrite\ReturningProjection;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(PgSqlReturningProjectionParser::class)]
+#[UsesClass(ReturningProjection::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+#[UsesClass(UnsupportedSqlException::class)]
+final class PgSqlReturningProjectionParserTest extends TestCase
+{
+    public function testParsesPostgresQualifiedQuotedAliasesAndWildcard(): void
+    {
+        $projection = (new PgSqlReturningProjectionParser())->parse(
+            'UPDATE users SET name = \'x\' RETURNING users.id AS original_id, *, "name" AS display_name',
+        );
+        self::assertNotNull($projection);
+
+        self::assertSame([
+            ['original_id' => 1, 'id' => 1, 'name' => 'Alice', 'display_name' => 'Alice'],
+        ], $projection->project([['id' => 1, 'name' => 'Alice']]));
+    }
+
+    public function testUnquotesEscapedPostgresIdentifiersAndStatementTerminator(): void
+    {
+        $projection = (new PgSqlReturningProjectionParser())->parse(
+            'INSERT INTO users VALUES (1) RETURNING "source""name" AS "output""name";',
+        );
+        self::assertNotNull($projection);
+
+        self::assertSame([['output"name' => 'value']], $projection->project([['source"name' => 'value']]));
+    }
+
+    public function testReturnsNullWithoutPostgresReturningClause(): void
+    {
+        self::assertNull((new PgSqlReturningProjectionParser())->parse('INSERT INTO users VALUES (1)'));
+    }
+
+    #[DataProvider('providerInvalidPostgresReturningProjection')]
+    public function testRejectsMalformedPostgresProjection(string $projection): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        (new PgSqlReturningProjectionParser())->parse('INSERT INTO users VALUES (1) RETURNING ' . $projection);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function providerInvalidPostgresReturningProjection(): array
+    {
+        return [
+            'empty' => [''],
+            'expression' => ['id + 1'],
+            'missing alias' => ['id AS'],
+            'invalid alias token' => ['id AS +'],
+            'tokens after alias' => ['id AS alias extra'],
+            'wildcard alias' => ['* AS all_columns'],
+            'leading dot' => ['.id'],
+            'trailing dot' => ['users.'],
+            'double dot' => ['users..id'],
+            'non-dot separator' => ['users + id'],
+            'leading wildcard path' => ['*.id'],
+            'non-trailing wildcard' => ['users.*.id'],
+            'non-wildcard symbol path' => ['users.+'],
+            'empty quoted identifier' => ['""'],
+            'backtick identifier' => ['`id`'],
+            'number token' => ['12'],
+            'string token' => ["'id'"],
+            'unterminated double quote' => ['"id'],
+        ];
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlReturningProjectionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlReturningProjectionParserTest.php
@@ -6,19 +6,11 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlReturningProjectionParser;
-use ZtdQuery\Rewrite\ReturningProjection;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(PgSqlReturningProjectionParser::class)]
-#[UsesClass(ReturningProjection::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
-#[UsesClass(UnsupportedSqlException::class)]
 final class PgSqlReturningProjectionParserTest extends TestCase
 {
     public function testParsesPostgresQualifiedQuotedAliasesAndWildcard(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 use ZtdQuery\Platform\Postgres\PgSqlMutationResolver;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\PgSqlQueryGuard;
+use ZtdQuery\Platform\Postgres\PgSqlReturningProjectionParser;
 use ZtdQuery\Platform\Postgres\PgSqlRewriter;
 use ZtdQuery\Platform\Postgres\PgSqlSchemaParser;
 use ZtdQuery\Platform\Postgres\PgSqlTransformer;
@@ -43,6 +44,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(PgSqlQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTransactionStatementParser::class)]
+#[UsesClass(PgSqlReturningProjectionParser::class)]
 #[UsesClass(PgSqlMutationResolver::class)]
 #[UsesClass(PgSqlTransformer::class)]
 #[UsesClass(SelectTransformer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -368,6 +368,7 @@ final class InsertTransformerTest extends TestCase
         ]];
 
         $first = $transformer->transform("INSERT INTO users (name) VALUES ('Alice'), ('Bob')", $tables);
+        $transformer->commitRewriteState();
         $second = $transformer->transform("INSERT INTO users (name) VALUES ('Carol')", $tables);
 
         self::assertStringContainsString('1 AS "id"', $first);

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -376,6 +376,23 @@ final class InsertTransformerTest extends TestCase
         self::assertStringContainsString('3 AS "id"', $second);
     }
 
+    public function testUncommittedTransformDoesNotConsumeSerialValue(): void
+    {
+        $transformer = new InsertTransformer(new PgSqlParser(), new SelectTransformer());
+        $tables = ['users' => [
+            'rows' => [],
+            'columns' => ['id', 'name'],
+            'columnTypes' => [],
+            'identityStrategies' => ['id' => IdentityGenerationStrategy::Sequence],
+        ]];
+
+        $preview = $transformer->transform("INSERT INTO users (name) VALUES ('preview')", $tables);
+        $executed = $transformer->transform("INSERT INTO users (name) VALUES ('executed')", $tables);
+
+        self::assertStringContainsString('1 AS "id"', $preview);
+        self::assertStringContainsString('1 AS "id"', $executed);
+    }
+
     public function testInsertAllocatesSerialValueAfterExistingRows(): void
     {
         $transformer = new InsertTransformer(new PgSqlParser(), new SelectTransformer());

--- a/packages/ztd-query-sqlite/src/SqliteReturningProjectionParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteReturningProjectionParser.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Rewrite\ReturningProjection;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class SqliteReturningProjectionParser
+{
+    public function parse(string $sql): ?ReturningProjection
+    {
+        $clause = SqlTokenStream::tokenize($sql)->topLevelClause(['RETURNING']);
+        if ($clause === null) {
+            return null;
+        }
+
+        $items = [];
+        foreach (SqlTokenStream::tokenize(rtrim($clause, "; \t\n\r\0\x0B"))->splitTopLevel() as $expression) {
+            $item = $this->parseItem($expression);
+            if ($item === null) {
+                throw new UnsupportedSqlException(
+                    $sql,
+                    'RETURNING supports columns, qualified columns, aliases, and wildcard projections',
+                );
+            }
+            $items[] = $item;
+        }
+
+        if ($items === []) {
+            throw new UnsupportedSqlException($sql, 'RETURNING requires a projection');
+        }
+
+        return ReturningProjection::fromItems($items);
+    }
+
+    /** @return array{source: string|null, output: string|null}|null */
+    private function parseItem(string $expression): ?array
+    {
+        $tokens = SqlTokenStream::tokenize($expression)->significantTokens();
+        $alias = null;
+        $asIndex = $this->asIndex($tokens);
+        if ($asIndex !== null) {
+            if ($asIndex + 2 !== count($tokens)) {
+                return null;
+            }
+            $aliasToken = $tokens[$asIndex + 1] ?? null;
+            if ($aliasToken === null) {
+                return null;
+            }
+            $alias = $this->identifierName($aliasToken);
+            if ($alias === null) {
+                return null;
+            }
+            $tokens = array_slice($tokens, 0, $asIndex);
+        }
+
+        if (!$this->isIdentifierPath($tokens)) {
+            return null;
+        }
+        $last = $tokens[count($tokens) - 1];
+        if ($last->text === '*') {
+            return $alias === null ? ['source' => null, 'output' => null] : null;
+        }
+
+        $source = $this->identifierName($last);
+        if ($source === null) {
+            return null;
+        }
+
+        return ['source' => $source, 'output' => $alias];
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function asIndex(array $tokens): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isKeyword('AS')) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function isIdentifierPath(array $tokens): bool
+    {
+        $lastIndex = count($tokens) - 1;
+        foreach ($tokens as $index => $token) {
+            if ($index % 2 === 0) {
+                if ($this->identifierName($token) !== null) {
+                    continue;
+                }
+
+                return $index === $lastIndex
+                    && $token->kind === SqlTokenKind::Symbol
+                    && $token->text === '*';
+            }
+            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '.') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function identifierName(SqlToken $token): ?string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+        if ($token->kind !== SqlTokenKind::QuotedIdentifier || strlen($token->text) <= 2) {
+            return null;
+        }
+
+        $identifier = $token->text;
+        $first = $identifier[0];
+        if (!in_array($first, ['"', '`'], true) || $identifier[strlen($identifier) - 1] !== $first) {
+            return null;
+        }
+
+        return str_replace($first . $first, $first, substr($identifier, 1, -1));
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -9,7 +9,10 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\Transformer\SqliteTransformer;
 use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\QueryKind;
+use ZtdQuery\Rewrite\AffectedRowsMode;
+use ZtdQuery\Rewrite\ReturningProjection;
 use ZtdQuery\Rewrite\RewritePlan;
+use ZtdQuery\Rewrite\RewriteStateCommitter;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Sql\TransactionStatement;
 use ZtdQuery\Schema\TableDefinition;
@@ -22,7 +25,7 @@ use ZtdQuery\Shadow\ShadowStore;
  * Orchestrates parsing, classification, transformation, and mutation resolution.
  * Uses Result Select Query approach (not RETURNING) for consistency.
  */
-final class SqliteRewriter implements SqlRewriter
+final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
 {
     public function transactionStatement(string $sql): ?TransactionStatement
     {
@@ -94,6 +97,11 @@ final class SqliteRewriter implements SqlRewriter
         return new MultiRewritePlan($plans);
     }
 
+    public function commitRewriteState(): void
+    {
+        $this->transformer->commitRewriteState();
+    }
+
     private function rewriteStatement(string $stmtSql, string $originalSql): RewritePlan
     {
         $kind = $this->guard->classify($stmtSql);
@@ -126,7 +134,13 @@ final class SqliteRewriter implements SqlRewriter
 
         $transformedSql = $this->transformer->transform($stmtSql, $tableContext);
 
-        return new RewritePlan($transformedSql, QueryKind::WRITE_SIMULATED, $mutation);
+        return new RewritePlan(
+            $transformedSql,
+            QueryKind::WRITE_SIMULATED,
+            $mutation,
+            ReturningProjection::parse($stmtSql),
+            AffectedRowsMode::Matched,
+        );
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -10,7 +10,6 @@ use ZtdQuery\Platform\Sqlite\Transformer\SqliteTransformer;
 use ZtdQuery\Rewrite\MultiRewritePlan;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\AffectedRowsMode;
-use ZtdQuery\Rewrite\ReturningProjection;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\RewriteStateCommitter;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -38,6 +37,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
     private SqliteTransformer $transformer;
     private SqliteMutationResolver $mutationResolver;
     private SqliteParser $parser;
+    private SqliteReturningProjectionParser $returningProjectionParser;
 
     public function __construct(
         SqliteQueryGuard $guard,
@@ -53,6 +53,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
         $this->transformer = $transformer;
         $this->mutationResolver = $mutationResolver;
         $this->parser = $parser;
+        $this->returningProjectionParser = new SqliteReturningProjectionParser();
     }
 
     /**
@@ -138,7 +139,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
             $transformedSql,
             QueryKind::WRITE_SIMULATED,
             $mutation,
-            ReturningProjection::parse($stmtSql),
+            $this->returningProjectionParser->parse($stmtSql),
             AffectedRowsMode::Matched,
         );
     }

--- a/packages/ztd-query-sqlite/src/SqliteSessionFactory.php
+++ b/packages/ztd-query-sqlite/src/SqliteSessionFactory.php
@@ -57,6 +57,7 @@ final class SqliteSessionFactory implements SessionFactory
             $config,
             $connection,
             new ShadowTransactionManager($shadowStore, $registry),
+            $registry,
         );
     }
 }

--- a/packages/ztd-query-sqlite/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/InsertTransformer.php
@@ -54,6 +54,7 @@ final class InsertTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
+        $this->identityAllocator->beginProjection();
         $type = $this->parser->classifyStatement($sql);
         if ($type !== 'INSERT') {
             throw new UnsupportedSqlException($sql, 'Expected INSERT/REPLACE statement');
@@ -89,6 +90,11 @@ final class InsertTransformer implements SqlTransformer
             $this->cteComposer->carryPrefix($sql, $selectSql),
             $tables,
         );
+    }
+
+    public function commitRewriteState(): void
+    {
+        $this->identityAllocator->commitProjection();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/SqliteTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SqliteTransformer.php
@@ -54,4 +54,9 @@ final class SqliteTransformer implements SqlTransformer
             default => throw new UnsupportedSqlException($sql, 'Statement type not supported by transformer'),
         };
     }
+
+    public function commitRewriteState(): void
+    {
+        $this->insertTransformer->commitRewriteState();
+    }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteReturningProjectionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteReturningProjectionParserTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Sqlite\SqliteReturningProjectionParser;
+use ZtdQuery\Rewrite\ReturningProjection;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(SqliteReturningProjectionParser::class)]
+#[UsesClass(ReturningProjection::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+#[UsesClass(UnsupportedSqlException::class)]
+final class SqliteReturningProjectionParserTest extends TestCase
+{
+    public function testParsesSqliteQualifiedQuotedAliasesAndWildcard(): void
+    {
+        $projection = (new SqliteReturningProjectionParser())->parse(
+            'UPDATE users SET name = \'x\' RETURNING users.id AS original_id, *, "name" AS display_name',
+        );
+        self::assertNotNull($projection);
+
+        self::assertSame([
+            ['original_id' => 1, 'id' => 1, 'name' => 'Alice', 'display_name' => 'Alice'],
+        ], $projection->project([['id' => 1, 'name' => 'Alice']]));
+    }
+
+    public function testUnquotesEscapedSqliteIdentifiersAndStatementTerminator(): void
+    {
+        $projection = (new SqliteReturningProjectionParser())->parse(
+            'INSERT INTO users VALUES (1) RETURNING "source""name" AS `output``name`;',
+        );
+        self::assertNotNull($projection);
+
+        self::assertSame([['output`name' => 'value']], $projection->project([['source"name' => 'value']]));
+    }
+
+    public function testReturnsNullWithoutSqliteReturningClause(): void
+    {
+        self::assertNull((new SqliteReturningProjectionParser())->parse('INSERT INTO users VALUES (1)'));
+    }
+
+    #[DataProvider('providerInvalidSqliteReturningProjection')]
+    public function testRejectsMalformedSqliteProjection(string $projection): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        (new SqliteReturningProjectionParser())->parse('INSERT INTO users VALUES (1) RETURNING ' . $projection);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function providerInvalidSqliteReturningProjection(): array
+    {
+        return [
+            'empty' => [''],
+            'expression' => ['id + 1'],
+            'missing alias' => ['id AS'],
+            'invalid alias token' => ['id AS +'],
+            'tokens after alias' => ['id AS alias extra'],
+            'wildcard alias' => ['* AS all_columns'],
+            'leading dot' => ['.id'],
+            'trailing dot' => ['users.'],
+            'double dot' => ['users..id'],
+            'non-dot separator' => ['users + id'],
+            'leading wildcard path' => ['*.id'],
+            'non-trailing wildcard' => ['users.*.id'],
+            'non-wildcard symbol path' => ['users.+'],
+            'empty quoted identifier' => ['""'],
+            'number token' => ['12'],
+            'string token' => ["'id'"],
+            'unterminated double quote' => ['"id'],
+            'unterminated backtick' => ['`id'],
+        ];
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteReturningProjectionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteReturningProjectionParserTest.php
@@ -6,19 +6,11 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteReturningProjectionParser;
-use ZtdQuery\Rewrite\ReturningProjection;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqliteReturningProjectionParser::class)]
-#[UsesClass(ReturningProjection::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
-#[UsesClass(UnsupportedSqlException::class)]
 final class SqliteReturningProjectionParserTest extends TestCase
 {
     public function testParsesSqliteQualifiedQuotedAliasesAndWildcard(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteReturningProjectionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteReturningProjectionParserTest.php
@@ -19,6 +19,11 @@ final class SqliteReturningProjectionParserTest extends TestCase
             'UPDATE users SET name = \'x\' RETURNING users.id AS original_id, *, "name" AS display_name',
         );
         self::assertNotNull($projection);
+        self::assertSame([
+            ['source' => 'id', 'output' => 'original_id'],
+            ['source' => null, 'output' => null],
+            ['source' => 'name', 'output' => 'display_name'],
+        ], $projection->items());
 
         self::assertSame([
             ['original_id' => 1, 'id' => 1, 'name' => 'Alice', 'display_name' => 'Alice'],

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -15,6 +15,7 @@ use ZtdQuery\Platform\Sqlite\SqliteMutationResolver;
 use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
+use ZtdQuery\Platform\Sqlite\SqliteReturningProjectionParser;
 use ZtdQuery\Platform\Sqlite\SqliteRewriter;
 use ZtdQuery\Platform\Sqlite\SqliteSchemaParser;
 use ZtdQuery\Platform\Sqlite\Transformer\DeleteTransformer;
@@ -42,6 +43,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SqliteQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteTransactionStatementParser::class)]
+#[UsesClass(SqliteReturningProjectionParser::class)]
 #[UsesClass(SqliteSchemaParser::class)]
 #[UsesClass(SqliteMutationResolver::class)]
 #[UsesClass(SqliteTransformer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -439,6 +439,23 @@ final class InsertTransformerTest extends TestCase
         self::assertStringContainsString('3 AS "id"', $second);
     }
 
+    public function testUncommittedTransformDoesNotConsumeRowidValue(): void
+    {
+        $transformer = new InsertTransformer(new SqliteParser(), new SelectTransformer());
+        $tables = ['users' => [
+            'rows' => [],
+            'columns' => ['id', 'name'],
+            'columnTypes' => [],
+            'identityStrategies' => ['id' => IdentityGenerationStrategy::MaxValue],
+        ]];
+
+        $preview = $transformer->transform("INSERT INTO users (name) VALUES ('preview')", $tables);
+        $executed = $transformer->transform("INSERT INTO users (name) VALUES ('executed')", $tables);
+
+        self::assertStringContainsString('1 AS "id"', $preview);
+        self::assertStringContainsString('1 AS "id"', $executed);
+    }
+
     public function testTransformAllocatesRowidAfterExistingRows(): void
     {
         $transformer = new InsertTransformer(new SqliteParser(), new SelectTransformer());

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -431,6 +431,7 @@ final class InsertTransformerTest extends TestCase
         ]];
 
         $first = $transformer->transform("INSERT INTO users (name) VALUES ('Alice'), ('Bob')", $tables);
+        $transformer->commitRewriteState();
         $second = $transformer->transform("INSERT INTO users (name) VALUES ('Carol')", $tables);
 
         self::assertStringContainsString('1 AS "id"', $first);


### PR DESCRIPTION
## Root problem

Mutation simulation updated the shadow store but discarded database-visible execution metadata. That made `RETURNING`, affected-row counts, and generated identity reporting diverge from native PDO/MySQLi behavior. Rewrite-time identity allocation also consumed values before execution succeeded.

## Fix

- carry a typed returning projection and affected-row convention in `RewritePlan`
- compute mutation impact from typed before/after rows
- expose buffered mutation result sets through the PDO statement API
- track generated identities in the session and implement shadow-aware `lastInsertId()`
- split identity allocation into projection and commit phases so prepare/rewrite cannot consume IDs
- configure platform-native affected-row semantics explicitly

## Recurrence prevention

- unit tests cover projections, mutation impact, execution result state, and two-phase identity allocation
- SQLite integration tests compare INSERT/UPDATE/DELETE RETURNING, prepared execution, row counts, and last insert IDs
- PostgreSQL integration tests exercise native RETURNING for all three DML forms
- MySQLi integration verifies changed-row affected count against a real server
- full core/MySQL/PostgreSQL/SQLite suites and package lint pass

Fixes #32
Fixes #53
Fixes #77
Fixes #121
Fixes #150