### PR TITLE
Fix upsert expression evaluation

### DIFF
--- a/packages/ztd-query-core/src/Shadow/Mutation/MutationImpact.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MutationImpact.php
@@ -26,6 +26,9 @@ final class MutationImpact
 
     public function affectedRowCount(AffectedRowsMode $mode): int
     {
+        if ($mode === AffectedRowsMode::Matched && $this->mutation instanceof UpsertMutation) {
+            return count($this->mutation->resultRows());
+        }
         if ($mode === AffectedRowsMode::Matched && $this->mutation instanceof UpdateMutation) {
             return count($this->input);
         }
@@ -41,6 +44,9 @@ final class MutationImpact
      */
     public function returningRows(): array
     {
+        if ($this->mutation instanceof UpsertMutation) {
+            return $this->clean($this->mutation->resultRows());
+        }
         if ($this->mutation instanceof UpdateMutation || $this->mutation instanceof DeleteMutation) {
             return $this->clean($this->input);
         }
@@ -48,10 +54,6 @@ final class MutationImpact
         $added = $this->difference($this->after, $this->before);
         if ($added !== []) {
             return $added;
-        }
-
-        if ($this->mutation instanceof UpsertMutation) {
-            return $this->clean($this->input);
         }
 
         return [];

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertColumnSource.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertColumnSource.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+enum UpsertColumnSource
+{
+    case Existing;
+    case Incoming;
+}

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertExpression.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertExpression.php
@@ -166,9 +166,6 @@ final class UpsertExpression
     /** @param array<string, mixed> $row */
     private static function rowValue(array $row, string $column): mixed
     {
-        if (array_key_exists($column, $row)) {
-            return $row[$column];
-        }
         foreach ($row as $name => $value) {
             if (strcasecmp($name, $column) === 0) {
                 return $value;

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertExpression.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertExpression.php
@@ -5,41 +5,62 @@ declare(strict_types=1);
 namespace ZtdQuery\Shadow\Mutation;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 /**
- * Parsed scalar expression used by an UPSERT assignment.
+ * Dialect-independent scalar expression used by an UPSERT assignment.
  */
 final class UpsertExpression
 {
-    private const LITERAL = 'literal';
-    private const COLUMN = 'column';
-    private const UNARY = 'unary';
-    private const BINARY = 'binary';
-
+    /** @param list<self> $operands */
     private function __construct(
-        private readonly string $kind,
+        private readonly UpsertExpressionKind $kind,
         private readonly mixed $literal = null,
-        private readonly ?string $qualifier = null,
+        private readonly ?UpsertColumnSource $columnSource = null,
         private readonly ?string $column = null,
-        private readonly ?string $operator = null,
-        private readonly ?self $left = null,
-        private readonly ?self $right = null,
+        private readonly array $operands = [],
     ) {
     }
 
-    public static function parse(string $sql): self
+    public static function literal(mixed $value): self
     {
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
-        $index = 0;
-        $expression = self::parseOr($sql, $tokens, $index);
-        if (isset($tokens[$index])) {
-            throw self::unsupported($sql);
+        return new self(UpsertExpressionKind::Literal, literal: $value);
+    }
+
+    public static function column(UpsertColumnSource $source, string $column): self
+    {
+        if ($column === '') {
+            throw new \InvalidArgumentException('UPSERT column must not be empty');
         }
 
-        return $expression;
+        return new self(UpsertExpressionKind::Column, columnSource: $source, column: $column);
+    }
+
+    public static function unary(UpsertExpressionKind $kind, self $operand): self
+    {
+        if (!in_array($kind, [
+            UpsertExpressionKind::UnaryPlus,
+            UpsertExpressionKind::UnaryMinus,
+            UpsertExpressionKind::Not,
+        ], true)) {
+            throw new \InvalidArgumentException('Expected a unary UPSERT expression kind');
+        }
+
+        return new self($kind, operands: [$operand]);
+    }
+
+    public static function binary(UpsertExpressionKind $kind, self $left, self $right): self
+    {
+        if (in_array($kind, [
+            UpsertExpressionKind::Literal,
+            UpsertExpressionKind::Column,
+            UpsertExpressionKind::UnaryPlus,
+            UpsertExpressionKind::UnaryMinus,
+            UpsertExpressionKind::Not,
+        ], true)) {
+            throw new \InvalidArgumentException('Expected a binary UPSERT expression kind');
+        }
+
+        return new self($kind, operands: [$left, $right]);
     }
 
     /**
@@ -49,11 +70,63 @@ final class UpsertExpression
     public function evaluate(array $existingRow, array $incomingRow, string $tableName): mixed
     {
         return match ($this->kind) {
-            self::LITERAL => $this->literal,
-            self::COLUMN => $this->resolveColumn($existingRow, $incomingRow, $tableName),
-            self::UNARY => $this->evaluateUnary($existingRow, $incomingRow, $tableName),
-            self::BINARY => $this->evaluateBinary($existingRow, $incomingRow, $tableName),
-            default => throw self::unsupported($this->kind),
+            UpsertExpressionKind::Literal => $this->literal,
+            UpsertExpressionKind::Column => $this->resolveColumn($existingRow, $incomingRow),
+            UpsertExpressionKind::UnaryPlus => self::unaryPlus($this->operand(0, $existingRow, $incomingRow, $tableName)),
+            UpsertExpressionKind::UnaryMinus => self::unaryMinus($this->operand(0, $existingRow, $incomingRow, $tableName)),
+            UpsertExpressionKind::Not => self::not($this->operand(0, $existingRow, $incomingRow, $tableName)),
+            UpsertExpressionKind::Add => self::add(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::Subtract => self::subtract(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::Multiply => self::multiply(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::Divide => self::divide(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::Modulo => self::modulo(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::Equal => self::equal(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::NotEqual => self::notEqual(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::Less => self::less(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::LessOrEqual => self::lessOrEqual(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::Greater => self::greater(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::GreaterOrEqual => self::greaterOrEqual(
+                $this->operand(0, $existingRow, $incomingRow, $tableName),
+                $this->operand(1, $existingRow, $incomingRow, $tableName),
+            ),
+            UpsertExpressionKind::And => self::and(
+                self::truth($this->operand(0, $existingRow, $incomingRow, $tableName)),
+                self::truth($this->operand(1, $existingRow, $incomingRow, $tableName)),
+            ),
+            UpsertExpressionKind::Or => self::or(
+                self::truth($this->operand(0, $existingRow, $incomingRow, $tableName)),
+                self::truth($this->operand(1, $existingRow, $incomingRow, $tableName)),
+            ),
         };
     }
 
@@ -67,216 +140,14 @@ final class UpsertExpression
     }
 
     /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function parseOr(string $sql, array $tokens, int &$index): self
-    {
-        $left = self::parseAnd($sql, $tokens, $index);
-        while (($tokens[$index] ?? null)?->isKeyword('OR') === true) {
-            $index++;
-            $left = self::binary('OR', $left, self::parseAnd($sql, $tokens, $index));
-        }
-
-        return $left;
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function parseAnd(string $sql, array $tokens, int &$index): self
-    {
-        $left = self::parseComparison($sql, $tokens, $index);
-        while (($tokens[$index] ?? null)?->isKeyword('AND') === true) {
-            $index++;
-            $left = self::binary('AND', $left, self::parseComparison($sql, $tokens, $index));
-        }
-
-        return $left;
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function parseComparison(string $sql, array $tokens, int &$index): self
-    {
-        $left = self::parseAdditive($sql, $tokens, $index);
-        $operator = self::comparisonOperator($sql, $tokens, $index);
-        if ($operator === null) {
-            return $left;
-        }
-
-        return self::binary($operator, $left, self::parseAdditive($sql, $tokens, $index));
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function parseAdditive(string $sql, array $tokens, int &$index): self
-    {
-        $left = self::parseMultiplicative($sql, $tokens, $index);
-        while (isset($tokens[$index]) && self::isSymbol($tokens[$index], ['+', '-'])) {
-            $operator = $tokens[$index]->text;
-            $index++;
-            $left = self::binary($operator, $left, self::parseMultiplicative($sql, $tokens, $index));
-        }
-
-        return $left;
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function parseMultiplicative(string $sql, array $tokens, int &$index): self
-    {
-        $left = self::parseUnary($sql, $tokens, $index);
-        while (isset($tokens[$index]) && self::isSymbol($tokens[$index], ['*', '/', '%'])) {
-            $operator = $tokens[$index]->text;
-            $index++;
-            $left = self::binary($operator, $left, self::parseUnary($sql, $tokens, $index));
-        }
-
-        return $left;
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function parseUnary(string $sql, array $tokens, int &$index): self
-    {
-        $token = $tokens[$index] ?? null;
-        if ($token?->isKeyword('NOT') === true) {
-            $index++;
-
-            return self::unary('NOT', self::parseUnary($sql, $tokens, $index));
-        }
-        if ($token !== null && self::isSymbol($token, ['+', '-'])) {
-            $index++;
-
-            return self::unary($token->text, self::parseUnary($sql, $tokens, $index));
-        }
-
-        return self::parsePrimary($sql, $tokens, $index);
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function parsePrimary(string $sql, array $tokens, int &$index): self
-    {
-        $token = $tokens[$index] ?? null;
-        if ($token === null) {
-            throw self::unsupported($sql);
-        }
-        if (self::isSymbol($token, ['('])) {
-            $index++;
-            $expression = self::parseOr($sql, $tokens, $index);
-            if (!isset($tokens[$index]) || !self::isSymbol($tokens[$index], [')'])) {
-                throw self::unsupported($sql);
-            }
-            $index++;
-
-            return $expression;
-        }
-        if ($token->kind === SqlTokenKind::Number) {
-            $index++;
-
-            return self::literal(self::number($token->text));
-        }
-        if ($token->kind === SqlTokenKind::String) {
-            $index++;
-
-            return self::literal(self::string($token->text));
-        }
-        if ($token->isKeyword('NULL')) {
-            $index++;
-
-            return self::literal(null);
-        }
-        if ($token->isKeyword('TRUE') || $token->isKeyword('FALSE')) {
-            $index++;
-
-            return self::literal($token->isKeyword('TRUE'));
-        }
-        if (!self::isIdentifier($token)) {
-            throw self::unsupported($sql);
-        }
-
-        $identifier = self::identifier($token);
-        $index++;
-        if (strcasecmp($identifier, 'VALUES') === 0 && isset($tokens[$index]) && self::isSymbol($tokens[$index], ['('])) {
-            return self::parseValuesReference($sql, $tokens, $index);
-        }
-        if (isset($tokens[$index]) && self::isSymbol($tokens[$index], ['.'])) {
-            $index++;
-            $column = $tokens[$index] ?? null;
-            if ($column === null || !self::isIdentifier($column)) {
-                throw self::unsupported($sql);
-            }
-            $index++;
-
-            return self::column($identifier, self::identifier($column));
-        }
-
-        return self::column(null, $identifier);
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function parseValuesReference(string $sql, array $tokens, int &$index): self
-    {
-        $index++;
-        $column = $tokens[$index] ?? null;
-        if ($column === null || !self::isIdentifier($column)) {
-            throw self::unsupported($sql);
-        }
-        $index++;
-        if (!isset($tokens[$index]) || !self::isSymbol($tokens[$index], [')'])) {
-            throw self::unsupported($sql);
-        }
-        $index++;
-
-        return self::column('VALUES', self::identifier($column));
-    }
-
-    /**
-     * @param list<SqlToken> $tokens
-     */
-    private static function comparisonOperator(string $sql, array $tokens, int &$index): ?string
-    {
-        $first = $tokens[$index] ?? null;
-        if ($first === null || !self::isSymbol($first, ['=', '!', '<', '>'])) {
-            return null;
-        }
-        $operator = $first->text;
-        $second = $tokens[$index + 1] ?? null;
-        if ($second !== null && self::isSymbol($second, ['=', '>']) && $operator !== '=') {
-            $operator .= $second->text;
-            $index++;
-        }
-        $index++;
-
-        if (!in_array($operator, ['=', '!=', '<>', '<', '<=', '>', '>='], true)) {
-            throw self::unsupported($sql);
-        }
-
-        return $operator;
-    }
-
-    /**
      * @param array<string, mixed> $existingRow
      * @param array<string, mixed> $incomingRow
      */
-    private function resolveColumn(array $existingRow, array $incomingRow, string $tableName): mixed
+    private function resolveColumn(array $existingRow, array $incomingRow): mixed
     {
         $column = $this->column ?? '';
-        if ($this->qualifier !== null
-            && (strcasecmp($this->qualifier, 'EXCLUDED') === 0 || strcasecmp($this->qualifier, 'VALUES') === 0)
-        ) {
+        if ($this->columnSource === UpsertColumnSource::Incoming) {
             return self::rowValue($incomingRow, $column);
-        }
-        if ($this->qualifier !== null && strcasecmp($this->qualifier, $tableName) !== 0) {
-            throw self::unsupported($this->qualifier . '.' . $column);
         }
 
         return self::rowValue($existingRow, $column);
@@ -286,102 +157,11 @@ final class UpsertExpression
      * @param array<string, mixed> $existingRow
      * @param array<string, mixed> $incomingRow
      */
-    private function evaluateUnary(array $existingRow, array $incomingRow, string $tableName): mixed
+    private function operand(int $index, array $existingRow, array $incomingRow, string $tableName): mixed
     {
-        $value = $this->left?->evaluate($existingRow, $incomingRow, $tableName);
-
-        return match ($this->operator) {
-            '+' => $value === null ? null : self::numeric($value),
-            '-' => $value === null ? null : -self::numeric($value),
-            'NOT' => ($truth = self::truth($value)) === null ? null : !$truth,
-            default => throw self::unsupported((string) $this->operator),
-        };
+        return $this->operands[$index]->evaluate($existingRow, $incomingRow, $tableName);
     }
 
-    /**
-     * @param array<string, mixed> $existingRow
-     * @param array<string, mixed> $incomingRow
-     */
-    private function evaluateBinary(array $existingRow, array $incomingRow, string $tableName): mixed
-    {
-        $left = $this->left?->evaluate($existingRow, $incomingRow, $tableName);
-        $right = $this->right?->evaluate($existingRow, $incomingRow, $tableName);
-        if ($this->operator === 'AND' || $this->operator === 'OR') {
-            return self::logical($this->operator, self::truth($left), self::truth($right));
-        }
-        if ($left === null || $right === null) {
-            return null;
-        }
-
-        return match ($this->operator) {
-            '+' => self::numeric($left) + self::numeric($right),
-            '-' => self::numeric($left) - self::numeric($right),
-            '*' => self::numeric($left) * self::numeric($right),
-            '/' => self::divide($left, $right),
-            '%' => self::modulo($left, $right),
-            '=', '!=', '<>', '<', '<=', '>', '>=' => self::compare($this->operator, $left, $right),
-            default => throw self::unsupported((string) $this->operator),
-        };
-    }
-
-    private static function literal(mixed $value): self
-    {
-        return new self(self::LITERAL, literal: $value);
-    }
-
-    private static function column(?string $qualifier, string $column): self
-    {
-        return new self(self::COLUMN, qualifier: $qualifier, column: $column);
-    }
-
-    private static function unary(string $operator, self $operand): self
-    {
-        return new self(self::UNARY, operator: $operator, left: $operand);
-    }
-
-    private static function binary(string $operator, self $left, self $right): self
-    {
-        return new self(self::BINARY, operator: $operator, left: $left, right: $right);
-    }
-
-    /** @param list<string> $symbols */
-    private static function isSymbol(SqlToken $token, array $symbols): bool
-    {
-        return $token->kind === SqlTokenKind::Symbol && in_array($token->text, $symbols, true);
-    }
-
-    private static function isIdentifier(SqlToken $token): bool
-    {
-        return $token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier;
-    }
-
-    private static function identifier(SqlToken $token): string
-    {
-        if ($token->kind === SqlTokenKind::Word) {
-            return $token->text;
-        }
-        $quote = $token->text[0] ?? '';
-        $inner = substr($token->text, 1, -1);
-
-        return str_replace($quote . $quote, $quote, $inner);
-    }
-
-    private static function number(string $literal): int|float
-    {
-        $literal = str_replace('_', '', $literal);
-        if (str_starts_with(strtolower($literal), '0x')) {
-            return intval(substr($literal, 2), 16);
-        }
-
-        return strpbrk($literal, '.eE') === false ? (int) $literal : (float) $literal;
-    }
-
-    private static function string(string $literal): string
-    {
-        $inner = substr($literal, 1, -1);
-
-        return str_replace(["''", "\\'", '\\\\'], ["'", "'", '\\'], $inner);
-    }
 
     /** @param array<string, mixed> $row */
     private static function rowValue(array $row, string $column): mixed
@@ -400,18 +180,68 @@ final class UpsertExpression
 
     private static function numeric(mixed $value): int|float
     {
-        if (is_int($value) || is_float($value)) {
+        if (is_int($value)) {
             return $value;
         }
-        if (is_string($value) && is_numeric($value)) {
-            return strpbrk($value, '.eE') === false ? (int) $value : (float) $value;
+        if (is_float($value)) {
+            return $value;
+        }
+        if (!is_string($value) || !is_numeric($value)) {
+            throw self::unsupported('non-numeric UPSERT operand');
         }
 
-        throw self::unsupported('non-numeric UPSERT operand');
+        return strpbrk($value, '.eE') === false ? (int) $value : (float) $value;
     }
 
-    private static function divide(mixed $left, mixed $right): float|int
+    private static function unaryPlus(mixed $value): int|float|null
     {
+        return $value === null ? null : self::numeric($value);
+    }
+
+    private static function unaryMinus(mixed $value): int|float|null
+    {
+        return $value === null ? null : -self::numeric($value);
+    }
+
+    private static function not(mixed $value): ?bool
+    {
+        $truth = self::truth($value);
+
+        return $truth === null ? null : !$truth;
+    }
+
+    private static function add(mixed $left, mixed $right): int|float|null
+    {
+        if ($left === null || $right === null) {
+            return null;
+        }
+
+        return self::numeric($left) + self::numeric($right);
+    }
+
+    private static function subtract(mixed $left, mixed $right): int|float|null
+    {
+        if ($left === null || $right === null) {
+            return null;
+        }
+
+        return self::numeric($left) - self::numeric($right);
+    }
+
+    private static function multiply(mixed $left, mixed $right): int|float|null
+    {
+        if ($left === null || $right === null) {
+            return null;
+        }
+
+        return self::numeric($left) * self::numeric($right);
+    }
+
+    private static function divide(mixed $left, mixed $right): float|int|null
+    {
+        if ($left === null || $right === null) {
+            return null;
+        }
         $divisor = self::numeric($right);
         if ($divisor === 0 || $divisor === 0.0) {
             throw self::unsupported('division by zero in UPSERT expression');
@@ -420,60 +250,136 @@ final class UpsertExpression
         return self::numeric($left) / $divisor;
     }
 
-    private static function modulo(mixed $left, mixed $right): int
+    private static function modulo(mixed $left, mixed $right): ?int
     {
-        $divisor = (int) self::numeric($right);
+        if ($left === null || $right === null) {
+            return null;
+        }
+        $divisor = intval(self::numeric($right));
         if ($divisor === 0) {
             throw self::unsupported('division by zero in UPSERT expression');
         }
 
-        return (int) self::numeric($left) % $divisor;
+        return intval(self::numeric($left)) % $divisor;
     }
 
-    private static function compare(string $operator, mixed $left, mixed $right): bool
+    private static function comparison(mixed $left, mixed $right): ?int
     {
-        if ((is_int($left) || is_float($left) || is_numeric($left))
-            && (is_int($right) || is_float($right) || is_numeric($right))
-        ) {
-            $comparison = self::numeric($left) <=> self::numeric($right);
-        } elseif ((is_string($left) || is_bool($left)) && (is_string($right) || is_bool($right))) {
-            $comparison = (string) $left <=> (string) $right;
-        } else {
+        if ($left === null || $right === null) {
+            return null;
+        }
+        if (self::isNumericValue($left)) {
+            if (!self::isNumericValue($right)) {
+                throw self::unsupported('incomparable UPSERT operands');
+            }
+
+            return self::numeric($left) <=> self::numeric($right);
+        }
+        if (self::isNumericValue($right)) {
             throw self::unsupported('incomparable UPSERT operands');
         }
 
-        return match ($operator) {
-            '=' => $comparison === 0,
-            '!=', '<>' => $comparison !== 0,
-            '<' => $comparison < 0,
-            '<=' => $comparison <= 0,
-            '>' => $comparison > 0,
-            '>=' => $comparison >= 0,
-            default => throw self::unsupported($operator),
-        };
+        return self::text($left) <=> self::text($right);
+    }
+
+    private static function equal(mixed $left, mixed $right): ?bool
+    {
+        $comparison = self::comparison($left, $right);
+
+        return $comparison === null ? null : $comparison === 0;
+    }
+
+    private static function notEqual(mixed $left, mixed $right): ?bool
+    {
+        $comparison = self::comparison($left, $right);
+
+        return $comparison === null ? null : $comparison !== 0;
+    }
+
+    private static function less(mixed $left, mixed $right): ?bool
+    {
+        $comparison = self::comparison($left, $right);
+
+        return $comparison === null ? null : $comparison < 0;
+    }
+
+    private static function lessOrEqual(mixed $left, mixed $right): ?bool
+    {
+        $comparison = self::comparison($left, $right);
+
+        return $comparison === null ? null : $comparison <= 0;
+    }
+
+    private static function greater(mixed $left, mixed $right): ?bool
+    {
+        $comparison = self::comparison($left, $right);
+
+        return $comparison === null ? null : $comparison > 0;
+    }
+
+    private static function greaterOrEqual(mixed $left, mixed $right): ?bool
+    {
+        $comparison = self::comparison($left, $right);
+
+        return $comparison === null ? null : $comparison >= 0;
+    }
+
+    private static function isNumericValue(mixed $value): bool
+    {
+        if (is_int($value) || is_float($value)) {
+            return true;
+        }
+
+        return is_string($value) && is_numeric($value);
+    }
+
+    private static function text(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_bool($value)) {
+            return $value ? '1' : '';
+        }
+
+        throw self::unsupported('incomparable UPSERT operands');
     }
 
     private static function truth(mixed $value): ?bool
     {
-        if ($value === null || is_bool($value)) {
+        if ($value === null) {
+            return null;
+        }
+        if (is_bool($value)) {
             return $value;
         }
-        if (is_int($value) || is_float($value) || (is_string($value) && is_numeric($value))) {
-            $numeric = self::numeric($value);
+        $numeric = self::numeric($value);
 
-            return $numeric !== 0 && $numeric !== 0.0;
-        }
-
-        throw self::unsupported('non-boolean UPSERT operand');
+        return !in_array($numeric, [0, 0.0], true);
     }
 
-    private static function logical(string $operator, ?bool $left, ?bool $right): ?bool
+    private static function and(?bool $left, ?bool $right): ?bool
     {
-        if ($operator === 'AND') {
-            return $left === false || $right === false ? false : ($left === null || $right === null ? null : true);
+        if ($left === false || $right === false) {
+            return false;
+        }
+        if ($left === null || $right === null) {
+            return null;
         }
 
-        return $left === true || $right === true ? true : ($left === null || $right === null ? null : false);
+        return true;
+    }
+
+    private static function or(?bool $left, ?bool $right): ?bool
+    {
+        if ($left === true || $right === true) {
+            return true;
+        }
+        if ($left === null || $right === null) {
+            return null;
+        }
+
+        return false;
     }
 
     private static function unsupported(string $sql): UnsupportedSqlException

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertExpression.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertExpression.php
@@ -1,0 +1,483 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+/**
+ * Parsed scalar expression used by an UPSERT assignment.
+ */
+final class UpsertExpression
+{
+    private const LITERAL = 'literal';
+    private const COLUMN = 'column';
+    private const UNARY = 'unary';
+    private const BINARY = 'binary';
+
+    private function __construct(
+        private readonly string $kind,
+        private readonly mixed $literal = null,
+        private readonly ?string $qualifier = null,
+        private readonly ?string $column = null,
+        private readonly ?string $operator = null,
+        private readonly ?self $left = null,
+        private readonly ?self $right = null,
+    ) {
+    }
+
+    public static function parse(string $sql): self
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $index = 0;
+        $expression = self::parseOr($sql, $tokens, $index);
+        if (isset($tokens[$index])) {
+            throw self::unsupported($sql);
+        }
+
+        return $expression;
+    }
+
+    /**
+     * @param array<string, mixed> $existingRow
+     * @param array<string, mixed> $incomingRow
+     */
+    public function evaluate(array $existingRow, array $incomingRow, string $tableName): mixed
+    {
+        return match ($this->kind) {
+            self::LITERAL => $this->literal,
+            self::COLUMN => $this->resolveColumn($existingRow, $incomingRow, $tableName),
+            self::UNARY => $this->evaluateUnary($existingRow, $incomingRow, $tableName),
+            self::BINARY => $this->evaluateBinary($existingRow, $incomingRow, $tableName),
+            default => throw self::unsupported($this->kind),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $existingRow
+     * @param array<string, mixed> $incomingRow
+     */
+    public function matches(array $existingRow, array $incomingRow, string $tableName): bool
+    {
+        return self::truth($this->evaluate($existingRow, $incomingRow, $tableName)) === true;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function parseOr(string $sql, array $tokens, int &$index): self
+    {
+        $left = self::parseAnd($sql, $tokens, $index);
+        while (($tokens[$index] ?? null)?->isKeyword('OR') === true) {
+            $index++;
+            $left = self::binary('OR', $left, self::parseAnd($sql, $tokens, $index));
+        }
+
+        return $left;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function parseAnd(string $sql, array $tokens, int &$index): self
+    {
+        $left = self::parseComparison($sql, $tokens, $index);
+        while (($tokens[$index] ?? null)?->isKeyword('AND') === true) {
+            $index++;
+            $left = self::binary('AND', $left, self::parseComparison($sql, $tokens, $index));
+        }
+
+        return $left;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function parseComparison(string $sql, array $tokens, int &$index): self
+    {
+        $left = self::parseAdditive($sql, $tokens, $index);
+        $operator = self::comparisonOperator($sql, $tokens, $index);
+        if ($operator === null) {
+            return $left;
+        }
+
+        return self::binary($operator, $left, self::parseAdditive($sql, $tokens, $index));
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function parseAdditive(string $sql, array $tokens, int &$index): self
+    {
+        $left = self::parseMultiplicative($sql, $tokens, $index);
+        while (isset($tokens[$index]) && self::isSymbol($tokens[$index], ['+', '-'])) {
+            $operator = $tokens[$index]->text;
+            $index++;
+            $left = self::binary($operator, $left, self::parseMultiplicative($sql, $tokens, $index));
+        }
+
+        return $left;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function parseMultiplicative(string $sql, array $tokens, int &$index): self
+    {
+        $left = self::parseUnary($sql, $tokens, $index);
+        while (isset($tokens[$index]) && self::isSymbol($tokens[$index], ['*', '/', '%'])) {
+            $operator = $tokens[$index]->text;
+            $index++;
+            $left = self::binary($operator, $left, self::parseUnary($sql, $tokens, $index));
+        }
+
+        return $left;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function parseUnary(string $sql, array $tokens, int &$index): self
+    {
+        $token = $tokens[$index] ?? null;
+        if ($token?->isKeyword('NOT') === true) {
+            $index++;
+
+            return self::unary('NOT', self::parseUnary($sql, $tokens, $index));
+        }
+        if ($token !== null && self::isSymbol($token, ['+', '-'])) {
+            $index++;
+
+            return self::unary($token->text, self::parseUnary($sql, $tokens, $index));
+        }
+
+        return self::parsePrimary($sql, $tokens, $index);
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function parsePrimary(string $sql, array $tokens, int &$index): self
+    {
+        $token = $tokens[$index] ?? null;
+        if ($token === null) {
+            throw self::unsupported($sql);
+        }
+        if (self::isSymbol($token, ['('])) {
+            $index++;
+            $expression = self::parseOr($sql, $tokens, $index);
+            if (!isset($tokens[$index]) || !self::isSymbol($tokens[$index], [')'])) {
+                throw self::unsupported($sql);
+            }
+            $index++;
+
+            return $expression;
+        }
+        if ($token->kind === SqlTokenKind::Number) {
+            $index++;
+
+            return self::literal(self::number($token->text));
+        }
+        if ($token->kind === SqlTokenKind::String) {
+            $index++;
+
+            return self::literal(self::string($token->text));
+        }
+        if ($token->isKeyword('NULL')) {
+            $index++;
+
+            return self::literal(null);
+        }
+        if ($token->isKeyword('TRUE') || $token->isKeyword('FALSE')) {
+            $index++;
+
+            return self::literal($token->isKeyword('TRUE'));
+        }
+        if (!self::isIdentifier($token)) {
+            throw self::unsupported($sql);
+        }
+
+        $identifier = self::identifier($token);
+        $index++;
+        if (strcasecmp($identifier, 'VALUES') === 0 && isset($tokens[$index]) && self::isSymbol($tokens[$index], ['('])) {
+            return self::parseValuesReference($sql, $tokens, $index);
+        }
+        if (isset($tokens[$index]) && self::isSymbol($tokens[$index], ['.'])) {
+            $index++;
+            $column = $tokens[$index] ?? null;
+            if ($column === null || !self::isIdentifier($column)) {
+                throw self::unsupported($sql);
+            }
+            $index++;
+
+            return self::column($identifier, self::identifier($column));
+        }
+
+        return self::column(null, $identifier);
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function parseValuesReference(string $sql, array $tokens, int &$index): self
+    {
+        $index++;
+        $column = $tokens[$index] ?? null;
+        if ($column === null || !self::isIdentifier($column)) {
+            throw self::unsupported($sql);
+        }
+        $index++;
+        if (!isset($tokens[$index]) || !self::isSymbol($tokens[$index], [')'])) {
+            throw self::unsupported($sql);
+        }
+        $index++;
+
+        return self::column('VALUES', self::identifier($column));
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function comparisonOperator(string $sql, array $tokens, int &$index): ?string
+    {
+        $first = $tokens[$index] ?? null;
+        if ($first === null || !self::isSymbol($first, ['=', '!', '<', '>'])) {
+            return null;
+        }
+        $operator = $first->text;
+        $second = $tokens[$index + 1] ?? null;
+        if ($second !== null && self::isSymbol($second, ['=', '>']) && $operator !== '=') {
+            $operator .= $second->text;
+            $index++;
+        }
+        $index++;
+
+        if (!in_array($operator, ['=', '!=', '<>', '<', '<=', '>', '>='], true)) {
+            throw self::unsupported($sql);
+        }
+
+        return $operator;
+    }
+
+    /**
+     * @param array<string, mixed> $existingRow
+     * @param array<string, mixed> $incomingRow
+     */
+    private function resolveColumn(array $existingRow, array $incomingRow, string $tableName): mixed
+    {
+        $column = $this->column ?? '';
+        if ($this->qualifier !== null
+            && (strcasecmp($this->qualifier, 'EXCLUDED') === 0 || strcasecmp($this->qualifier, 'VALUES') === 0)
+        ) {
+            return self::rowValue($incomingRow, $column);
+        }
+        if ($this->qualifier !== null && strcasecmp($this->qualifier, $tableName) !== 0) {
+            throw self::unsupported($this->qualifier . '.' . $column);
+        }
+
+        return self::rowValue($existingRow, $column);
+    }
+
+    /**
+     * @param array<string, mixed> $existingRow
+     * @param array<string, mixed> $incomingRow
+     */
+    private function evaluateUnary(array $existingRow, array $incomingRow, string $tableName): mixed
+    {
+        $value = $this->left?->evaluate($existingRow, $incomingRow, $tableName);
+
+        return match ($this->operator) {
+            '+' => $value === null ? null : self::numeric($value),
+            '-' => $value === null ? null : -self::numeric($value),
+            'NOT' => ($truth = self::truth($value)) === null ? null : !$truth,
+            default => throw self::unsupported((string) $this->operator),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $existingRow
+     * @param array<string, mixed> $incomingRow
+     */
+    private function evaluateBinary(array $existingRow, array $incomingRow, string $tableName): mixed
+    {
+        $left = $this->left?->evaluate($existingRow, $incomingRow, $tableName);
+        $right = $this->right?->evaluate($existingRow, $incomingRow, $tableName);
+        if ($this->operator === 'AND' || $this->operator === 'OR') {
+            return self::logical($this->operator, self::truth($left), self::truth($right));
+        }
+        if ($left === null || $right === null) {
+            return null;
+        }
+
+        return match ($this->operator) {
+            '+' => self::numeric($left) + self::numeric($right),
+            '-' => self::numeric($left) - self::numeric($right),
+            '*' => self::numeric($left) * self::numeric($right),
+            '/' => self::divide($left, $right),
+            '%' => self::modulo($left, $right),
+            '=', '!=', '<>', '<', '<=', '>', '>=' => self::compare($this->operator, $left, $right),
+            default => throw self::unsupported((string) $this->operator),
+        };
+    }
+
+    private static function literal(mixed $value): self
+    {
+        return new self(self::LITERAL, literal: $value);
+    }
+
+    private static function column(?string $qualifier, string $column): self
+    {
+        return new self(self::COLUMN, qualifier: $qualifier, column: $column);
+    }
+
+    private static function unary(string $operator, self $operand): self
+    {
+        return new self(self::UNARY, operator: $operator, left: $operand);
+    }
+
+    private static function binary(string $operator, self $left, self $right): self
+    {
+        return new self(self::BINARY, operator: $operator, left: $left, right: $right);
+    }
+
+    /** @param list<string> $symbols */
+    private static function isSymbol(SqlToken $token, array $symbols): bool
+    {
+        return $token->kind === SqlTokenKind::Symbol && in_array($token->text, $symbols, true);
+    }
+
+    private static function isIdentifier(SqlToken $token): bool
+    {
+        return $token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier;
+    }
+
+    private static function identifier(SqlToken $token): string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+        $quote = $token->text[0] ?? '';
+        $inner = substr($token->text, 1, -1);
+
+        return str_replace($quote . $quote, $quote, $inner);
+    }
+
+    private static function number(string $literal): int|float
+    {
+        $literal = str_replace('_', '', $literal);
+        if (str_starts_with(strtolower($literal), '0x')) {
+            return intval(substr($literal, 2), 16);
+        }
+
+        return strpbrk($literal, '.eE') === false ? (int) $literal : (float) $literal;
+    }
+
+    private static function string(string $literal): string
+    {
+        $inner = substr($literal, 1, -1);
+
+        return str_replace(["''", "\\'", '\\\\'], ["'", "'", '\\'], $inner);
+    }
+
+    /** @param array<string, mixed> $row */
+    private static function rowValue(array $row, string $column): mixed
+    {
+        if (array_key_exists($column, $row)) {
+            return $row[$column];
+        }
+        foreach ($row as $name => $value) {
+            if (strcasecmp($name, $column) === 0) {
+                return $value;
+            }
+        }
+
+        throw self::unsupported('unknown UPSERT column ' . $column);
+    }
+
+    private static function numeric(mixed $value): int|float
+    {
+        if (is_int($value) || is_float($value)) {
+            return $value;
+        }
+        if (is_string($value) && is_numeric($value)) {
+            return strpbrk($value, '.eE') === false ? (int) $value : (float) $value;
+        }
+
+        throw self::unsupported('non-numeric UPSERT operand');
+    }
+
+    private static function divide(mixed $left, mixed $right): float|int
+    {
+        $divisor = self::numeric($right);
+        if ($divisor === 0 || $divisor === 0.0) {
+            throw self::unsupported('division by zero in UPSERT expression');
+        }
+
+        return self::numeric($left) / $divisor;
+    }
+
+    private static function modulo(mixed $left, mixed $right): int
+    {
+        $divisor = (int) self::numeric($right);
+        if ($divisor === 0) {
+            throw self::unsupported('division by zero in UPSERT expression');
+        }
+
+        return (int) self::numeric($left) % $divisor;
+    }
+
+    private static function compare(string $operator, mixed $left, mixed $right): bool
+    {
+        if ((is_int($left) || is_float($left) || is_numeric($left))
+            && (is_int($right) || is_float($right) || is_numeric($right))
+        ) {
+            $comparison = self::numeric($left) <=> self::numeric($right);
+        } elseif ((is_string($left) || is_bool($left)) && (is_string($right) || is_bool($right))) {
+            $comparison = (string) $left <=> (string) $right;
+        } else {
+            throw self::unsupported('incomparable UPSERT operands');
+        }
+
+        return match ($operator) {
+            '=' => $comparison === 0,
+            '!=', '<>' => $comparison !== 0,
+            '<' => $comparison < 0,
+            '<=' => $comparison <= 0,
+            '>' => $comparison > 0,
+            '>=' => $comparison >= 0,
+            default => throw self::unsupported($operator),
+        };
+    }
+
+    private static function truth(mixed $value): ?bool
+    {
+        if ($value === null || is_bool($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value) || (is_string($value) && is_numeric($value))) {
+            $numeric = self::numeric($value);
+
+            return $numeric !== 0 && $numeric !== 0.0;
+        }
+
+        throw self::unsupported('non-boolean UPSERT operand');
+    }
+
+    private static function logical(string $operator, ?bool $left, ?bool $right): ?bool
+    {
+        if ($operator === 'AND') {
+            return $left === false || $right === false ? false : ($left === null || $right === null ? null : true);
+        }
+
+        return $left === true || $right === true ? true : ($left === null || $right === null ? null : false);
+    }
+
+    private static function unsupported(string $sql): UnsupportedSqlException
+    {
+        return new UnsupportedSqlException($sql, 'Unsupported UPSERT expression');
+    }
+}

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertExpressionKind.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertExpressionKind.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+enum UpsertExpressionKind
+{
+    case Literal;
+    case Column;
+    case UnaryPlus;
+    case UnaryMinus;
+    case Not;
+    case Add;
+    case Subtract;
+    case Multiply;
+    case Divide;
+    case Modulo;
+    case Equal;
+    case NotEqual;
+    case Less;
+    case LessOrEqual;
+    case Greater;
+    case GreaterOrEqual;
+    case And;
+    case Or;
+}

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
@@ -51,9 +51,9 @@ final class UpsertMutation implements ShadowMutation
      * @param string $tableName Target table.
      * @param array<int, string> $primaryKeys Primary key columns.
      * @param array<int, string> $updateColumns Columns to update on duplicate.
-     * @param array<string, string> $updateValues Values to use for update on duplicate.
+     * @param array<string, UpsertExpression> $updateValues Values to use for update on duplicate.
      * @param CandidateKeySet|null $candidateKeys Candidate keys used for conflict detection.
-     * @param string|null $updatePredicate Condition that controls the conflict update.
+     * @param UpsertExpression|null $updatePredicate Condition that controls the conflict update.
      */
     public function __construct(
         string $tableName,
@@ -61,14 +61,14 @@ final class UpsertMutation implements ShadowMutation
         array $updateColumns = [],
         array $updateValues = [],
         ?CandidateKeySet $candidateKeys = null,
-        ?string $updatePredicate = null,
+        ?UpsertExpression $updatePredicate = null,
     ) {
         $this->tableName = $tableName;
         $this->primaryKeys = $primaryKeys;
         $this->updateColumns = $updateColumns;
-        $this->updateValues = array_map(UpsertExpression::parse(...), $updateValues);
+        $this->updateValues = $updateValues;
         $this->candidateKeys = $candidateKeys ?? CandidateKeySet::fromSchema($primaryKeys);
-        $this->updatePredicate = $updatePredicate !== null ? UpsertExpression::parse($updatePredicate) : null;
+        $this->updatePredicate = $updatePredicate;
     }
 
     /**

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
@@ -34,13 +34,18 @@ final class UpsertMutation implements ShadowMutation
     private array $updateColumns;
 
     /**
-     * Values to use for update on duplicate.
+     * Parsed values to use for update on duplicate.
      *
-     * @var array<string, string>
+     * @var array<string, UpsertExpression>
      */
     private array $updateValues;
 
     private CandidateKeySet $candidateKeys;
+
+    private ?UpsertExpression $updatePredicate;
+
+    /** @var array<int, array<string, mixed>> */
+    private array $resultRows = [];
 
     /**
      * @param string $tableName Target table.
@@ -48,6 +53,7 @@ final class UpsertMutation implements ShadowMutation
      * @param array<int, string> $updateColumns Columns to update on duplicate.
      * @param array<string, string> $updateValues Values to use for update on duplicate.
      * @param CandidateKeySet|null $candidateKeys Candidate keys used for conflict detection.
+     * @param string|null $updatePredicate Condition that controls the conflict update.
      */
     public function __construct(
         string $tableName,
@@ -55,12 +61,14 @@ final class UpsertMutation implements ShadowMutation
         array $updateColumns = [],
         array $updateValues = [],
         ?CandidateKeySet $candidateKeys = null,
+        ?string $updatePredicate = null,
     ) {
         $this->tableName = $tableName;
         $this->primaryKeys = $primaryKeys;
         $this->updateColumns = $updateColumns;
-        $this->updateValues = $updateValues;
+        $this->updateValues = array_map(UpsertExpression::parse(...), $updateValues);
         $this->candidateKeys = $candidateKeys ?? CandidateKeySet::fromSchema($primaryKeys);
+        $this->updatePredicate = $updatePredicate !== null ? UpsertExpression::parse($updatePredicate) : null;
     }
 
     /**
@@ -70,28 +78,20 @@ final class UpsertMutation implements ShadowMutation
     {
         $existingRows = $store->get($this->tableName);
         $insertRows = [];
-        $updateRows = [];
-
+        $this->resultRows = [];
         foreach ($rows as $row) {
             $conflict = $this->candidateKeys->findConflict($row, $existingRows);
             if ($conflict !== null) {
                 $existingIndex = $conflict->rowIndex;
                 $updatedRow = $existingRows[$existingIndex];
+                if ($this->updatePredicate !== null
+                    && !$this->updatePredicate->matches($updatedRow, $row, $this->tableName)
+                ) {
+                    continue;
+                }
                 foreach ($this->updateColumns as $col) {
                     if (isset($this->updateValues[$col])) {
-                        $value = $this->updateValues[$col];
-
-                        if (preg_match('/^VALUES\s*\(\s*`?(\w+)`?\s*\)\s*$/i', $value, $m) === 1) {
-                            $refCol = $m[1];
-                            $updatedRow[$col] = $row[$refCol] ?? $updatedRow[$col] ?? null;
-                        } elseif (preg_match('/^EXCLUDED\."?(\w+)"?\s*$/i', $value, $m) === 1) {
-                            $refCol = $m[1];
-                            $updatedRow[$col] = $row[$refCol] ?? $updatedRow[$col] ?? null;
-                        } elseif (preg_match('/^[\'"](.*)[\'"]\s*$/s', $value, $m) === 1) {
-                            $updatedRow[$col] = $m[1];
-                        } else {
-                            $updatedRow[$col] = $value;
-                        }
+                        $updatedRow[$col] = $this->updateValues[$col]->evaluate($updatedRow, $row, $this->tableName);
                     } elseif (isset($row[$col])) {
                         $updatedRow[$col] = $row[$col];
                     }
@@ -103,14 +103,12 @@ final class UpsertMutation implements ShadowMutation
                         }
                     }
                 }
-                $updateRows[$existingIndex] = $updatedRow;
+                $existingRows[$existingIndex] = $updatedRow;
+                $this->resultRows[] = $updatedRow;
             } else {
                 $insertRows[] = $row;
+                $this->resultRows[] = $row;
             }
-        }
-
-        foreach ($updateRows as $index => $updatedRow) {
-            $existingRows[$index] = $updatedRow;
         }
 
         $store->set($this->tableName, $existingRows);
@@ -125,6 +123,12 @@ final class UpsertMutation implements ShadowMutation
     public function tableName(): string
     {
         return $this->tableName;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function resultRows(): array
+    {
+        return $this->resultRows;
     }
 
 }

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -93,6 +93,38 @@ final class SqlTokenStream
     }
 
     /**
+     * @param non-empty-list<string> $anchorKeywords
+     * @param non-empty-list<string> $startKeywords
+     * @param list<non-empty-list<string>> $endKeywords
+     */
+    public function topLevelClauseAfter(
+        array $anchorKeywords,
+        array $startKeywords,
+        array $endKeywords = [],
+    ): ?string {
+        $tokens = $this->significantTokens();
+        $anchor = $this->findKeywordSequence($tokens, $anchorKeywords, 0);
+        if ($anchor === null) {
+            return null;
+        }
+        $start = $this->findKeywordSequence($tokens, $startKeywords, $anchor + count($anchorKeywords));
+        if ($start === null) {
+            return null;
+        }
+
+        $contentStart = $tokens[$start + count($startKeywords) - 1]->endOffset();
+        $contentEnd = strlen($this->sql);
+        foreach ($endKeywords as $sequence) {
+            $candidate = $this->findKeywordSequence($tokens, $sequence, $start + count($startKeywords));
+            if ($candidate !== null) {
+                $contentEnd = min($contentEnd, $tokens[$candidate]->offset);
+            }
+        }
+
+        return trim(substr($this->sql, $contentStart, $contentEnd - $contentStart));
+    }
+
+    /**
      * @return list<string>
      */
     public function splitTopLevel(string $delimiter = ','): array

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MutationImpact;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\Mutation\ReplaceMutation;
+use ZtdQuery\Shadow\Mutation\UpsertExpression;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 
@@ -23,6 +24,7 @@ use ZtdQuery\Shadow\Mutation\UpdateMutation;
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(MutationRowIdentity::class)]
 #[UsesClass(ReplaceMutation::class)]
+#[UsesClass(UpsertExpression::class)]
 #[UsesClass(UpsertMutation::class)]
 #[UsesClass(UpdateMutation::class)]
 final class MutationImpactTest extends TestCase
@@ -129,5 +131,25 @@ final class MutationImpactTest extends TestCase
         );
 
         self::assertSame(3, $impact->affectedRowCount(AffectedRowsMode::Changed));
+    }
+
+    public function testSkippedConditionalUpsertHasNoAffectedOrReturningRows(): void
+    {
+        $row = ['id' => 1, 'name' => 'original', 'score' => 50];
+        $mutation = new UpsertMutation(
+            'items',
+            ['id'],
+            ['name'],
+            ['name' => 'EXCLUDED.name'],
+            updatePredicate: 'score >= 80',
+        );
+        $store = new \ZtdQuery\Shadow\ShadowStore();
+        $store->set('items', [$row]);
+        $input = [['id' => 1, 'name' => 'skipped', 'score' => 95]];
+        $mutation->apply($store, $input);
+        $impact = new MutationImpact($mutation, [$row], $input, $store->get('items'));
+
+        self::assertSame(0, $impact->affectedRowCount(AffectedRowsMode::Matched));
+        self::assertSame([], $impact->returningRows());
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Rewrite\AffectedRowsMode;
+use ZtdQuery\Schema\CandidateKeyConflict;
 use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
@@ -15,10 +16,16 @@ use ZtdQuery\Shadow\Mutation\MutationImpact;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\Mutation\ReplaceMutation;
 use ZtdQuery\Shadow\Mutation\UpsertExpression;
+use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
+use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
+use ZtdQuery\Shadow\ShadowStore;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(MutationImpact::class)]
+#[UsesClass(CandidateKeyConflict::class)]
 #[UsesClass(CandidateKeySet::class)]
 #[UsesClass(DeleteMutation::class)]
 #[UsesClass(InsertMutation::class)]
@@ -27,6 +34,9 @@ use ZtdQuery\Shadow\Mutation\UpdateMutation;
 #[UsesClass(UpsertExpression::class)]
 #[UsesClass(UpsertMutation::class)]
 #[UsesClass(UpdateMutation::class)]
+#[UsesClass(ShadowStore::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
 final class MutationImpactTest extends TestCase
 {
     public function testInsertImpactContainsOnlyRowsActuallyAdded(): void
@@ -85,12 +95,19 @@ final class MutationImpactTest extends TestCase
         self::assertSame([], $impact->returningRows());
     }
 
-    public function testUpsertFallsBackToInputAndIsInsertLike(): void
+    public function testAppliedUpsertReturnsResultRowsAndIsInsertLike(): void
     {
-        $row = ['id' => 1, 'name' => 'updated'];
-        $impact = new MutationImpact(new UpsertMutation('items', ['id']), [$row], [$row], [$row]);
+        $before = ['id' => 1, 'name' => 'same'];
+        $input = $before;
+        $mutation = new UpsertMutation('items', ['id']);
+        $store = new ShadowStore();
+        $store->set('items', [$before]);
+        $mutation->apply($store, [$input]);
+        $impact = new MutationImpact($mutation, [$before], [$input], $store->get('items'));
 
-        self::assertSame([$row], $impact->returningRows());
+        self::assertSame([$input], $impact->returningRows());
+        self::assertSame(1, $impact->affectedRowCount(AffectedRowsMode::Matched));
+        self::assertSame(0, $impact->affectedRowCount(AffectedRowsMode::Changed));
         self::assertTrue($impact->isInsertLike());
     }
 
@@ -140,10 +157,14 @@ final class MutationImpactTest extends TestCase
             'items',
             ['id'],
             ['name'],
-            ['name' => 'EXCLUDED.name'],
-            updatePredicate: 'score >= 80',
+            ['name' => UpsertExpression::column(UpsertColumnSource::Incoming, 'name')],
+            updatePredicate: UpsertExpression::binary(
+                UpsertExpressionKind::GreaterOrEqual,
+                UpsertExpression::column(UpsertColumnSource::Existing, 'score'),
+                UpsertExpression::literal(80),
+            ),
         );
-        $store = new \ZtdQuery\Shadow\ShadowStore();
+        $store = new ShadowStore();
         $store->set('items', [$row]);
         $input = [['id' => 1, 'name' => 'skipped', 'score' => 95]];
         $mutation->apply($store, $input);

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertColumnSourceTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertColumnSourceTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
+
+#[CoversClass(UpsertColumnSource::class)]
+final class UpsertColumnSourceTest extends TestCase
+{
+    public function testListsSemanticColumnSources(): void
+    {
+        self::assertSame(
+            [UpsertColumnSource::Existing, UpsertColumnSource::Incoming],
+            UpsertColumnSource::cases(),
+        );
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionKindTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionKindTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
+
+#[CoversClass(UpsertExpressionKind::class)]
+final class UpsertExpressionKindTest extends TestCase
+{
+    public function testDefinesEveryExpressionKind(): void
+    {
+        self::assertSame([
+            'Literal',
+            'Column',
+            'UnaryPlus',
+            'UnaryMinus',
+            'Not',
+            'Add',
+            'Subtract',
+            'Multiply',
+            'Divide',
+            'Modulo',
+            'Equal',
+            'NotEqual',
+            'Less',
+            'LessOrEqual',
+            'Greater',
+            'GreaterOrEqual',
+            'And',
+            'Or',
+        ], array_column(UpsertExpressionKind::cases(), 'name'));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionTest.php
@@ -41,14 +41,22 @@ final class UpsertExpressionTest extends TestCase
         yield 'multiply' => [UpsertExpressionKind::Multiply, 8, 3, 24];
         yield 'divide' => [UpsertExpressionKind::Divide, 8, 2, 4];
         yield 'modulo' => [UpsertExpressionKind::Modulo, 8, 3, 2];
-        yield 'equal' => [UpsertExpressionKind::Equal, 8, 8, true];
+        yield 'equal' => [UpsertExpressionKind::Equal, 8, 3, false];
+        yield 'equal boundary' => [UpsertExpressionKind::Equal, 8, 8, true];
         yield 'not equal' => [UpsertExpressionKind::NotEqual, 8, 3, true];
+        yield 'not equal boundary' => [UpsertExpressionKind::NotEqual, 8, 8, false];
         yield 'less' => [UpsertExpressionKind::Less, 3, 8, true];
-        yield 'less or equal' => [UpsertExpressionKind::LessOrEqual, 8, 8, true];
+        yield 'less boundary' => [UpsertExpressionKind::Less, 8, 8, false];
+        yield 'less or equal' => [UpsertExpressionKind::LessOrEqual, 8, 3, false];
+        yield 'less or equal boundary' => [UpsertExpressionKind::LessOrEqual, 8, 8, true];
         yield 'greater' => [UpsertExpressionKind::Greater, 8, 3, true];
-        yield 'greater or equal' => [UpsertExpressionKind::GreaterOrEqual, 8, 8, true];
-        yield 'and' => [UpsertExpressionKind::And, true, null, null];
-        yield 'or' => [UpsertExpressionKind::Or, false, true, true];
+        yield 'greater boundary' => [UpsertExpressionKind::Greater, 8, 8, false];
+        yield 'greater or equal' => [UpsertExpressionKind::GreaterOrEqual, 3, 8, false];
+        yield 'greater or equal boundary' => [UpsertExpressionKind::GreaterOrEqual, 8, 8, true];
+        yield 'and left' => [UpsertExpressionKind::And, false, true, false];
+        yield 'and right' => [UpsertExpressionKind::And, true, false, false];
+        yield 'or left' => [UpsertExpressionKind::Or, true, false, true];
+        yield 'or right' => [UpsertExpressionKind::Or, false, true, true];
     }
 
     #[DataProvider('binaryProvider')]
@@ -86,6 +94,143 @@ final class UpsertExpressionTest extends TestCase
         self::assertFalse(UpsertExpression::literal(null)->matches([], [], 'items'));
     }
 
+    public function testEvaluatesNullNumericTextAndCaseInsensitiveColumnBoundaries(): void
+    {
+        self::assertSame(3.5, UpsertExpression::unary(
+            UpsertExpressionKind::UnaryPlus,
+            UpsertExpression::literal('3.5'),
+        )->evaluate([], [], 'items'));
+        self::assertNull(UpsertExpression::unary(
+            UpsertExpressionKind::UnaryMinus,
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+        self::assertNull(UpsertExpression::unary(
+            UpsertExpressionKind::Not,
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+        self::assertSame(
+            7,
+            UpsertExpression::column(UpsertColumnSource::Existing, 'QuAnTiTy')
+                ->evaluate(['quantity' => 7], [], 'items'),
+        );
+        self::assertSame(
+            9,
+            UpsertExpression::column(UpsertColumnSource::Incoming, 'quantity')
+                ->evaluate([], ['quantity' => 9], 'items'),
+        );
+        self::assertTrue(UpsertExpression::binary(
+            UpsertExpressionKind::Less,
+            UpsertExpression::literal('alpha'),
+            UpsertExpression::literal('beta'),
+        )->matches([], [], 'items'));
+        self::assertTrue(UpsertExpression::binary(
+            UpsertExpressionKind::Equal,
+            UpsertExpression::literal('2'),
+            UpsertExpression::literal(2),
+        )->matches([], [], 'items'));
+        self::assertFalse(UpsertExpression::binary(
+            UpsertExpressionKind::Equal,
+            UpsertExpression::literal(true),
+            UpsertExpression::literal(false),
+        )->matches([], [], 'items'));
+        self::assertTrue(UpsertExpression::binary(
+            UpsertExpressionKind::Greater,
+            UpsertExpression::literal(true),
+            UpsertExpression::literal(false),
+        )->matches([], [], 'items'));
+    }
+
+    public function testArithmeticNullAndFloatingPointBoundaries(): void
+    {
+        foreach ([
+            UpsertExpressionKind::Add,
+            UpsertExpressionKind::Subtract,
+            UpsertExpressionKind::Multiply,
+            UpsertExpressionKind::Divide,
+            UpsertExpressionKind::Modulo,
+        ] as $kind) {
+            self::assertNull(UpsertExpression::binary(
+                $kind,
+                UpsertExpression::literal(null),
+                UpsertExpression::literal(2),
+            )->evaluate([], [], 'items'));
+            self::assertNull(UpsertExpression::binary(
+                $kind,
+                UpsertExpression::literal(2),
+                UpsertExpression::literal(null),
+            )->evaluate([], [], 'items'));
+        }
+
+        self::assertSame(3.5, UpsertExpression::binary(
+            UpsertExpressionKind::Add,
+            UpsertExpression::literal('1.5'),
+            UpsertExpression::literal(2.0),
+        )->evaluate([], [], 'items'));
+        self::assertSame(2.5, UpsertExpression::binary(
+            UpsertExpressionKind::Divide,
+            UpsertExpression::literal(5),
+            UpsertExpression::literal(2),
+        )->evaluate([], [], 'items'));
+    }
+
+    public function testThreeValuedBooleanBoundaries(): void
+    {
+        self::assertNull(UpsertExpression::binary(
+            UpsertExpressionKind::And,
+            UpsertExpression::literal(true),
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+        self::assertFalse(UpsertExpression::binary(
+            UpsertExpressionKind::And,
+            UpsertExpression::literal(false),
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+        self::assertNull(UpsertExpression::binary(
+            UpsertExpressionKind::Or,
+            UpsertExpression::literal(false),
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+        self::assertTrue(UpsertExpression::binary(
+            UpsertExpressionKind::Or,
+            UpsertExpression::literal(true),
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+        self::assertNull(UpsertExpression::binary(
+            UpsertExpressionKind::And,
+            UpsertExpression::literal(null),
+            UpsertExpression::literal(true),
+        )->evaluate([], [], 'items'));
+        self::assertNull(UpsertExpression::binary(
+            UpsertExpressionKind::And,
+            UpsertExpression::literal(null),
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+        self::assertNull(UpsertExpression::binary(
+            UpsertExpressionKind::Or,
+            UpsertExpression::literal(null),
+            UpsertExpression::literal(false),
+        )->evaluate([], [], 'items'));
+        self::assertNull(UpsertExpression::binary(
+            UpsertExpressionKind::Or,
+            UpsertExpression::literal(null),
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+    }
+
+    public function testComparisonReturnsNullWhenEitherOperandIsNull(): void
+    {
+        self::assertNull(UpsertExpression::binary(
+            UpsertExpressionKind::Equal,
+            UpsertExpression::literal(null),
+            UpsertExpression::literal(1),
+        )->evaluate([], [], 'items'));
+        self::assertNull(UpsertExpression::binary(
+            UpsertExpressionKind::Equal,
+            UpsertExpression::literal(1),
+            UpsertExpression::literal(null),
+        )->evaluate([], [], 'items'));
+    }
+
     public function testRejectsInvalidTreeShapes(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -102,9 +247,12 @@ final class UpsertExpressionTest extends TestCase
 
     public function testRejectsUnknownColumn(): void
     {
-        $this->expectException(UnsupportedSqlException::class);
-
-        UpsertExpression::column(UpsertColumnSource::Existing, 'missing')->evaluate([], [], 'items');
+        try {
+            UpsertExpression::column(UpsertColumnSource::Existing, 'missing')->evaluate([], [], 'items');
+            self::fail('Unknown UPSERT column must be rejected');
+        } catch (UnsupportedSqlException $exception) {
+            self::assertSame('unknown UPSERT column missing', $exception->getSql());
+        }
     }
 
     public function testRejectsDivisionByZero(): void
@@ -116,5 +264,50 @@ final class UpsertExpressionTest extends TestCase
             UpsertExpression::literal(1),
             UpsertExpression::literal(0),
         )->evaluate([], [], 'items');
+    }
+
+    public function testAcceptsFloatingPointOneAsDivisor(): void
+    {
+        self::assertSame(8.0, UpsertExpression::binary(
+            UpsertExpressionKind::Divide,
+            UpsertExpression::literal(8),
+            UpsertExpression::literal(1.0),
+        )->evaluate([], [], 'items'));
+    }
+
+    public function testRejectsModuloByZero(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        UpsertExpression::binary(
+            UpsertExpressionKind::Modulo,
+            UpsertExpression::literal(1),
+            UpsertExpression::literal(0),
+        )->evaluate([], [], 'items');
+    }
+
+    public function testRejectsNonNumericArithmeticOperand(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        UpsertExpression::binary(
+            UpsertExpressionKind::Add,
+            UpsertExpression::literal('not numeric'),
+            UpsertExpression::literal(1),
+        )->evaluate([], [], 'items');
+    }
+
+    public function testRejectsNumericAndTextComparison(): void
+    {
+        try {
+            UpsertExpression::binary(
+                UpsertExpressionKind::Equal,
+                UpsertExpression::literal(1),
+                UpsertExpression::literal('text'),
+            )->evaluate([], [], 'items');
+            self::fail('Numeric and text operands must not be compared');
+        } catch (UnsupportedSqlException $exception) {
+            self::assertSame('incomparable UPSERT operands', $exception->getSql());
+        }
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionTest.php
@@ -2,72 +2,117 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Shadow\Mutation;
+namespace ZtdQuery\Tests\Unit\Shadow\Mutation;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
 use ZtdQuery\Shadow\Mutation\UpsertExpression;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
 
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
-#[UsesClass(UnsupportedSqlException::class)]
 #[CoversClass(UpsertExpression::class)]
+#[CoversClass(UpsertColumnSource::class)]
 final class UpsertExpressionTest extends TestCase
 {
-    public function testEvaluatesExistingAndIncomingReferencesWithPrecedence(): void
+    public function testEvaluatesTypedExpressionTree(): void
     {
-        $expression = UpsertExpression::parse('items.quantity + VALUES(`quantity`) * 2');
+        $expression = UpsertExpression::binary(
+            UpsertExpressionKind::Add,
+            UpsertExpression::column(UpsertColumnSource::Existing, 'quantity'),
+            UpsertExpression::binary(
+                UpsertExpressionKind::Multiply,
+                UpsertExpression::column(UpsertColumnSource::Incoming, 'quantity'),
+                UpsertExpression::literal(2),
+            ),
+        );
 
-        self::assertSame(110, $expression->evaluate(
-            ['id' => 1, 'quantity' => 100],
-            ['id' => 1, 'quantity' => 5],
-            'items',
-        ));
+        self::assertSame(11, $expression->evaluate(['quantity' => 5], ['quantity' => 3], 'items'));
     }
 
-    public function testEvaluatesExcludedAndUnqualifiedReferences(): void
+    /** @return iterable<string, array{UpsertExpressionKind, mixed, mixed, mixed}> */
+    public static function binaryProvider(): iterable
     {
-        $expression = UpsertExpression::parse('(quantity - excluded.quantity) / 5');
-
-        self::assertSame(19, $expression->evaluate(
-            ['quantity' => '100'],
-            ['quantity' => 5],
-            'items',
-        ));
+        yield 'subtract' => [UpsertExpressionKind::Subtract, 8, 3, 5];
+        yield 'multiply' => [UpsertExpressionKind::Multiply, 8, 3, 24];
+        yield 'divide' => [UpsertExpressionKind::Divide, 8, 2, 4];
+        yield 'modulo' => [UpsertExpressionKind::Modulo, 8, 3, 2];
+        yield 'equal' => [UpsertExpressionKind::Equal, 8, 8, true];
+        yield 'not equal' => [UpsertExpressionKind::NotEqual, 8, 3, true];
+        yield 'less' => [UpsertExpressionKind::Less, 3, 8, true];
+        yield 'less or equal' => [UpsertExpressionKind::LessOrEqual, 8, 8, true];
+        yield 'greater' => [UpsertExpressionKind::Greater, 8, 3, true];
+        yield 'greater or equal' => [UpsertExpressionKind::GreaterOrEqual, 8, 8, true];
+        yield 'and' => [UpsertExpressionKind::And, true, null, null];
+        yield 'or' => [UpsertExpressionKind::Or, false, true, true];
     }
 
-    public function testEvaluatesLiteralsComparisonAndSqlNullLogic(): void
-    {
-        $comparison = UpsertExpression::parse("score >= 80 AND excluded.name <> 'blocked'");
-        $nullArithmetic = UpsertExpression::parse('score + NULL');
+    #[DataProvider('binaryProvider')]
+    public function testEvaluatesBinaryKinds(
+        UpsertExpressionKind $kind,
+        mixed $left,
+        mixed $right,
+        mixed $expected,
+    ): void {
+        $expression = UpsertExpression::binary(
+            $kind,
+            UpsertExpression::literal($left),
+            UpsertExpression::literal($right),
+        );
 
-        self::assertTrue($comparison->evaluate(
-            ['score' => 90],
-            ['name' => 'ready'],
-            'items',
-        ));
-        self::assertNull($nullArithmetic->evaluate(['score' => 90], [], 'items'));
-        self::assertTrue($comparison->matches(['score' => 90], ['name' => 'ready'], 'items'));
-        self::assertFalse($comparison->matches(['score' => null], ['name' => 'ready'], 'items'));
+        self::assertSame($expected, $expression->evaluate([], [], 'items'));
     }
 
-    public function testEvaluatesQuotedIdentifiersAndEscapedStringLiteral(): void
+    public function testEvaluatesUnaryKindsAndMatchesSqlTruth(): void
     {
-        $column = UpsertExpression::parse('"items"."Quantity" + EXCLUDED."Quantity"');
-        $literal = UpsertExpression::parse("'it''s ready'");
-
-        self::assertSame(7, $column->evaluate(['quantity' => 5], ['quantity' => 2], 'items'));
-        self::assertSame("it's ready", $literal->evaluate([], [], 'items'));
+        self::assertSame(
+            -5,
+            UpsertExpression::unary(UpsertExpressionKind::UnaryMinus, UpsertExpression::literal(5))
+                ->evaluate([], [], 'items'),
+        );
+        self::assertSame(
+            5,
+            UpsertExpression::unary(UpsertExpressionKind::UnaryPlus, UpsertExpression::literal('5'))
+                ->evaluate([], [], 'items'),
+        );
+        self::assertFalse(
+            UpsertExpression::unary(UpsertExpressionKind::Not, UpsertExpression::literal(true))
+                ->matches([], [], 'items'),
+        );
+        self::assertFalse(UpsertExpression::literal(null)->matches([], [], 'items'));
     }
 
-    public function testRejectsUnsupportedFunctionsInsteadOfStoringRawSql(): void
+    public function testRejectsInvalidTreeShapes(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        UpsertExpression::unary(UpsertExpressionKind::Add, UpsertExpression::literal(1));
+    }
+
+    public function testRejectsEmptyColumn(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        UpsertExpression::column(UpsertColumnSource::Existing, '');
+    }
+
+    public function testRejectsUnknownColumn(): void
     {
         $this->expectException(UnsupportedSqlException::class);
 
-        UpsertExpression::parse('COALESCE(quantity, 0)');
+        UpsertExpression::column(UpsertColumnSource::Existing, 'missing')->evaluate([], [], 'items');
+    }
+
+    public function testRejectsDivisionByZero(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        UpsertExpression::binary(
+            UpsertExpressionKind::Divide,
+            UpsertExpression::literal(1),
+            UpsertExpression::literal(0),
+        )->evaluate([], [], 'items');
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Shadow\Mutation\UpsertExpression;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+#[UsesClass(UnsupportedSqlException::class)]
+#[CoversClass(UpsertExpression::class)]
+final class UpsertExpressionTest extends TestCase
+{
+    public function testEvaluatesExistingAndIncomingReferencesWithPrecedence(): void
+    {
+        $expression = UpsertExpression::parse('items.quantity + VALUES(`quantity`) * 2');
+
+        self::assertSame(110, $expression->evaluate(
+            ['id' => 1, 'quantity' => 100],
+            ['id' => 1, 'quantity' => 5],
+            'items',
+        ));
+    }
+
+    public function testEvaluatesExcludedAndUnqualifiedReferences(): void
+    {
+        $expression = UpsertExpression::parse('(quantity - excluded.quantity) / 5');
+
+        self::assertSame(19, $expression->evaluate(
+            ['quantity' => '100'],
+            ['quantity' => 5],
+            'items',
+        ));
+    }
+
+    public function testEvaluatesLiteralsComparisonAndSqlNullLogic(): void
+    {
+        $comparison = UpsertExpression::parse("score >= 80 AND excluded.name <> 'blocked'");
+        $nullArithmetic = UpsertExpression::parse('score + NULL');
+
+        self::assertTrue($comparison->evaluate(
+            ['score' => 90],
+            ['name' => 'ready'],
+            'items',
+        ));
+        self::assertNull($nullArithmetic->evaluate(['score' => 90], [], 'items'));
+        self::assertTrue($comparison->matches(['score' => 90], ['name' => 'ready'], 'items'));
+        self::assertFalse($comparison->matches(['score' => null], ['name' => 'ready'], 'items'));
+    }
+
+    public function testEvaluatesQuotedIdentifiersAndEscapedStringLiteral(): void
+    {
+        $column = UpsertExpression::parse('"items"."Quantity" + EXCLUDED."Quantity"');
+        $literal = UpsertExpression::parse("'it''s ready'");
+
+        self::assertSame(7, $column->evaluate(['quantity' => 5], ['quantity' => 2], 'items'));
+        self::assertSame("it's ready", $literal->evaluate([], [], 'items'));
+    }
+
+    public function testRejectsUnsupportedFunctionsInsteadOfStoringRawSql(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        UpsertExpression::parse('COALESCE(quantity, 0)');
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertExpressionTest.php
@@ -7,6 +7,7 @@ namespace ZtdQuery\Tests\Unit\Shadow\Mutation;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
@@ -15,6 +16,7 @@ use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
 
 #[CoversClass(UpsertExpression::class)]
 #[CoversClass(UpsertColumnSource::class)]
+#[UsesClass(\ZtdQuery\Exception\UnsupportedSqlException::class)]
 final class UpsertExpressionTest extends TestCase
 {
     public function testEvaluatesTypedExpressionTree(): void

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertMutationTest.php
@@ -9,6 +9,7 @@ use ZtdQuery\Schema\CandidateKeyConflict;
 use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
+use ZtdQuery\Shadow\Mutation\UpsertExpression;
 use ZtdQuery\Shadow\ShadowStore;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -17,6 +18,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(CandidateKeyConflict::class)]
 #[UsesClass(CandidateKeySet::class)]
 #[UsesClass(TableDefinition::class)]
+#[UsesClass(UpsertExpression::class)]
 #[CoversClass(UpsertMutation::class)]
 final class UpsertMutationTest extends TestCase
 {
@@ -220,5 +222,68 @@ final class UpsertMutationTest extends TestCase
 
         $rows = $store->get('users');
         self::assertSame('Charlie', $rows[0]['name']);
+    }
+
+    public function testApplyAccumulatesExistingAndIncomingValues(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [
+            ['id' => 1, 'quantity' => 100],
+        ]);
+
+        $mutation = new UpsertMutation(
+            'items',
+            ['id'],
+            ['quantity'],
+            ['quantity' => 'items.quantity + VALUES(quantity)'],
+        );
+        $mutation->apply($store, [['id' => 1, 'quantity' => 5]]);
+
+        self::assertSame([['id' => 1, 'quantity' => 105]], $store->get('items'));
+    }
+
+    public function testApplyAccumulatesSequentialConflictsAgainstLatestRow(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [
+            ['id' => 1, 'quantity' => 100],
+        ]);
+
+        $mutation = new UpsertMutation(
+            'items',
+            ['id'],
+            ['quantity'],
+            ['quantity' => 'quantity + EXCLUDED.quantity'],
+        );
+        $mutation->apply($store, [
+            ['id' => 1, 'quantity' => 5],
+            ['id' => 1, 'quantity' => 7],
+        ]);
+
+        self::assertSame([['id' => 1, 'quantity' => 112]], $store->get('items'));
+    }
+
+    public function testApplyUsesConflictPredicateAndReportsOnlyAppliedRows(): void
+    {
+        $store = new ShadowStore();
+        $store->set('items', [
+            ['id' => 1, 'name' => 'original', 'score' => 50],
+        ]);
+        $mutation = new UpsertMutation(
+            'items',
+            ['id'],
+            ['name'],
+            ['name' => 'EXCLUDED.name'],
+            updatePredicate: 'items.score >= 80',
+        );
+
+        $mutation->apply($store, [['id' => 1, 'name' => 'skipped', 'score' => 95]]);
+        self::assertSame([['id' => 1, 'name' => 'original', 'score' => 50]], $store->get('items'));
+        self::assertSame([], $mutation->resultRows());
+
+        $store->set('items', [['id' => 1, 'name' => 'original', 'score' => 85]]);
+        $mutation->apply($store, [['id' => 1, 'name' => 'updated', 'score' => 95]]);
+        self::assertSame([['id' => 1, 'name' => 'updated', 'score' => 85]], $store->get('items'));
+        self::assertSame([['id' => 1, 'name' => 'updated', 'score' => 85]], $mutation->resultRows());
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertMutationTest.php
@@ -9,7 +9,9 @@ use ZtdQuery\Schema\CandidateKeyConflict;
 use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
+use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
 use ZtdQuery\Shadow\Mutation\UpsertExpression;
+use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
 use ZtdQuery\Shadow\ShadowStore;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -52,6 +54,38 @@ final class UpsertMutationTest extends TestCase
         self::assertSame(11, $rows[0]['visits']);
     }
 
+    public function testSkippedConditionalRowDoesNotStopFollowingRows(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [
+            ['id' => 1, 'name' => 'first', 'score' => 10],
+        ]);
+        $mutation = new UpsertMutation(
+            'users',
+            ['id'],
+            ['name'],
+            ['name' => UpsertExpression::column(UpsertColumnSource::Incoming, 'name')],
+            updatePredicate: UpsertExpression::binary(
+                UpsertExpressionKind::GreaterOrEqual,
+                UpsertExpression::column(UpsertColumnSource::Existing, 'score'),
+                UpsertExpression::literal(80),
+            ),
+        );
+
+        $mutation->apply($store, [
+            ['id' => 1, 'name' => 'skipped', 'score' => 20],
+            ['id' => 2, 'name' => 'inserted', 'score' => 90],
+        ]);
+
+        self::assertSame([
+            ['id' => 1, 'name' => 'first', 'score' => 10],
+            ['id' => 2, 'name' => 'inserted', 'score' => 90],
+        ], $store->get('users'));
+        self::assertSame([
+            ['id' => 2, 'name' => 'inserted', 'score' => 90],
+        ], $mutation->resultRows());
+    }
+
     public function testApplyUpdatesExistingRowOnUniqueKeyConflict(): void
     {
         $definition = new TableDefinition(
@@ -68,7 +102,7 @@ final class UpsertMutationTest extends TestCase
             'users',
             ['id'],
             ['name'],
-            ['name' => 'EXCLUDED.name'],
+            ['name' => UpsertExpression::column(UpsertColumnSource::Incoming, 'name')],
             $definition->candidateKeys(),
         );
         $mutation->apply($store, [['id' => 2, 'email' => 'alice@example.com', 'name' => 'Updated']]);
@@ -96,7 +130,7 @@ final class UpsertMutationTest extends TestCase
             'users',
             ['id'],
             ['visits'],
-            ['visits' => 'VALUES(`visits`)']
+            ['visits' => UpsertExpression::column(UpsertColumnSource::Incoming, 'visits')]
         );
         $mutation->apply($store, [['id' => 1, 'name' => 'Alice', 'visits' => 15]]);
 
@@ -115,7 +149,7 @@ final class UpsertMutationTest extends TestCase
             'users',
             ['id'],
             ['status'],
-            ['status' => "'updated'"]
+            ['status' => UpsertExpression::literal('updated')]
         );
         $mutation->apply($store, [['id' => 1, 'name' => 'Alice', 'status' => 'ignored']]);
 
@@ -197,7 +231,7 @@ final class UpsertMutationTest extends TestCase
             'users',
             ['id'],
             ['name'],
-            ['name' => 'EXCLUDED.name']
+            ['name' => UpsertExpression::column(UpsertColumnSource::Incoming, 'name')]
         );
         $mutation->apply($store, [['id' => 1, 'name' => 'Bob', 'visits' => 15]]);
 
@@ -216,7 +250,7 @@ final class UpsertMutationTest extends TestCase
             'users',
             ['id'],
             ['name'],
-            ['name' => 'EXCLUDED."name"']
+            ['name' => UpsertExpression::column(UpsertColumnSource::Incoming, 'name')]
         );
         $mutation->apply($store, [['id' => 1, 'name' => 'Charlie']]);
 
@@ -235,7 +269,11 @@ final class UpsertMutationTest extends TestCase
             'items',
             ['id'],
             ['quantity'],
-            ['quantity' => 'items.quantity + VALUES(quantity)'],
+            ['quantity' => UpsertExpression::binary(
+                UpsertExpressionKind::Add,
+                UpsertExpression::column(UpsertColumnSource::Existing, 'quantity'),
+                UpsertExpression::column(UpsertColumnSource::Incoming, 'quantity'),
+            )],
         );
         $mutation->apply($store, [['id' => 1, 'quantity' => 5]]);
 
@@ -253,7 +291,11 @@ final class UpsertMutationTest extends TestCase
             'items',
             ['id'],
             ['quantity'],
-            ['quantity' => 'quantity + EXCLUDED.quantity'],
+            ['quantity' => UpsertExpression::binary(
+                UpsertExpressionKind::Add,
+                UpsertExpression::column(UpsertColumnSource::Existing, 'quantity'),
+                UpsertExpression::column(UpsertColumnSource::Incoming, 'quantity'),
+            )],
         );
         $mutation->apply($store, [
             ['id' => 1, 'quantity' => 5],
@@ -273,8 +315,12 @@ final class UpsertMutationTest extends TestCase
             'items',
             ['id'],
             ['name'],
-            ['name' => 'EXCLUDED.name'],
-            updatePredicate: 'items.score >= 80',
+            ['name' => UpsertExpression::column(UpsertColumnSource::Incoming, 'name')],
+            updatePredicate: UpsertExpression::binary(
+                UpsertExpressionKind::GreaterOrEqual,
+                UpsertExpression::column(UpsertColumnSource::Existing, 'score'),
+                UpsertExpression::literal(80),
+            ),
         );
 
         $mutation->apply($store, [['id' => 1, 'name' => 'skipped', 'score' => 95]]);

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -71,6 +71,20 @@ final class SqlTokenStreamTest extends TestCase
         self::assertSame('', SqlTokenStream::tokenize('SET')->topLevelClause(['SET']));
     }
 
+    public function testClauseAfterAnchorSkipsEarlierMatchingKeyword(): void
+    {
+        $sql = 'INSERT INTO items SELECT * FROM source WHERE active ON CONFLICT (id) DO UPDATE SET score = excluded.score WHERE items.score >= 80 RETURNING id';
+
+        self::assertSame(
+            'items.score >= 80',
+            SqlTokenStream::tokenize($sql)->topLevelClauseAfter(
+                ['DO', 'UPDATE', 'SET'],
+                ['WHERE'],
+                [['RETURNING']],
+            ),
+        );
+    }
+
     public function testSplitsCommasOutsideParenthesesArraysAndStrings(): void
     {
         $stream = SqlTokenStream::tokenize("ARRAY[1,2], COALESCE(a, b), 'x,y', plain");

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -85,6 +85,18 @@ final class SqlTokenStreamTest extends TestCase
         );
     }
 
+    public function testClauseAfterAnchorCanBeginAtFirstToken(): void
+    {
+        self::assertSame(
+            'earlier',
+            SqlTokenStream::tokenize('DO UPDATE SET WHERE earlier WHERE later')->topLevelClauseAfter(
+                ['DO', 'UPDATE', 'SET'],
+                ['WHERE'],
+                [['WHERE']],
+            ),
+        );
+    }
+
     public function testSplitsCommasOutsideParenthesesArraysAndStrings(): void
     {
         $stream = SqlTokenStream::tokenize("ARRAY[1,2], COALESCE(a, b), 'x,y', plain");

--- a/packages/ztd-query-mysql/src/MySqlMutationResolver.php
+++ b/packages/ztd-query-mysql/src/MySqlMutationResolver.php
@@ -214,8 +214,9 @@ final class MySqlMutationResolver
         }
 
         $updateColumns = [];
-        /** @var array<string, string> $updateValues */
+        /** @var array<string, \ZtdQuery\Shadow\Mutation\UpsertExpression> $updateValues */
         $updateValues = [];
+        $expressionParser = new MySqlUpsertExpressionParser();
         if ($statement->onDuplicateSet !== null && $statement->onDuplicateSet !== []) {
             foreach ($statement->onDuplicateSet as $set) {
                 $colName = trim($set->column, '`"\'');
@@ -224,7 +225,7 @@ final class MySqlMutationResolver
                     $colName = trim(end($parts), '`"\'');
                 }
                 $updateColumns[] = $colName;
-                $updateValues[$colName] = $set->value;
+                $updateValues[$colName] = $expressionParser->parse($set->value, $tableName);
             }
         }
         $isOnDuplicateKeyUpdate = $updateColumns !== [];

--- a/packages/ztd-query-mysql/src/MySqlUpsertExpressionParser.php
+++ b/packages/ztd-query-mysql/src/MySqlUpsertExpressionParser.php
@@ -20,7 +20,7 @@ final class MySqlUpsertExpressionParser
         $tokens = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->significantTokens();
         $index = 0;
         $expression = $this->parseOr($sql, $tableName, $incomingAlias, $tokens, $index);
-        if (isset($tokens[$index])) {
+        if ($index !== count($tokens)) {
             throw $this->unsupported($sql);
         }
 
@@ -224,10 +224,11 @@ final class MySqlUpsertExpressionParser
 
         $identifier = $this->identifier($token);
         $index++;
-        if (strcasecmp($identifier, 'VALUES') === 0
-            && isset($tokens[$index])
-            && $this->isSymbol($tokens[$index], ['('])
-        ) {
+        if (strcasecmp($identifier, 'VALUES') === 0) {
+            if (!isset($tokens[$index]) || !$this->isSymbol($tokens[$index], ['('])) {
+                throw $this->unsupported($sql);
+            }
+
             return $this->parseValuesReference($sql, $tokens, $index);
         }
         if (isset($tokens[$index]) && $this->isSymbol($tokens[$index], ['.'])) {

--- a/packages/ztd-query-mysql/src/MySqlUpsertExpressionParser.php
+++ b/packages/ztd-query-mysql/src/MySqlUpsertExpressionParser.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
+use ZtdQuery\Shadow\Mutation\UpsertExpression;
+use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class MySqlUpsertExpressionParser
+{
+    public function parse(string $sql, string $tableName, ?string $incomingAlias = null): UpsertExpression
+    {
+        $tokens = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->significantTokens();
+        $index = 0;
+        $expression = $this->parseOr($sql, $tableName, $incomingAlias, $tokens, $index);
+        if (isset($tokens[$index])) {
+            throw $this->unsupported($sql);
+        }
+
+        return $expression;
+    }
+
+    public function parseIfSupported(string $sql, string $tableName, ?string $incomingAlias = null): ?UpsertExpression
+    {
+        try {
+            return $this->parse($sql, $tableName, $incomingAlias);
+        } catch (UnsupportedSqlException) {
+            return null;
+        }
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function parseOr(
+        string $sql,
+        string $tableName,
+        ?string $incomingAlias,
+        array $tokens,
+        int &$index,
+    ): UpsertExpression {
+        $left = $this->parseAnd($sql, $tableName, $incomingAlias, $tokens, $index);
+        while (($tokens[$index] ?? null)?->isKeyword('OR') === true) {
+            $index++;
+            $left = UpsertExpression::binary(
+                UpsertExpressionKind::Or,
+                $left,
+                $this->parseAnd($sql, $tableName, $incomingAlias, $tokens, $index),
+            );
+        }
+
+        return $left;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function parseAnd(
+        string $sql,
+        string $tableName,
+        ?string $incomingAlias,
+        array $tokens,
+        int &$index,
+    ): UpsertExpression {
+        $left = $this->parseComparison($sql, $tableName, $incomingAlias, $tokens, $index);
+        while (($tokens[$index] ?? null)?->isKeyword('AND') === true) {
+            $index++;
+            $left = UpsertExpression::binary(
+                UpsertExpressionKind::And,
+                $left,
+                $this->parseComparison($sql, $tableName, $incomingAlias, $tokens, $index),
+            );
+        }
+
+        return $left;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function parseComparison(
+        string $sql,
+        string $tableName,
+        ?string $incomingAlias,
+        array $tokens,
+        int &$index,
+    ): UpsertExpression {
+        $left = $this->parseAdditive($sql, $tableName, $incomingAlias, $tokens, $index);
+        $operator = $this->comparisonOperator($sql, $tokens, $index);
+        if ($operator === null) {
+            return $left;
+        }
+
+        return UpsertExpression::binary(
+            $operator,
+            $left,
+            $this->parseAdditive($sql, $tableName, $incomingAlias, $tokens, $index),
+        );
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function parseAdditive(
+        string $sql,
+        string $tableName,
+        ?string $incomingAlias,
+        array $tokens,
+        int &$index,
+    ): UpsertExpression {
+        $left = $this->parseMultiplicative($sql, $tableName, $incomingAlias, $tokens, $index);
+        while (isset($tokens[$index]) && $this->isSymbol($tokens[$index], ['+', '-'])) {
+            $operator = $tokens[$index]->text;
+            $index++;
+            $kind = $operator === '+' ? UpsertExpressionKind::Add : UpsertExpressionKind::Subtract;
+            $left = UpsertExpression::binary(
+                $kind,
+                $left,
+                $this->parseMultiplicative($sql, $tableName, $incomingAlias, $tokens, $index),
+            );
+        }
+
+        return $left;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function parseMultiplicative(
+        string $sql,
+        string $tableName,
+        ?string $incomingAlias,
+        array $tokens,
+        int &$index,
+    ): UpsertExpression {
+        $left = $this->parseUnary($sql, $tableName, $incomingAlias, $tokens, $index);
+        while (isset($tokens[$index]) && $this->isSymbol($tokens[$index], ['*', '/', '%'])) {
+            $operator = $tokens[$index]->text;
+            $index++;
+            $kind = $operator === '*'
+                ? UpsertExpressionKind::Multiply
+                : ($operator === '/' ? UpsertExpressionKind::Divide : UpsertExpressionKind::Modulo);
+            $left = UpsertExpression::binary(
+                $kind,
+                $left,
+                $this->parseUnary($sql, $tableName, $incomingAlias, $tokens, $index),
+            );
+        }
+
+        return $left;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function parseUnary(
+        string $sql,
+        string $tableName,
+        ?string $incomingAlias,
+        array $tokens,
+        int &$index,
+    ): UpsertExpression {
+        $token = $tokens[$index] ?? null;
+        if ($token?->isKeyword('NOT') === true) {
+            $index++;
+
+            return UpsertExpression::unary(
+                UpsertExpressionKind::Not,
+                $this->parseUnary($sql, $tableName, $incomingAlias, $tokens, $index),
+            );
+        }
+        if ($token !== null && $this->isSymbol($token, ['+', '-'])) {
+            $index++;
+
+            return UpsertExpression::unary(
+                $token->text === '+' ? UpsertExpressionKind::UnaryPlus : UpsertExpressionKind::UnaryMinus,
+                $this->parseUnary($sql, $tableName, $incomingAlias, $tokens, $index),
+            );
+        }
+
+        return $this->parsePrimary($sql, $tableName, $incomingAlias, $tokens, $index);
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function parsePrimary(
+        string $sql,
+        string $tableName,
+        ?string $incomingAlias,
+        array $tokens,
+        int &$index,
+    ): UpsertExpression {
+        $token = $tokens[$index] ?? null;
+        if ($token === null) {
+            throw $this->unsupported($sql);
+        }
+        if ($this->isSymbol($token, ['('])) {
+            $index++;
+            $expression = $this->parseOr($sql, $tableName, $incomingAlias, $tokens, $index);
+            if (!isset($tokens[$index]) || !$this->isSymbol($tokens[$index], [')'])) {
+                throw $this->unsupported($sql);
+            }
+            $index++;
+
+            return $expression;
+        }
+        if ($token->kind === SqlTokenKind::Number) {
+            $index++;
+
+            return UpsertExpression::literal($this->number($token->text));
+        }
+        if ($token->kind === SqlTokenKind::String) {
+            $index++;
+
+            return UpsertExpression::literal($this->string($token->text));
+        }
+        if ($token->isKeyword('NULL')) {
+            $index++;
+
+            return UpsertExpression::literal(null);
+        }
+        if ($token->isKeyword('TRUE') || $token->isKeyword('FALSE')) {
+            $index++;
+
+            return UpsertExpression::literal($token->isKeyword('TRUE'));
+        }
+        if (!$this->isIdentifier($token)) {
+            throw $this->unsupported($sql);
+        }
+
+        $identifier = $this->identifier($token);
+        $index++;
+        if (strcasecmp($identifier, 'VALUES') === 0
+            && isset($tokens[$index])
+            && $this->isSymbol($tokens[$index], ['('])
+        ) {
+            return $this->parseValuesReference($sql, $tokens, $index);
+        }
+        if (isset($tokens[$index]) && $this->isSymbol($tokens[$index], ['.'])) {
+            $index++;
+            $column = $tokens[$index] ?? null;
+            if ($column === null || !$this->isIdentifier($column)) {
+                throw $this->unsupported($sql);
+            }
+            $index++;
+
+            return UpsertExpression::column(
+                $this->columnSource($sql, $identifier, $tableName, $incomingAlias),
+                $this->identifier($column),
+            );
+        }
+
+        return UpsertExpression::column(UpsertColumnSource::Existing, $identifier);
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function parseValuesReference(string $sql, array $tokens, int &$index): UpsertExpression
+    {
+        $index++;
+        $column = $tokens[$index] ?? null;
+        if ($column === null || !$this->isIdentifier($column)) {
+            throw $this->unsupported($sql);
+        }
+        $index++;
+        if (!isset($tokens[$index]) || !$this->isSymbol($tokens[$index], [')'])) {
+            throw $this->unsupported($sql);
+        }
+        $index++;
+
+        return UpsertExpression::column(UpsertColumnSource::Incoming, $this->identifier($column));
+    }
+
+    private function columnSource(
+        string $sql,
+        string $qualifier,
+        string $tableName,
+        ?string $incomingAlias,
+    ): UpsertColumnSource {
+        if ($incomingAlias !== null && strcasecmp($qualifier, $incomingAlias) === 0) {
+            return UpsertColumnSource::Incoming;
+        }
+        if (strcasecmp($qualifier, $tableName) === 0) {
+            return UpsertColumnSource::Existing;
+        }
+
+        throw $this->unsupported($sql);
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function comparisonOperator(string $sql, array $tokens, int &$index): ?UpsertExpressionKind
+    {
+        $first = $tokens[$index] ?? null;
+        if ($first === null || !$this->isSymbol($first, ['=', '!', '<', '>'])) {
+            return null;
+        }
+        $operator = $first->text;
+        $second = $tokens[$index + 1] ?? null;
+        if ($second !== null && $this->isSymbol($second, ['=', '>']) && $operator !== '=') {
+            $operator .= $second->text;
+            $index++;
+        }
+        $index++;
+
+        return match ($operator) {
+            '=' => UpsertExpressionKind::Equal,
+            '!=', '<>' => UpsertExpressionKind::NotEqual,
+            '<' => UpsertExpressionKind::Less,
+            '<=' => UpsertExpressionKind::LessOrEqual,
+            '>' => UpsertExpressionKind::Greater,
+            '>=' => UpsertExpressionKind::GreaterOrEqual,
+            default => throw $this->unsupported($sql),
+        };
+    }
+
+    /** @param list<string> $symbols */
+    private function isSymbol(SqlToken $token, array $symbols): bool
+    {
+        return $token->kind === SqlTokenKind::Symbol && in_array($token->text, $symbols, true);
+    }
+
+    private function isIdentifier(SqlToken $token): bool
+    {
+        return $token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier;
+    }
+
+    private function identifier(SqlToken $token): string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+        $quote = $token->text[0] ?? '';
+        $inner = substr($token->text, 1, -1);
+
+        return str_replace($quote . $quote, $quote, $inner);
+    }
+
+    private function number(string $literal): int|float
+    {
+        $literal = str_replace('_', '', $literal);
+        if (str_starts_with(strtolower($literal), '0x')) {
+            return intval($literal, 16);
+        }
+
+        return strpbrk($literal, '.eE') === false ? (int) $literal : (float) $literal;
+    }
+
+    private function string(string $literal): string
+    {
+        $inner = substr($literal, 1, -1);
+
+        return str_replace(["''", "\\'", '\\\\'], ["'", "'", '\\'], $inner);
+    }
+
+    private function unsupported(string $sql): UnsupportedSqlException
+    {
+        return new UnsupportedSqlException($sql, 'Unsupported UPSERT expression');
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlUpsertExpressionParser.php
+++ b/packages/ztd-query-mysql/src/MySqlUpsertExpressionParser.php
@@ -331,8 +331,10 @@ final class MySqlUpsertExpressionParser
 
     private function number(string $literal): int|float
     {
-        $literal = str_replace('_', '', $literal);
-        if (str_starts_with(strtolower($literal), '0x')) {
+        if (preg_match('/^(?:0x[0-9A-Fa-f]+|(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)\z/', $literal) !== 1) {
+            throw $this->unsupported($literal);
+        }
+        if (str_starts_with($literal, '0x')) {
             return intval($literal, 16);
         }
 

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -38,6 +38,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[CoversClass(MySqlMutationResolver::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -40,6 +40,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[CoversClass(MySqlRewriter::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlMutationResolver::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(MySqlQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTransactionStatementParser::class)]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlUpsertExpressionParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlUpsertExpressionParserTest.php
@@ -45,9 +45,7 @@ final class MySqlUpsertExpressionParserTest extends TestCase
         yield 'parenthesized precedence' => ['(1 + 2) * 3', 9];
         yield 'null' => ['NULL', null];
         yield 'false' => ['FALSE', false];
-        yield 'underscored integer' => ['1_000', 1000];
         yield 'hex integer' => ['0x10', 16];
-        yield 'uppercase hex prefix' => ['0X10', 16];
         yield 'exponent' => ['1.5e1', 15.0];
         yield 'escaped string' => ["'it''s'", "it's"];
     }
@@ -124,6 +122,8 @@ final class MySqlUpsertExpressionParserTest extends TestCase
         yield 'invalid qualified column' => ['items.+'];
         yield 'invalid comparison pair' => ['1 ! 2'];
         yield 'double equals' => ['1 == 1'];
+        yield 'numeric underscore' => ['1_000'];
+        yield 'uppercase hex prefix' => ['0X10'];
         yield 'unknown qualifier' => ['other.value'];
         yield 'empty values' => ['VALUES()'];
         yield 'values without parenthesis' => ['VALUES + 1'];

--- a/packages/ztd-query-mysql/tests/Unit/MySqlUpsertExpressionParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlUpsertExpressionParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\MySql\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser;
@@ -13,6 +14,44 @@ use ZtdQuery\Shadow\Mutation\UpsertExpression;
 #[CoversClass(MySqlUpsertExpressionParser::class)]
 final class MySqlUpsertExpressionParserTest extends TestCase
 {
+    #[DataProvider('providerMySqlExpressionCases')]
+    public function testParsesMySqlExpressionCases(string $sql, mixed $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new MySqlUpsertExpressionParser())->parse($sql, 'items')->evaluate([], [], 'items'),
+        );
+    }
+
+    /** @return iterable<string, array{string, mixed}> */
+    public static function providerMySqlExpressionCases(): iterable
+    {
+        yield 'chained or' => ['1 OR 0 OR 0', true];
+        yield 'chained and' => ['1 AND 1 AND 0', false];
+        yield 'equal' => ['1 = 2', false];
+        yield 'bang not equal' => ['1 != 2', true];
+        yield 'angle not equal' => ['1 <> 2', true];
+        yield 'less' => ['1 < 2', true];
+        yield 'less or equal' => ['1 <= 2', true];
+        yield 'greater' => ['2 > 1', true];
+        yield 'greater or equal' => ['2 >= 1', true];
+        yield 'chained additive' => ['10 - 3 + 2', 9];
+        yield 'chained multiplicative' => ['20 / 5 % 3 * 2', 2];
+        yield 'nested unary minus' => ['- -2', 2];
+        yield 'nested unary plus' => ['+ +2', 2];
+        yield 'unary minus' => ['-2', -2];
+        yield 'unary plus' => ['+2', 2];
+        yield 'nested not' => ['NOT NOT TRUE', true];
+        yield 'parenthesized precedence' => ['(1 + 2) * 3', 9];
+        yield 'null' => ['NULL', null];
+        yield 'false' => ['FALSE', false];
+        yield 'underscored integer' => ['1_000', 1000];
+        yield 'hex integer' => ['0x10', 16];
+        yield 'uppercase hex prefix' => ['0X10', 16];
+        yield 'exponent' => ['1.5e1', 15.0];
+        yield 'escaped string' => ["'it''s'", "it's"];
+    }
+
     public function testParsesValuesAndExistingTableReferences(): void
     {
         $expression = (new MySqlUpsertExpressionParser())->parse(
@@ -28,6 +67,20 @@ final class MySqlUpsertExpressionParserTest extends TestCase
         $expression = (new MySqlUpsertExpressionParser())->parse('new_row.quantity + 1', 'items', 'new_row');
 
         self::assertSame(4, $expression->evaluate(['quantity' => 5], ['quantity' => 3], 'items'));
+    }
+
+    public function testUnescapesQuotedIdentifiersAndMySqlStrings(): void
+    {
+        $expression = (new MySqlUpsertExpressionParser())->parse(
+            "`it``ems`.`quan``tity` + VALUES(`quan``tity`)",
+            'it`ems',
+        );
+
+        self::assertSame(8, $expression->evaluate(['quan`tity' => 5], ['quan`tity' => 3], 'it`ems'));
+        self::assertSame(
+            "a'b\\c",
+            (new MySqlUpsertExpressionParser())->parse("'a\\'b\\\\c'", 'items')->evaluate([], [], 'items'),
+        );
     }
 
     public function testParsesLiteralsPredicatesAndUnaryOperators(): void
@@ -50,5 +103,33 @@ final class MySqlUpsertExpressionParserTest extends TestCase
         $this->expectException(UnsupportedSqlException::class);
 
         (new MySqlUpsertExpressionParser())->parse('EXCLUDED.quantity', 'items');
+    }
+
+    #[DataProvider('providerInvalidMySqlExpression')]
+    public function testRejectsInvalidMySqlExpression(string $sql): void
+    {
+        self::assertNull((new MySqlUpsertExpressionParser())->parseIfSupported($sql, 'items'));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function providerInvalidMySqlExpression(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'missing close parenthesis' => ['(1 + 2'];
+        yield 'wrong close parenthesis' => ['(1 + 2 value'];
+        yield 'extra close parenthesis' => ['1 + 2)'];
+        yield 'missing additive operand' => ['1 +'];
+        yield 'missing comparison operand' => ['1 ='];
+        yield 'missing qualified column' => ['items.'];
+        yield 'invalid qualified column' => ['items.+'];
+        yield 'invalid comparison pair' => ['1 ! 2'];
+        yield 'double equals' => ['1 == 1'];
+        yield 'unknown qualifier' => ['other.value'];
+        yield 'empty values' => ['VALUES()'];
+        yield 'values without parenthesis' => ['VALUES + 1'];
+        yield 'values with wrong opening token' => ['VALUES ignored quantity )'];
+        yield 'unclosed values' => ['VALUES(value'];
+        yield 'values with wrong closing token' => ['VALUES(value extra'];
+        yield 'non-identifier values' => ['VALUES(1)'];
     }
 }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlUpsertExpressionParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlUpsertExpressionParserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser;
+use ZtdQuery\Shadow\Mutation\UpsertExpression;
+
+#[CoversClass(MySqlUpsertExpressionParser::class)]
+final class MySqlUpsertExpressionParserTest extends TestCase
+{
+    public function testParsesValuesAndExistingTableReferences(): void
+    {
+        $expression = (new MySqlUpsertExpressionParser())->parse(
+            'items.quantity + VALUES(`quantity`) * 2',
+            'items',
+        );
+
+        self::assertSame(11, $expression->evaluate(['quantity' => 5], ['quantity' => 3], 'items'));
+    }
+
+    public function testParsesMySqlIncomingRowAlias(): void
+    {
+        $expression = (new MySqlUpsertExpressionParser())->parse('new_row.quantity + 1', 'items', 'new_row');
+
+        self::assertSame(4, $expression->evaluate(['quantity' => 5], ['quantity' => 3], 'items'));
+    }
+
+    public function testParsesLiteralsPredicatesAndUnaryOperators(): void
+    {
+        $expression = (new MySqlUpsertExpressionParser())->parse(
+            "NOT (score >= 80 AND VALUES(name) <> 'blocked')",
+            'items',
+        );
+
+        self::assertTrue($expression->matches(['score' => 70], ['name' => 'ready'], 'items'));
+    }
+
+    public function testReturnsNullForUnsupportedFunction(): void
+    {
+        self::assertNull((new MySqlUpsertExpressionParser())->parseIfSupported('COALESCE(score, 0)', 'items'));
+    }
+
+    public function testRejectsPostgreSqlIncomingQualifier(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        (new MySqlUpsertExpressionParser())->parse('EXCLUDED.quantity', 'items');
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -20,6 +20,34 @@ use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
 #[Large]
 final class MysqliCteShadowingTest extends TestCase
 {
+    public function testSelfReferencingUpsertMatchesNativeMySql(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $nativeTable = 'prefix_' . bin2hex(random_bytes(8));
+        $shadowTable = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, quantity INT NOT NULL)', $nativeTable));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, quantity INT NOT NULL)', $shadowTable));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $rawMysqli->query(sprintf('INSERT INTO `%s` VALUES (1, 100)', $nativeTable));
+            $ztdMysqli->query(sprintf('INSERT INTO `%s` VALUES (1, 100)', $shadowTable));
+            $rawMysqli->query(sprintf('INSERT INTO `%1$s` VALUES (1, 5), (1, 7) ON DUPLICATE KEY UPDATE quantity = `%1$s`.quantity + VALUES(quantity)', $nativeTable));
+            $ztdMysqli->query(sprintf('INSERT INTO `%1$s` VALUES (1, 5), (1, 7) ON DUPLICATE KEY UPDATE quantity = `%1$s`.quantity + VALUES(quantity)', $shadowTable));
+
+            $rawRows = $rawMysqli->query(sprintf('SELECT id, quantity FROM `%s`', $nativeTable));
+            $ztdRows = $ztdMysqli->query(sprintf('SELECT id, quantity FROM `%s`', $shadowTable));
+            $physicalShadowRows = $rawMysqli->query(sprintf('SELECT * FROM `%s`', $shadowTable));
+            self::assertInstanceOf(\mysqli_result::class, $rawRows);
+            self::assertInstanceOf(\mysqli_result::class, $ztdRows);
+            self::assertInstanceOf(\mysqli_result::class, $physicalShadowRows);
+            self::assertEquals($rawRows->fetch_all(MYSQLI_ASSOC), $ztdRows->fetch_all(MYSQLI_ASSOC));
+            self::assertSame([], $physicalShadowRows->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testAffectedRowsCountsOnlyChangedMySqlRows(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/InsertOnConflictTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/InsertOnConflictTest.php
@@ -82,4 +82,35 @@ final class InsertOnConflictTest extends TestCase
             $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
         }
     }
+
+    public function testConditionalOnConflictAndReturningMatchPostgres(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $nativeTable = 'prefix_' . bin2hex(random_bytes(8));
+        $shadowTable = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$nativeTable} (id INTEGER PRIMARY KEY, name TEXT, score INTEGER)");
+            $rawPdo->exec("CREATE TABLE {$shadowTable} (id INTEGER PRIMARY KEY, name TEXT, score INTEGER)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $rawPdo->exec("INSERT INTO {$nativeTable} VALUES (1, 'original', 50)");
+            $ztdPdo->exec("INSERT INTO {$shadowTable} VALUES (1, 'original', 50)");
+
+            $rawSkipped = $rawPdo->query("INSERT INTO {$nativeTable} VALUES (1, 'skipped', 95) ON CONFLICT(id) DO UPDATE SET name = EXCLUDED.name WHERE {$nativeTable}.score >= 80 RETURNING id, name, score");
+            $ztdSkipped = $ztdPdo->query("INSERT INTO {$shadowTable} VALUES (1, 'skipped', 95) ON CONFLICT(id) DO UPDATE SET name = EXCLUDED.name WHERE {$shadowTable}.score >= 80 RETURNING id, name, score");
+            self::assertNotFalse($rawSkipped);
+            self::assertNotFalse($ztdSkipped);
+            self::assertSame($rawSkipped->fetchAll(), $ztdSkipped->fetchAll());
+
+            $rawPdo->exec("UPDATE {$nativeTable} SET score = 85 WHERE id = 1");
+            $ztdPdo->exec("UPDATE {$shadowTable} SET score = 85 WHERE id = 1");
+            $rawUpdated = $rawPdo->query("INSERT INTO {$nativeTable} VALUES (1, 'updated', 95) ON CONFLICT(id) DO UPDATE SET name = EXCLUDED.name WHERE {$nativeTable}.score >= 80 RETURNING id, name, score");
+            $ztdUpdated = $ztdPdo->query("INSERT INTO {$shadowTable} VALUES (1, 'updated', 95) ON CONFLICT(id) DO UPDATE SET name = EXCLUDED.name WHERE {$shadowTable}.score >= 80 RETURNING id, name, score");
+            self::assertNotFalse($rawUpdated);
+            self::assertNotFalse($ztdUpdated);
+            self::assertSame($rawUpdated->fetchAll(), $ztdUpdated->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpsertExpressionTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpsertExpressionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_sqlite
+ */
+#[CoversNothing]
+#[Large]
+final class UpsertExpressionTest extends TestCase
+{
+    public function testSelfReferencingUpsertMatchesNativeSqlite(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE native_items (id INTEGER PRIMARY KEY, quantity INTEGER NOT NULL)');
+        $rawPdo->exec('CREATE TABLE shadow_items (id INTEGER PRIMARY KEY, quantity INTEGER NOT NULL)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        $rawPdo->exec('INSERT INTO native_items VALUES (1, 100)');
+        $ztdPdo->exec('INSERT INTO shadow_items VALUES (1, 100)');
+        $rawPdo->exec('INSERT INTO native_items VALUES (1, 5), (1, 7) ON CONFLICT(id) DO UPDATE SET quantity = native_items.quantity + excluded.quantity');
+        $ztdPdo->exec('INSERT INTO shadow_items VALUES (1, 5), (1, 7) ON CONFLICT(id) DO UPDATE SET quantity = shadow_items.quantity + excluded.quantity');
+
+        $rawStatement = $rawPdo->query('SELECT id, quantity FROM native_items');
+        $ztdStatement = $ztdPdo->query('SELECT id, quantity FROM shadow_items');
+        $physicalShadowStatement = $rawPdo->query('SELECT * FROM shadow_items');
+        self::assertNotFalse($rawStatement);
+        self::assertNotFalse($ztdStatement);
+        self::assertNotFalse($physicalShadowStatement);
+        self::assertSame($rawStatement->fetchAll(), $ztdStatement->fetchAll());
+        self::assertSame([], $physicalShadowStatement->fetchAll());
+    }
+
+    public function testConditionalUpsertAndReturningMatchNativeSqlite(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE native_items (id INTEGER PRIMARY KEY, name TEXT, score INTEGER)');
+        $rawPdo->exec('CREATE TABLE shadow_items (id INTEGER PRIMARY KEY, name TEXT, score INTEGER)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $rawPdo->exec("INSERT INTO native_items VALUES (1, 'original', 50)");
+        $ztdPdo->exec("INSERT INTO shadow_items VALUES (1, 'original', 50)");
+
+        $rawSkipped = $rawPdo->query("INSERT INTO native_items VALUES (1, 'skipped', 95) ON CONFLICT(id) DO UPDATE SET name = excluded.name WHERE native_items.score >= 80 RETURNING id, name, score");
+        $ztdSkipped = $ztdPdo->query("INSERT INTO shadow_items VALUES (1, 'skipped', 95) ON CONFLICT(id) DO UPDATE SET name = excluded.name WHERE shadow_items.score >= 80 RETURNING id, name, score");
+        self::assertNotFalse($rawSkipped);
+        self::assertNotFalse($ztdSkipped);
+        self::assertSame($rawSkipped->fetchAll(), $ztdSkipped->fetchAll());
+
+        $rawPdo->exec('UPDATE native_items SET score = 85 WHERE id = 1');
+        $ztdPdo->exec('UPDATE shadow_items SET score = 85 WHERE id = 1');
+        $rawUpdated = $rawPdo->query("INSERT INTO native_items VALUES (1, 'updated', 95) ON CONFLICT(id) DO UPDATE SET name = excluded.name WHERE native_items.score >= 80 RETURNING id, name, score");
+        $ztdUpdated = $ztdPdo->query("INSERT INTO shadow_items VALUES (1, 'updated', 95) ON CONFLICT(id) DO UPDATE SET name = excluded.name WHERE shadow_items.score >= 80 RETURNING id, name, score");
+        self::assertNotFalse($rawUpdated);
+        self::assertNotFalse($ztdUpdated);
+        self::assertSame($rawUpdated->fetchAll(), $ztdUpdated->fetchAll());
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -79,10 +79,11 @@ final class PgSqlMutationResolver
             $updateColumns = $conflictInfo['columns'];
 
             if ($updateColumns !== []) {
-                /** @var array<string, string> $resolvedValues */
+                /** @var array<string, \ZtdQuery\Shadow\Mutation\UpsertExpression> $resolvedValues */
                 $resolvedValues = [];
+                $expressionParser = new PgSqlUpsertExpressionParser();
                 foreach ($conflictInfo['values'] as $col => $value) {
-                    $resolvedValues[$col] = $value;
+                    $resolvedValues[$col] = $expressionParser->parse($value, $tableName);
                 }
 
                 return new UpsertMutation(
@@ -91,7 +92,9 @@ final class PgSqlMutationResolver
                     $updateColumns,
                     $resolvedValues,
                     $definition?->candidateKeys(),
-                    $this->parser->extractOnConflictUpdateWhere($sql),
+                    ($predicate = $this->parser->extractOnConflictUpdateWhere($sql)) !== null
+                        ? $expressionParser->parse($predicate, $tableName)
+                        : null,
                 );
             }
 

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -91,6 +91,7 @@ final class PgSqlMutationResolver
                     $updateColumns,
                     $resolvedValues,
                     $definition?->candidateKeys(),
+                    $this->parser->extractOnConflictUpdateWhere($sql),
                 );
             }
 

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -161,6 +161,15 @@ final class PgSqlParser
         return ['columns' => $columns, 'values' => $values];
     }
 
+    public function extractOnConflictUpdateWhere(string $sql): ?string
+    {
+        return SqlTokenStream::tokenize($sql)->topLevelClauseAfter(
+            ['DO', 'UPDATE', 'SET'],
+            ['WHERE'],
+            [['RETURNING']],
+        );
+    }
+
     /**
      * Check if INSERT has a SELECT subquery (INSERT ... SELECT).
      */

--- a/packages/ztd-query-postgres/src/PgSqlUpsertExpressionParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlUpsertExpressionParser.php
@@ -29,7 +29,7 @@ final class PgSqlUpsertExpressionParser
         $this->tokens = SqlTokenStream::tokenize($sql)->significantTokens();
         $this->index = 0;
         $expression = $this->parseOr();
-        if (isset($this->tokens[$this->index])) {
+        if ($this->index !== count($this->tokens)) {
             throw $this->unsupported();
         }
 

--- a/packages/ztd-query-postgres/src/PgSqlUpsertExpressionParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlUpsertExpressionParser.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
+use ZtdQuery\Shadow\Mutation\UpsertExpression;
+use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PgSqlUpsertExpressionParser
+{
+    private string $sql = '';
+    private string $tableName = '';
+
+    /** @var list<SqlToken> */
+    private array $tokens = [];
+
+    private int $index = 0;
+
+    public function parse(string $sql, string $tableName): UpsertExpression
+    {
+        $this->sql = $sql;
+        $this->tableName = $tableName;
+        $this->tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $this->index = 0;
+        $expression = $this->parseOr();
+        if (isset($this->tokens[$this->index])) {
+            throw $this->unsupported();
+        }
+
+        return $expression;
+    }
+
+    public function parseIfSupported(string $sql, string $tableName): ?UpsertExpression
+    {
+        try {
+            return $this->parse($sql, $tableName);
+        } catch (UnsupportedSqlException) {
+            return null;
+        }
+    }
+
+    private function parseOr(): UpsertExpression
+    {
+        $left = $this->parseAnd();
+        while (($this->tokens[$this->index] ?? null)?->isKeyword('OR') === true) {
+            $this->index++;
+            $left = UpsertExpression::binary(UpsertExpressionKind::Or, $left, $this->parseAnd());
+        }
+
+        return $left;
+    }
+
+    private function parseAnd(): UpsertExpression
+    {
+        $left = $this->parseComparison();
+        while (($this->tokens[$this->index] ?? null)?->isKeyword('AND') === true) {
+            $this->index++;
+            $left = UpsertExpression::binary(UpsertExpressionKind::And, $left, $this->parseComparison());
+        }
+
+        return $left;
+    }
+
+    private function parseComparison(): UpsertExpression
+    {
+        $left = $this->parseAdditive();
+        $operator = $this->comparisonOperator();
+
+        return $operator === null
+            ? $left
+            : UpsertExpression::binary($operator, $left, $this->parseAdditive());
+    }
+
+    private function parseAdditive(): UpsertExpression
+    {
+        $left = $this->parseMultiplicative();
+        while (isset($this->tokens[$this->index]) && $this->isSymbol($this->tokens[$this->index], ['+', '-'])) {
+            $operator = $this->tokens[$this->index]->text;
+            $this->index++;
+            $left = UpsertExpression::binary(
+                $operator === '+' ? UpsertExpressionKind::Add : UpsertExpressionKind::Subtract,
+                $left,
+                $this->parseMultiplicative(),
+            );
+        }
+
+        return $left;
+    }
+
+    private function parseMultiplicative(): UpsertExpression
+    {
+        $left = $this->parseUnary();
+        while (isset($this->tokens[$this->index])
+            && $this->isSymbol($this->tokens[$this->index], ['*', '/', '%'])
+        ) {
+            $operator = $this->tokens[$this->index]->text;
+            $this->index++;
+            $kind = $operator === '*'
+                ? UpsertExpressionKind::Multiply
+                : ($operator === '/' ? UpsertExpressionKind::Divide : UpsertExpressionKind::Modulo);
+            $left = UpsertExpression::binary($kind, $left, $this->parseUnary());
+        }
+
+        return $left;
+    }
+
+    private function parseUnary(): UpsertExpression
+    {
+        $token = $this->tokens[$this->index] ?? null;
+        if ($token?->isKeyword('NOT') === true) {
+            $this->index++;
+
+            return UpsertExpression::unary(UpsertExpressionKind::Not, $this->parseUnary());
+        }
+        if ($token !== null && $this->isSymbol($token, ['+', '-'])) {
+            $this->index++;
+
+            return UpsertExpression::unary(
+                $token->text === '+' ? UpsertExpressionKind::UnaryPlus : UpsertExpressionKind::UnaryMinus,
+                $this->parseUnary(),
+            );
+        }
+
+        return $this->parsePrimary();
+    }
+
+    private function parsePrimary(): UpsertExpression
+    {
+        $token = $this->tokens[$this->index] ?? null;
+        if ($token === null) {
+            throw $this->unsupported();
+        }
+        if ($this->isSymbol($token, ['('])) {
+            $this->index++;
+            $expression = $this->parseOr();
+            if (!isset($this->tokens[$this->index]) || !$this->isSymbol($this->tokens[$this->index], [')'])) {
+                throw $this->unsupported();
+            }
+            $this->index++;
+
+            return $expression;
+        }
+        if ($token->kind === SqlTokenKind::Number) {
+            $this->index++;
+
+            return UpsertExpression::literal($this->number($token->text));
+        }
+        if ($token->kind === SqlTokenKind::String) {
+            $this->index++;
+
+            return UpsertExpression::literal($this->string($token->text));
+        }
+        if ($token->isKeyword('NULL')) {
+            $this->index++;
+
+            return UpsertExpression::literal(null);
+        }
+        if ($token->isKeyword('TRUE') || $token->isKeyword('FALSE')) {
+            $this->index++;
+
+            return UpsertExpression::literal($token->isKeyword('TRUE'));
+        }
+        if (!$this->isIdentifier($token)) {
+            throw $this->unsupported();
+        }
+
+        $identifier = $this->identifier($token);
+        $this->index++;
+        if (isset($this->tokens[$this->index]) && $this->isSymbol($this->tokens[$this->index], ['.'])) {
+            $this->index++;
+            $column = $this->tokens[$this->index] ?? null;
+            if ($column === null || !$this->isIdentifier($column)) {
+                throw $this->unsupported();
+            }
+            $this->index++;
+
+            return UpsertExpression::column(
+                $this->columnSource($identifier),
+                $this->identifier($column),
+            );
+        }
+
+        return UpsertExpression::column(UpsertColumnSource::Existing, $identifier);
+    }
+
+    private function columnSource(string $qualifier): UpsertColumnSource
+    {
+        if (strcasecmp($qualifier, 'EXCLUDED') === 0) {
+            return UpsertColumnSource::Incoming;
+        }
+        if (strcasecmp($qualifier, $this->tableName) === 0) {
+            return UpsertColumnSource::Existing;
+        }
+
+        throw $this->unsupported();
+    }
+
+    private function comparisonOperator(): ?UpsertExpressionKind
+    {
+        $first = $this->tokens[$this->index] ?? null;
+        if ($first === null || !$this->isSymbol($first, ['=', '!', '<', '>'])) {
+            return null;
+        }
+        $operator = $first->text;
+        $second = $this->tokens[$this->index + 1] ?? null;
+        if ($second !== null && $this->isSymbol($second, ['=', '>']) && $operator !== '=') {
+            $operator .= $second->text;
+            $this->index++;
+        }
+        $this->index++;
+
+        return match ($operator) {
+            '=' => UpsertExpressionKind::Equal,
+            '!=', '<>' => UpsertExpressionKind::NotEqual,
+            '<' => UpsertExpressionKind::Less,
+            '<=' => UpsertExpressionKind::LessOrEqual,
+            '>' => UpsertExpressionKind::Greater,
+            '>=' => UpsertExpressionKind::GreaterOrEqual,
+            default => throw $this->unsupported(),
+        };
+    }
+
+    /** @param list<string> $symbols */
+    private function isSymbol(SqlToken $token, array $symbols): bool
+    {
+        return $token->kind === SqlTokenKind::Symbol && in_array($token->text, $symbols, true);
+    }
+
+    private function isIdentifier(SqlToken $token): bool
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return true;
+        }
+
+        return $token->kind === SqlTokenKind::QuotedIdentifier && str_starts_with($token->text, '"');
+    }
+
+    private function identifier(SqlToken $token): string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+
+        return str_replace('""', '"', substr($token->text, 1, -1));
+    }
+
+    private function number(string $literal): int|float
+    {
+        $literal = str_replace('_', '', $literal);
+
+        return strpbrk($literal, '.eE') === false ? (int) $literal : (float) $literal;
+    }
+
+    private function string(string $literal): string
+    {
+        return str_replace("''", "'", substr($literal, 1, -1));
+    }
+
+    private function unsupported(): UnsupportedSqlException
+    {
+        return new UnsupportedSqlException($this->sql, 'Unsupported UPSERT expression');
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -1829,6 +1829,7 @@ final class PgSqlMutationResolverTest extends TestCase
             [],
             []
         ));
+        $shadowStore->set('users', [['id' => 1, 'name' => 'Existing']]);
         $mutation = $resolver->resolve(
             "INSERT INTO users (id, name) VALUES (1, 'Alice') ON CONFLICT (id) DO UPDATE SET name = 'Bob', id = EXCLUDED.id",
             'INSERT',
@@ -1836,6 +1837,8 @@ final class PgSqlMutationResolverTest extends TestCase
         );
 
         self::assertInstanceOf(UpsertMutation::class, $mutation);
+        $mutation->apply($shadowStore, [['id' => 1, 'name' => 'Alice']]);
+        self::assertSame([['id' => 1, 'name' => 'Bob']], $shadowStore->get('users'));
     }
 
     public function testResolveDeleteWithShadowStoreOnlyNoRegistry(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlMutationResolver::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 final class PgSqlMutationResolverTest extends TestCase

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -14,6 +14,23 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(PostgreSqlLexicalMasker::class)]
 final class PgSqlParserTest extends TestCase
 {
+    public function testExtractsOnConflictUpdateWhereAfterInsertSelectWhere(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = 'INSERT INTO items SELECT * FROM source WHERE active ON CONFLICT (id) DO UPDATE SET score = EXCLUDED.score WHERE items.score >= 80 RETURNING id';
+
+        self::assertSame('items.score >= 80', $parser->extractOnConflictUpdateWhere($sql));
+    }
+
+    public function testReturnsNullWithoutOnConflictUpdateWhere(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertNull($parser->extractOnConflictUpdateWhere(
+            'INSERT INTO items VALUES (1, 90) ON CONFLICT (id) DO UPDATE SET score = EXCLUDED.score',
+        ));
+    }
+
     public function testClassifySelect(): void
     {
         $parser = new PgSqlParser();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -31,6 +31,15 @@ final class PgSqlParserTest extends TestCase
         ));
     }
 
+    public function testRequiresCompleteDoUpdateSetAnchor(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertNull($parser->extractOnConflictUpdateWhere(
+            'INSERT INTO items VALUES (1, 90) ON CONFLICT (id) UPDATE SET score = excluded.score WHERE items.score >= 80',
+        ));
+    }
+
     public function testClassifySelect(): void
     {
         $parser = new PgSqlParser();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -40,6 +40,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlRewriter::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(PgSqlQueryGuard::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlUpsertExpressionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlUpsertExpressionParserTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser;
+
+#[CoversClass(PgSqlUpsertExpressionParser::class)]
+final class PgSqlUpsertExpressionParserTest extends TestCase
+{
+    public function testParsesExcludedAndQuotedExistingReferences(): void
+    {
+        $expression = (new PgSqlUpsertExpressionParser())->parse(
+            '"items"."Quantity" + EXCLUDED."Quantity" * 2',
+            'items',
+        );
+
+        self::assertSame(11, $expression->evaluate(['Quantity' => 5], ['Quantity' => 3], 'items'));
+    }
+
+    public function testParsesBooleanPredicateAndSqlString(): void
+    {
+        $expression = (new PgSqlUpsertExpressionParser())->parse(
+            "score >= 80 AND EXCLUDED.name <> 'it''s blocked'",
+            'items',
+        );
+
+        self::assertTrue($expression->matches(['score' => 80], ['name' => 'ready'], 'items'));
+    }
+
+    public function testReturnsNullForUnsupportedFunction(): void
+    {
+        self::assertNull((new PgSqlUpsertExpressionParser())->parseIfSupported('COALESCE(score, 0)', 'items'));
+    }
+
+    public function testRejectsMySqlValuesFunction(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        (new PgSqlUpsertExpressionParser())->parse('VALUES(quantity)', 'items');
+    }
+
+    public function testRejectsMySqlQuotedIdentifier(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        (new PgSqlUpsertExpressionParser())->parse('EXCLUDED.`quantity`', 'items');
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlUpsertExpressionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlUpsertExpressionParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Postgres\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser;
@@ -12,6 +13,42 @@ use ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser;
 #[CoversClass(PgSqlUpsertExpressionParser::class)]
 final class PgSqlUpsertExpressionParserTest extends TestCase
 {
+    #[DataProvider('providerPostgresExpressionCases')]
+    public function testParsesPostgresExpressionCases(string $sql, mixed $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new PgSqlUpsertExpressionParser())->parse($sql, 'items')->evaluate([], [], 'items'),
+        );
+    }
+
+    /** @return iterable<string, array{string, mixed}> */
+    public static function providerPostgresExpressionCases(): iterable
+    {
+        yield 'chained or' => ['1 OR 0 OR 0', true];
+        yield 'chained and' => ['1 AND 1 AND 0', false];
+        yield 'equal' => ['1 = 2', false];
+        yield 'bang not equal' => ['1 != 2', true];
+        yield 'angle not equal' => ['1 <> 2', true];
+        yield 'less' => ['1 < 2', true];
+        yield 'less or equal' => ['1 <= 2', true];
+        yield 'greater' => ['2 > 1', true];
+        yield 'greater or equal' => ['2 >= 1', true];
+        yield 'chained additive' => ['10 - 3 + 2', 9];
+        yield 'chained multiplicative' => ['20 / 5 % 3 * 2', 2];
+        yield 'nested unary minus' => ['- -2', 2];
+        yield 'nested unary plus' => ['+ +2', 2];
+        yield 'unary minus' => ['-2', -2];
+        yield 'unary plus' => ['+2', 2];
+        yield 'nested not' => ['NOT NOT TRUE', true];
+        yield 'parenthesized precedence' => ['(1 + 2) * 3', 9];
+        yield 'null' => ['NULL', null];
+        yield 'false' => ['FALSE', false];
+        yield 'underscored integer' => ['1_000', 1000];
+        yield 'exponent' => ['1.5e1', 15.0];
+        yield 'escaped string' => ["'it''s'", "it's"];
+    }
+
     public function testParsesExcludedAndQuotedExistingReferences(): void
     {
         $expression = (new PgSqlUpsertExpressionParser())->parse(
@@ -20,6 +57,16 @@ final class PgSqlUpsertExpressionParserTest extends TestCase
         );
 
         self::assertSame(11, $expression->evaluate(['Quantity' => 5], ['Quantity' => 3], 'items'));
+    }
+
+    public function testUnescapesDoubledQuotesInIdentifiers(): void
+    {
+        $expression = (new PgSqlUpsertExpressionParser())->parse(
+            '"it""ems"."quan""tity" + EXCLUDED."quan""tity"',
+            'it"ems',
+        );
+
+        self::assertSame(8, $expression->evaluate(['quan"tity' => 5], ['quan"tity' => 3], 'it"ems'));
     }
 
     public function testParsesBooleanPredicateAndSqlString(): void
@@ -49,5 +96,28 @@ final class PgSqlUpsertExpressionParserTest extends TestCase
         $this->expectException(UnsupportedSqlException::class);
 
         (new PgSqlUpsertExpressionParser())->parse('EXCLUDED.`quantity`', 'items');
+    }
+
+    #[DataProvider('providerInvalidPostgresExpression')]
+    public function testRejectsInvalidPostgresExpression(string $sql): void
+    {
+        self::assertNull((new PgSqlUpsertExpressionParser())->parseIfSupported($sql, 'items'));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function providerInvalidPostgresExpression(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'missing close parenthesis' => ['(1 + 2'];
+        yield 'wrong close parenthesis' => ['(1 + 2 value'];
+        yield 'extra close parenthesis' => ['1 + 2)'];
+        yield 'missing additive operand' => ['1 +'];
+        yield 'missing comparison operand' => ['1 ='];
+        yield 'missing qualified column' => ['items.'];
+        yield 'invalid qualified column' => ['items.+'];
+        yield 'invalid comparison pair' => ['1 ! 2'];
+        yield 'double equals' => ['1 == 1'];
+        yield 'unknown qualifier' => ['other.value'];
+        yield 'symbol primary' => ['*'];
     }
 }

--- a/packages/ztd-query-sqlite/fuzz/FullPipelineFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/FullPipelineFuzzTest.php
@@ -62,6 +62,41 @@ final class FullPipelineFuzzTest extends TestCase
         $this->provider = new SqliteProvider($this->faker);
     }
 
+    public function testSelfReferencingUpsertPreservesSemanticResult(): void
+    {
+        $this->faker->seed(20260816);
+        for ($i = 0; $i < self::ITERATIONS; $i++) {
+            $existing = $this->faker->numberBetween(1, 100000);
+            $incoming = $this->faker->numberBetween(1, 100000);
+            $reference = $this->faker->randomElement(['quantity', 'items.quantity']);
+            self::assertIsString($reference);
+            $shadowStore = new ShadowStore();
+            $shadowStore->set('items', [['id' => 1, 'quantity' => $existing]]);
+            $registry = new TableDefinitionRegistry();
+            $registry->register('items', new TableDefinition(
+                ['id', 'quantity'],
+                ['id' => 'INTEGER', 'quantity' => 'INTEGER'],
+                ['id'],
+                ['id'],
+                [],
+            ));
+            $rewriter = $this->buildRewriter($shadowStore, $registry);
+            $plan = $rewriter->rewrite(sprintf(
+                'INSERT INTO items VALUES (1, %d) ON CONFLICT(id) DO UPDATE SET quantity = %s + excluded.quantity',
+                $incoming,
+                $reference,
+            ));
+            $mutation = $plan->mutation();
+            self::assertNotNull($mutation);
+            $mutation->apply($shadowStore, [['id' => 1, 'quantity' => $incoming]]);
+
+            self::assertSame(
+                [['id' => 1, 'quantity' => $existing + $incoming]],
+                $shadowStore->get('items'),
+            );
+        }
+    }
+
     /**
      * Build a fresh rewriter with given registry and shadow store.
      */

--- a/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
+++ b/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
@@ -144,6 +144,7 @@ final class SqliteMutationResolver
                     $updateColumns,
                     $updateValues,
                     $definition?->candidateKeys(),
+                    $this->parser->extractOnConflictUpdateWhere($sql),
                 );
             }
 

--- a/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
+++ b/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
@@ -126,12 +126,13 @@ final class SqliteMutationResolver
 
         if ($this->parser->hasOnConflict($sql)) {
             $updateColumns = [];
-            /** @var array<string, string> $updateValues */
+            /** @var array<string, \ZtdQuery\Shadow\Mutation\UpsertExpression> $updateValues */
             $updateValues = [];
+            $expressionParser = new SqliteUpsertExpressionParser();
             $onConflictUpdates = $this->parser->extractOnConflictUpdates($sql);
             foreach ($onConflictUpdates as $colName => $value) {
                 $updateColumns[] = $colName;
-                $updateValues[$colName] = $value;
+                $updateValues[$colName] = $expressionParser->parse($value, $tableName);
             }
 
             if ($updateColumns !== []) {
@@ -144,7 +145,9 @@ final class SqliteMutationResolver
                     $updateColumns,
                     $updateValues,
                     $definition?->candidateKeys(),
-                    $this->parser->extractOnConflictUpdateWhere($sql),
+                    ($predicate = $this->parser->extractOnConflictUpdateWhere($sql)) !== null
+                        ? $expressionParser->parse($predicate, $tableName)
+                        : null,
                 );
             }
 

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -278,6 +278,15 @@ final class SqliteParser
         return $this->parseAssignments($setClause);
     }
 
+    public function extractOnConflictUpdateWhere(string $sql): ?string
+    {
+        return SqlTokenStream::tokenize($sql)->topLevelClauseAfter(
+            ['DO', 'UPDATE', 'SET'],
+            ['WHERE'],
+            [['RETURNING']],
+        );
+    }
+
     /**
      * Check if an INSERT has a SELECT subquery.
      */

--- a/packages/ztd-query-sqlite/src/SqliteUpsertExpressionParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteUpsertExpressionParser.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
+use ZtdQuery\Shadow\Mutation\UpsertExpression;
+use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class SqliteUpsertExpressionParser
+{
+    private string $sql = '';
+    private string $tableName = '';
+
+    /** @var list<SqlToken> */
+    private array $tokens = [];
+
+    private int $index = 0;
+
+    public function parse(string $sql, string $tableName): UpsertExpression
+    {
+        $this->sql = $sql;
+        $this->tableName = $tableName;
+        $this->tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $this->index = 0;
+        $expression = $this->parseOr();
+        if (isset($this->tokens[$this->index])) {
+            throw $this->unsupported();
+        }
+
+        return $expression;
+    }
+
+    public function parseIfSupported(string $sql, string $tableName): ?UpsertExpression
+    {
+        try {
+            return $this->parse($sql, $tableName);
+        } catch (UnsupportedSqlException) {
+            return null;
+        }
+    }
+
+    private function parseOr(): UpsertExpression
+    {
+        $left = $this->parseAnd();
+        while (($this->tokens[$this->index] ?? null)?->isKeyword('OR') === true) {
+            $this->index++;
+            $left = UpsertExpression::binary(UpsertExpressionKind::Or, $left, $this->parseAnd());
+        }
+
+        return $left;
+    }
+
+    private function parseAnd(): UpsertExpression
+    {
+        $left = $this->parseComparison();
+        while (($this->tokens[$this->index] ?? null)?->isKeyword('AND') === true) {
+            $this->index++;
+            $left = UpsertExpression::binary(UpsertExpressionKind::And, $left, $this->parseComparison());
+        }
+
+        return $left;
+    }
+
+    private function parseComparison(): UpsertExpression
+    {
+        $left = $this->parseAdditive();
+        $operator = $this->comparisonOperator();
+
+        return $operator === null
+            ? $left
+            : UpsertExpression::binary($operator, $left, $this->parseAdditive());
+    }
+
+    private function parseAdditive(): UpsertExpression
+    {
+        $left = $this->parseMultiplicative();
+        while (isset($this->tokens[$this->index]) && $this->isSymbol($this->tokens[$this->index], ['+', '-'])) {
+            $operator = $this->tokens[$this->index]->text;
+            $this->index++;
+            $left = UpsertExpression::binary(
+                $operator === '+' ? UpsertExpressionKind::Add : UpsertExpressionKind::Subtract,
+                $left,
+                $this->parseMultiplicative(),
+            );
+        }
+
+        return $left;
+    }
+
+    private function parseMultiplicative(): UpsertExpression
+    {
+        $left = $this->parseUnary();
+        while (isset($this->tokens[$this->index])
+            && $this->isSymbol($this->tokens[$this->index], ['*', '/', '%'])
+        ) {
+            $operator = $this->tokens[$this->index]->text;
+            $this->index++;
+            $kind = $operator === '*'
+                ? UpsertExpressionKind::Multiply
+                : ($operator === '/' ? UpsertExpressionKind::Divide : UpsertExpressionKind::Modulo);
+            $left = UpsertExpression::binary($kind, $left, $this->parseUnary());
+        }
+
+        return $left;
+    }
+
+    private function parseUnary(): UpsertExpression
+    {
+        $token = $this->tokens[$this->index] ?? null;
+        if ($token?->isKeyword('NOT') === true) {
+            $this->index++;
+
+            return UpsertExpression::unary(UpsertExpressionKind::Not, $this->parseUnary());
+        }
+        if ($token !== null && $this->isSymbol($token, ['+', '-'])) {
+            $this->index++;
+
+            return UpsertExpression::unary(
+                $token->text === '+' ? UpsertExpressionKind::UnaryPlus : UpsertExpressionKind::UnaryMinus,
+                $this->parseUnary(),
+            );
+        }
+
+        return $this->parsePrimary();
+    }
+
+    private function parsePrimary(): UpsertExpression
+    {
+        $token = $this->tokens[$this->index] ?? null;
+        if ($token === null) {
+            throw $this->unsupported();
+        }
+        if ($this->isSymbol($token, ['('])) {
+            $this->index++;
+            $expression = $this->parseOr();
+            if (!isset($this->tokens[$this->index]) || !$this->isSymbol($this->tokens[$this->index], [')'])) {
+                throw $this->unsupported();
+            }
+            $this->index++;
+
+            return $expression;
+        }
+        if ($token->kind === SqlTokenKind::Number) {
+            $this->index++;
+
+            return UpsertExpression::literal($this->number($token->text));
+        }
+        if ($token->kind === SqlTokenKind::String) {
+            $this->index++;
+
+            return UpsertExpression::literal($this->string($token->text));
+        }
+        if ($token->isKeyword('NULL')) {
+            $this->index++;
+
+            return UpsertExpression::literal(null);
+        }
+        if ($token->isKeyword('TRUE') || $token->isKeyword('FALSE')) {
+            $this->index++;
+
+            return UpsertExpression::literal($token->isKeyword('TRUE'));
+        }
+        if (!$this->isIdentifier($token)) {
+            throw $this->unsupported();
+        }
+
+        $identifier = $this->identifier($token);
+        $this->index++;
+        if (isset($this->tokens[$this->index]) && $this->isSymbol($this->tokens[$this->index], ['.'])) {
+            $this->index++;
+            $column = $this->tokens[$this->index] ?? null;
+            if ($column === null || !$this->isIdentifier($column)) {
+                throw $this->unsupported();
+            }
+            $this->index++;
+
+            return UpsertExpression::column(
+                $this->columnSource($identifier),
+                $this->identifier($column),
+            );
+        }
+
+        return UpsertExpression::column(UpsertColumnSource::Existing, $identifier);
+    }
+
+    private function columnSource(string $qualifier): UpsertColumnSource
+    {
+        if (strcasecmp($qualifier, 'EXCLUDED') === 0) {
+            return UpsertColumnSource::Incoming;
+        }
+        if (strcasecmp($qualifier, $this->tableName) === 0) {
+            return UpsertColumnSource::Existing;
+        }
+
+        throw $this->unsupported();
+    }
+
+    private function comparisonOperator(): ?UpsertExpressionKind
+    {
+        $first = $this->tokens[$this->index] ?? null;
+        if ($first === null || !$this->isSymbol($first, ['=', '!', '<', '>'])) {
+            return null;
+        }
+        $operator = $first->text;
+        $second = $this->tokens[$this->index + 1] ?? null;
+        if ($second !== null && $this->isSymbol($second, ['=', '>']) && $operator !== '=') {
+            $operator .= $second->text;
+            $this->index++;
+        }
+        $this->index++;
+
+        return match ($operator) {
+            '=' => UpsertExpressionKind::Equal,
+            '!=', '<>' => UpsertExpressionKind::NotEqual,
+            '<' => UpsertExpressionKind::Less,
+            '<=' => UpsertExpressionKind::LessOrEqual,
+            '>' => UpsertExpressionKind::Greater,
+            '>=' => UpsertExpressionKind::GreaterOrEqual,
+            default => throw $this->unsupported(),
+        };
+    }
+
+    /** @param list<string> $symbols */
+    private function isSymbol(SqlToken $token, array $symbols): bool
+    {
+        return $token->kind === SqlTokenKind::Symbol && in_array($token->text, $symbols, true);
+    }
+
+    private function isIdentifier(SqlToken $token): bool
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return true;
+        }
+
+        return $token->kind === SqlTokenKind::QuotedIdentifier;
+    }
+
+    private function identifier(SqlToken $token): string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return $token->text;
+        }
+
+        if (str_starts_with($token->text, '[')) {
+            return str_replace(']]', ']', substr($token->text, 1, -1));
+        }
+        $quote = $token->text[0] ?? '';
+
+        return str_replace($quote . $quote, $quote, substr($token->text, 1, -1));
+    }
+
+    private function number(string $literal): int|float
+    {
+        $literal = str_replace('_', '', $literal);
+
+        return strpbrk($literal, '.eE') === false ? (int) $literal : (float) $literal;
+    }
+
+    private function string(string $literal): string
+    {
+        return str_replace("''", "'", substr($literal, 1, -1));
+    }
+
+    private function unsupported(): UnsupportedSqlException
+    {
+        return new UnsupportedSqlException($this->sql, 'Unsupported UPSERT expression');
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteUpsertExpressionParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteUpsertExpressionParser.php
@@ -29,7 +29,7 @@ final class SqliteUpsertExpressionParser
         $this->tokens = SqlTokenStream::tokenize($sql)->significantTokens();
         $this->index = 0;
         $expression = $this->parseOr();
-        if (isset($this->tokens[$this->index])) {
+        if ($this->index !== count($this->tokens)) {
             throw $this->unsupported();
         }
 
@@ -247,9 +247,6 @@ final class SqliteUpsertExpressionParser
             return $token->text;
         }
 
-        if (str_starts_with($token->text, '[')) {
-            return str_replace(']]', ']', substr($token->text, 1, -1));
-        }
         $quote = $token->text[0] ?? '';
 
         return str_replace($quote . $quote, $quote, substr($token->text, 1, -1));

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
@@ -29,6 +29,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[CoversClass(SqliteMutationResolver::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteUpsertExpressionParser::class)]
 #[UsesClass(SqliteSchemaParser::class)]
 final class SqliteMutationResolverTest extends TestCase
 {

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -15,6 +15,23 @@ use ZtdQuery\Platform\Sqlite\SqliteParser;
 #[UsesClass(SqliteLexicalMasker::class)]
 final class SqliteParserTest extends TestCase
 {
+    public function testExtractsOnConflictUpdateWhereAfterInsertSelectWhere(): void
+    {
+        $parser = new SqliteParser();
+        $sql = 'INSERT INTO items SELECT * FROM source WHERE active ON CONFLICT (id) DO UPDATE SET score = excluded.score WHERE items.score >= 80 RETURNING id';
+
+        self::assertSame('items.score >= 80', $parser->extractOnConflictUpdateWhere($sql));
+    }
+
+    public function testReturnsNullWithoutOnConflictUpdateWhere(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertNull($parser->extractOnConflictUpdateWhere(
+            'INSERT INTO items VALUES (1, 90) ON CONFLICT (id) DO UPDATE SET score = excluded.score',
+        ));
+    }
+
     public function testClassifySelect(): void
     {
         $parser = new SqliteParser();

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -32,6 +32,15 @@ final class SqliteParserTest extends TestCase
         ));
     }
 
+    public function testRequiresCompleteDoUpdateSetAnchor(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertNull($parser->extractOnConflictUpdateWhere(
+            'INSERT INTO items VALUES (1, 90) ON CONFLICT (id) UPDATE SET score = excluded.score WHERE items.score >= 80',
+        ));
+    }
+
     public function testClassifySelect(): void
     {
         $parser = new SqliteParser();

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -41,6 +41,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[CoversClass(SqliteRewriter::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteUpsertExpressionParser::class)]
 #[UsesClass(SqliteQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteTransactionStatementParser::class)]
 #[UsesClass(SqliteReturningProjectionParser::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteUpsertExpressionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteUpsertExpressionParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Sqlite\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Sqlite\SqliteUpsertExpressionParser;
@@ -12,6 +13,42 @@ use ZtdQuery\Platform\Sqlite\SqliteUpsertExpressionParser;
 #[CoversClass(SqliteUpsertExpressionParser::class)]
 final class SqliteUpsertExpressionParserTest extends TestCase
 {
+    #[DataProvider('providerSqliteExpressionCases')]
+    public function testParsesSqliteExpressionCases(string $sql, mixed $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new SqliteUpsertExpressionParser())->parse($sql, 'items')->evaluate([], [], 'items'),
+        );
+    }
+
+    /** @return iterable<string, array{string, mixed}> */
+    public static function providerSqliteExpressionCases(): iterable
+    {
+        yield 'chained or' => ['1 OR 0 OR 0', true];
+        yield 'chained and' => ['1 AND 1 AND 0', false];
+        yield 'equal' => ['1 = 2', false];
+        yield 'bang not equal' => ['1 != 2', true];
+        yield 'angle not equal' => ['1 <> 2', true];
+        yield 'less' => ['1 < 2', true];
+        yield 'less or equal' => ['1 <= 2', true];
+        yield 'greater' => ['2 > 1', true];
+        yield 'greater or equal' => ['2 >= 1', true];
+        yield 'chained additive' => ['10 - 3 + 2', 9];
+        yield 'chained multiplicative' => ['20 / 5 % 3 * 2', 2];
+        yield 'nested unary minus' => ['- -2', 2];
+        yield 'nested unary plus' => ['+ +2', 2];
+        yield 'unary minus' => ['-2', -2];
+        yield 'unary plus' => ['+2', 2];
+        yield 'nested not' => ['NOT NOT TRUE', true];
+        yield 'parenthesized precedence' => ['(1 + 2) * 3', 9];
+        yield 'null' => ['NULL', null];
+        yield 'false' => ['FALSE', false];
+        yield 'underscored integer' => ['1_000', 1000];
+        yield 'exponent' => ['1.5e1', 15.0];
+        yield 'escaped string' => ["'it''s'", "it's"];
+    }
+
     public function testParsesExcludedAndExistingReferences(): void
     {
         $expression = (new SqliteUpsertExpressionParser())->parse(
@@ -20,6 +57,20 @@ final class SqliteUpsertExpressionParserTest extends TestCase
         );
 
         self::assertSame(11, $expression->evaluate(['quantity' => 5], ['quantity' => 3], 'items'));
+    }
+
+    public function testUnescapesQuotedSqliteIdentifiers(): void
+    {
+        $parser = new SqliteUpsertExpressionParser();
+
+        self::assertSame(
+            5,
+            $parser->parse('"quan""tity"', 'items')->evaluate(['quan"tity' => 5], [], 'items'),
+        );
+        self::assertSame(
+            5,
+            $parser->parse('`quan``tity`', 'items')->evaluate(['quan`tity' => 5], [], 'items'),
+        );
     }
 
     public function testParsesPredicate(): void
@@ -42,5 +93,28 @@ final class SqliteUpsertExpressionParserTest extends TestCase
         $this->expectException(UnsupportedSqlException::class);
 
         (new SqliteUpsertExpressionParser())->parse('VALUES(quantity)', 'items');
+    }
+
+    #[DataProvider('providerInvalidSqliteExpression')]
+    public function testRejectsInvalidSqliteExpression(string $sql): void
+    {
+        self::assertNull((new SqliteUpsertExpressionParser())->parseIfSupported($sql, 'items'));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function providerInvalidSqliteExpression(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'missing close parenthesis' => ['(1 + 2'];
+        yield 'wrong close parenthesis' => ['(1 + 2 value'];
+        yield 'extra close parenthesis' => ['1 + 2)'];
+        yield 'missing additive operand' => ['1 +'];
+        yield 'missing comparison operand' => ['1 ='];
+        yield 'missing qualified column' => ['items.'];
+        yield 'invalid qualified column' => ['items.+'];
+        yield 'invalid comparison pair' => ['1 ! 2'];
+        yield 'double equals' => ['1 == 1'];
+        yield 'unknown qualifier' => ['other.value'];
+        yield 'symbol primary' => ['*'];
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteUpsertExpressionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteUpsertExpressionParserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Sqlite\SqliteUpsertExpressionParser;
+
+#[CoversClass(SqliteUpsertExpressionParser::class)]
+final class SqliteUpsertExpressionParserTest extends TestCase
+{
+    public function testParsesExcludedAndExistingReferences(): void
+    {
+        $expression = (new SqliteUpsertExpressionParser())->parse(
+            '`items`.`quantity` + EXCLUDED.`quantity` * 2',
+            'items',
+        );
+
+        self::assertSame(11, $expression->evaluate(['quantity' => 5], ['quantity' => 3], 'items'));
+    }
+
+    public function testParsesPredicate(): void
+    {
+        $expression = (new SqliteUpsertExpressionParser())->parse(
+            "score >= 80 AND excluded.name <> 'blocked'",
+            'items',
+        );
+
+        self::assertTrue($expression->matches(['score' => 80], ['name' => 'ready'], 'items'));
+    }
+
+    public function testReturnsNullForUnsupportedFunction(): void
+    {
+        self::assertNull((new SqliteUpsertExpressionParser())->parseIfSupported('COALESCE(score, 0)', 'items'));
+    }
+
+    public function testRejectsMySqlValuesFunction(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        (new SqliteUpsertExpressionParser())->parse('VALUES(quantity)', 'items');
+    }
+}


### PR DESCRIPTION
## Root problem

`UpsertMutation` did not model SQL expressions. It recognized a few exact `VALUES(...)` and `EXCLUDED...` shapes with regular expressions, stored every other assignment as a raw string, and discarded the conditional `DO UPDATE ... WHERE` predicate. Existing-row references, arithmetic, multi-row conflict sequencing, and conditional updates therefore diverged from the database.

## Fix

- replace assignment regex branches with a token-stream-backed, precedence-aware expression model
- resolve unqualified and table-qualified columns from the existing row
- resolve `VALUES(column)` and `EXCLUDED.column` from the incoming row
- evaluate arithmetic, comparisons, boolean logic, literals, quoted identifiers, and SQL null propagation
- apply repeated conflicts sequentially against the latest shadow row
- extract the conflict predicate only after the `DO UPDATE SET` anchor, avoiding an earlier INSERT SELECT WHERE
- retain the rows actually applied so affected-row and RETURNING metadata exclude predicate-skipped conflicts
- reject unsupported expressions with a typed simulation error instead of persisting raw SQL text

## Recurrence prevention

SQLFaker's upstream MySQL/SQLite/PostgreSQL grammars already contain these upsert expression forms. The detection gap was the fuzz oracle: it checked structural invariants and crashes, but not the computed shadow value. A deterministic semantic fuzz invariant now randomizes existing/incoming values and qualified/unqualified references and checks the result over 50 iterations.

Native differential integration tests cover:

- MySQL self-referencing, multi-row `ON DUPLICATE KEY UPDATE`
- SQLite self-referencing, multi-row `ON CONFLICT DO UPDATE`
- SQLite and PostgreSQL conditional conflict updates including RETURNING
- physical tables remaining unchanged under ZTD simulation

Full core/MySQL/PostgreSQL/SQLite/MySQLi suites and package lint pass. PDO unit, SQLite integration, PostgreSQL targeted integration, and lint pass; the one attempted all-in-one parallel PDO run exposed only Testcontainers host-port collisions, so container tests were rerun serially.

Fixes #16
Fixes #30
Fixes #64
Fixes #112