### PR TITLE
Fix SQLite UPDATE selection scope

### DIFF
--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Sqlite/SqliteSchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Sqlite/SqliteSchemaAwareSqlBuilder.php
@@ -99,9 +99,11 @@ final class SqliteSchemaAwareSqlBuilder
         $updateCol = $this->faker->randomElement($nonPkCols);
         $newValue = $this->generateLiteral($updateCol);
 
-        $whereClause = $this->buildPkWhere($schema);
+        $alias = $this->faker->boolean(35) ? '_ztd_target' : null;
+        $whereClause = $this->buildPkWhere($schema, $alias);
+        $target = $alias === null ? $table : "$table AS " . $this->quoteIdentifier($alias);
 
-        return "UPDATE $table SET " . $this->quoteIdentifier($updateCol) . " = $newValue WHERE $whereClause";
+        return "UPDATE $target SET " . $this->quoteIdentifier($updateCol) . " = $newValue WHERE $whereClause";
     }
 
     public function buildDelete(SchemaDefinition $schema): string
@@ -112,12 +114,16 @@ final class SqliteSchemaAwareSqlBuilder
         return "DELETE FROM $table WHERE $whereClause";
     }
 
-    private function buildPkWhere(SchemaDefinition $schema): string
+    private function buildPkWhere(SchemaDefinition $schema, ?string $qualifier = null): string
     {
         $conditions = [];
         foreach ($schema->primaryKeys as $pk) {
             $literal = $this->generateLiteral($pk);
-            $conditions[] = $this->quoteIdentifier($pk) . " = $literal";
+            $column = $this->quoteIdentifier($pk);
+            if ($qualifier !== null) {
+                $column = $this->quoteIdentifier($qualifier) . '.' . $column;
+            }
+            $conditions[] = $column . " = $literal";
         }
         return implode(' AND ', $conditions);
     }

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Sqlite/Target/UpdateCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Sqlite/Target/UpdateCorrectnessTarget.php
@@ -55,10 +55,11 @@ final class UpdateCorrectnessTarget
 
             try {
                 $this->harness->getZtdPdo()->exec($sql);
-            } catch (UnsupportedSqlException | UnknownSchemaException) {
-                return;
-            } catch (DatabaseException | PDOException) {
-                return;
+            } catch (UnsupportedSqlException | UnknownSchemaException | DatabaseException | PDOException $e) {
+                if ($rawError !== null) {
+                    return;
+                }
+                throw new Error("ZTD UPDATE failed after native success\nSeed: $seed\nSQL: $sql", 0, $e);
             }
 
             if ($rawError !== null) {

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateScopeTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateScopeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_sqlite
+ */
+#[CoversNothing]
+#[Large]
+final class UpdateScopeTest extends TestCase
+{
+    public function testUpdateFromReadsJoinedShadowRows(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE native_inventory (id INTEGER PRIMARY KEY, quantity INTEGER)');
+        $rawPdo->exec('CREATE TABLE native_incoming (id INTEGER PRIMARY KEY, delta INTEGER)');
+        $rawPdo->exec('CREATE TABLE shadow_inventory (id INTEGER PRIMARY KEY, quantity INTEGER)');
+        $rawPdo->exec('CREATE TABLE shadow_incoming (id INTEGER PRIMARY KEY, delta INTEGER)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $rawPdo->exec('INSERT INTO native_inventory VALUES (1, 10), (2, 20)');
+        $rawPdo->exec('INSERT INTO native_incoming VALUES (1, 5), (2, -3)');
+        $ztdPdo->exec('INSERT INTO shadow_inventory VALUES (1, 10), (2, 20)');
+        $ztdPdo->exec('INSERT INTO shadow_incoming VALUES (1, 5), (2, -3)');
+
+        $rawPdo->exec('UPDATE native_inventory SET quantity = quantity + native_incoming.delta FROM native_incoming WHERE native_inventory.id = native_incoming.id');
+        $ztdPdo->exec('UPDATE shadow_inventory SET quantity = quantity + shadow_incoming.delta FROM shadow_incoming WHERE shadow_inventory.id = shadow_incoming.id');
+        $native = $rawPdo->query('SELECT * FROM native_inventory ORDER BY id');
+        $shadow = $ztdPdo->query('SELECT * FROM shadow_inventory ORDER BY id');
+
+        self::assertNotFalse($native);
+        self::assertNotFalse($shadow);
+        self::assertSame($native->fetchAll(), $shadow->fetchAll());
+    }
+
+    public function testUpdateTargetAliasQualifiesSelectionScope(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE native_items (id INTEGER PRIMARY KEY, quantity INTEGER)');
+        $rawPdo->exec('CREATE TABLE shadow_items (id INTEGER PRIMARY KEY, quantity INTEGER)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $rawPdo->exec('INSERT INTO native_items VALUES (1, 10), (2, 20)');
+        $ztdPdo->exec('INSERT INTO shadow_items VALUES (1, 10), (2, 20)');
+
+        $rawPdo->exec('UPDATE native_items AS target SET quantity = quantity + 1 WHERE target.id = 1');
+        $ztdPdo->exec('UPDATE shadow_items AS target SET quantity = quantity + 1 WHERE target.id = 1');
+        $native = $rawPdo->query('SELECT * FROM native_items ORDER BY id');
+        $shadow = $ztdPdo->query('SELECT * FROM shadow_items ORDER BY id');
+
+        self::assertNotFalse($native);
+        self::assertNotFalse($shadow);
+        self::assertSame($native->fetchAll(), $shadow->fetchAll());
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -527,15 +527,25 @@ final class SqliteParser
     private function identifierEndIndex(array $tokens, int $index): int
     {
         $token = $tokens[$index] ?? null;
-        if ($token === null || $token->kind !== SqlTokenKind::Symbol || $token->text !== '[') {
+        if ($token?->text !== '[') {
             return $index + 1;
         }
 
-        for ($index++; isset($tokens[$index]); $index++) {
-            $token = $tokens[$index];
-            if ($token->kind === SqlTokenKind::Symbol && $token->text === ']' && $token->isTopLevel()) {
-                return $index + 1;
+        for (; isset($tokens[$index]); $index++) {
+            $endToken = $tokens[$index];
+            if ($endToken->text !== ']') {
+                continue;
             }
+            if (!$endToken->isTopLevel()) {
+                continue;
+            }
+            $following = $tokens[$index + 1] ?? null;
+            if ($following?->text === ']' && $following->isTopLevel()) {
+                $index++;
+                continue;
+            }
+
+            return $index + 1;
         }
 
         return $index;

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Sqlite;
 
 use ZtdQuery\Sql\SqlTokenStream;
+use ZtdQuery\Sql\SqlTokenKind;
 
 /**
  * Lightweight SQL parser for SQLite.
@@ -164,6 +165,52 @@ final class SqliteParser
         }
 
         return $this->parseAssignments($setClause);
+    }
+
+    public function extractUpdateAlias(string $sql): ?string
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        foreach ($tokens as $index => $token) {
+            if (!$token->isTopLevel() || !$token->isKeyword('UPDATE')) {
+                continue;
+            }
+
+            $index++;
+            if (($tokens[$index] ?? null)?->isKeyword('OR') === true) {
+                $index += 2;
+            }
+            $index = $this->identifierEndIndex($tokens, $index);
+            if (($tokens[$index] ?? null)?->kind === SqlTokenKind::Symbol
+                && $tokens[$index]->text === '.'
+            ) {
+                $index = $this->identifierEndIndex($tokens, $index + 1);
+            }
+            if (($tokens[$index] ?? null)?->isKeyword('AS') === true) {
+                $index++;
+            }
+
+            $alias = $tokens[$index] ?? null;
+            $set = $tokens[$index + 1] ?? null;
+            if ($alias === null
+                || $set === null
+                || !$set->isKeyword('SET')
+                || !in_array($alias->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)
+            ) {
+                return null;
+            }
+
+            return $this->unquoteIdentifier($alias->text);
+        }
+
+        return null;
+    }
+
+    public function extractUpdateFromClause(string $sql): ?string
+    {
+        return SqlTokenStream::tokenize($sql)->topLevelClause(
+            ['FROM'],
+            [['WHERE'], ['ORDER', 'BY'], ['LIMIT'], ['RETURNING']],
+        );
     }
 
     /**
@@ -474,6 +521,24 @@ final class SqliteParser
         }
 
         return null;
+    }
+
+    /** @param list<\ZtdQuery\Sql\SqlToken> $tokens */
+    private function identifierEndIndex(array $tokens, int $index): int
+    {
+        $token = $tokens[$index] ?? null;
+        if ($token === null || $token->kind !== SqlTokenKind::Symbol || $token->text !== '[') {
+            return $index + 1;
+        }
+
+        for ($index++; isset($tokens[$index]); $index++) {
+            $token = $tokens[$index];
+            if ($token->kind === SqlTokenKind::Symbol && $token->text === ']' && $token->isTopLevel()) {
+                return $index + 1;
+            }
+        }
+
+        return $index;
     }
 
     private function extractUpdateTable(string $sql): ?string

--- a/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/UpdateTransformer.php
@@ -76,6 +76,8 @@ final class UpdateTransformer implements SqlTransformer
         array $primaryKeys = [],
     ): string {
         $assignments = $this->parser->extractUpdateAssignments($sql);
+        $alias = $this->parser->extractUpdateAlias($sql);
+        $qualifier = $alias ?? $targetTable;
 
         $selectCols = [];
         $coveredCols = [];
@@ -87,13 +89,13 @@ final class UpdateTransformer implements SqlTransformer
 
         foreach ($columns as $col) {
             if (!isset($coveredCols[$col])) {
-                $selectCols[] = "\"$targetTable\".\"$col\"";
+                $selectCols[] = "\"$qualifier\".\"$col\"";
             }
         }
 
         $identity = new MutationRowIdentity();
         foreach ($primaryKeys as $primaryKey) {
-            $selectCols[] = '"' . $targetTable . '"."' . $primaryKey . '" AS "' . $identity->column($primaryKey) . '"';
+            $selectCols[] = '"' . $qualifier . '"."' . $primaryKey . '" AS "' . $identity->column($primaryKey) . '"';
         }
 
         if ($selectCols === []) {
@@ -101,6 +103,10 @@ final class UpdateTransformer implements SqlTransformer
         }
 
         $selectList = implode(', ', $selectCols);
+
+        $aliasClause = $alias === null ? '' : ' AS "' . $alias . '"';
+        $fromClause = $this->parser->extractUpdateFromClause($sql);
+        $additionalFrom = $fromClause === null ? '' : ', ' . $fromClause;
 
         $whereClause = '';
         $where = $this->parser->extractWhereClause($sql);
@@ -120,7 +126,7 @@ final class UpdateTransformer implements SqlTransformer
             $limitClause = " LIMIT $limit";
         }
 
-        return "SELECT $selectList FROM \"$targetTable\"$whereClause$orderByClause$limitClause";
+        return "SELECT $selectList FROM \"$targetTable\"$aliasClause$additionalFrom$whereClause$orderByClause$limitClause";
     }
 
     /**

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -188,6 +188,25 @@ SELECT * FROM users'));
         self::assertSame('users', $parser->extractTargetTable('DELETE FROM users WHERE id = 1'));
     }
 
+    public function testExtractUpdateAliasFromStructuredTarget(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame('target', $parser->extractUpdateAlias('UPDATE users AS target SET name = \'Alice\' WHERE target.id = 1'));
+        self::assertSame('target', $parser->extractUpdateAlias('UPDATE users target SET name = \'Alice\' WHERE target.id = 1'));
+        self::assertNull($parser->extractUpdateAlias('UPDATE users SET name = \'Alice\' WHERE id = 1'));
+    }
+
+    public function testExtractUpdateFromClausePreservesJoinSource(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            'incoming AS source',
+            $parser->extractUpdateFromClause('UPDATE inventory SET quantity = source.quantity FROM incoming AS source WHERE inventory.id = source.id'),
+        );
+    }
+
     public function testExtractCreateTableTarget(): void
     {
         $parser = new SqliteParser();

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -197,6 +197,39 @@ SELECT * FROM users'));
         self::assertNull($parser->extractUpdateAlias('UPDATE users SET name = \'Alice\' WHERE id = 1'));
     }
 
+    public function testExtractUpdateAliasHandlesConflictSchemaAndBracketedTarget(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            'target',
+            $parser->extractUpdateAlias(
+                'UPDATE OR REPLACE main.[user table] AS target SET name = \'Alice\' WHERE target.id = 1',
+            ),
+        );
+    }
+
+    public function testExtractUpdateAliasSkipsNestedUpdateKeyword(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            'target',
+            $parser->extractUpdateAlias(
+                'WITH source AS (SELECT UPDATE FROM audit) UPDATE users AS target SET name = \'Alice\'',
+            ),
+        );
+    }
+
+    public function testExtractUpdateAliasRejectsIncompleteTargets(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertNull($parser->extractUpdateAlias('UPDATE'));
+        self::assertNull($parser->extractUpdateAlias('UPDATE users'));
+        self::assertNull($parser->extractUpdateAlias('UPDATE users target'));
+    }
+
     public function testExtractUpdateFromClausePreservesJoinSource(): void
     {
         $parser = new SqliteParser();
@@ -204,6 +237,18 @@ SELECT * FROM users'));
         self::assertSame(
             'incoming AS source',
             $parser->extractUpdateFromClause('UPDATE inventory SET quantity = source.quantity FROM incoming AS source WHERE inventory.id = source.id'),
+        );
+    }
+
+    public function testExtractUpdateFromClauseStopsBeforeOrderedLimit(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            'incoming AS source',
+            $parser->extractUpdateFromClause(
+                'UPDATE inventory SET quantity = source.quantity FROM incoming AS source ORDER BY source.id LIMIT 1',
+            ),
         );
     }
 

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -209,6 +209,21 @@ SELECT * FROM users'));
         );
     }
 
+    public function testExtractUpdateAliasHandlesEscapedBracketTargetWithoutAs(): void
+    {
+        $parser = new SqliteParser();
+
+        self::assertSame(
+            'target',
+            $parser->extractUpdateAlias(
+                'UPDATE main.[user]]table] target SET name = \'Alice\' WHERE target.id = 1',
+            ),
+        );
+        self::assertNull(
+            $parser->extractUpdateAlias('UPDATE + ignored ] AS target SET name = \'Alice\''),
+        );
+    }
+
     public function testExtractUpdateAliasSkipsNestedUpdateKeyword(): void
     {
         $parser = new SqliteParser();
@@ -227,6 +242,7 @@ SELECT * FROM users'));
 
         self::assertNull($parser->extractUpdateAlias('UPDATE'));
         self::assertNull($parser->extractUpdateAlias('UPDATE users'));
+        self::assertNull($parser->extractUpdateAlias('UPDATE [users]'));
         self::assertNull($parser->extractUpdateAlias('UPDATE users target'));
     }
 

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -172,6 +172,44 @@ final class UpdateTransformerTest extends TestCase
         self::assertStringContainsString('"users"."id"', $projection);
     }
 
+    public function testBuildProjectionPreservesAliasFromSourceAndIdentityQualifier(): void
+    {
+        $parser = new SqliteParser();
+        $selectTransformer = new SelectTransformer();
+        $transformer = new UpdateTransformer($parser, $selectTransformer);
+
+        $projection = $transformer->buildProjection(
+            'UPDATE users AS target SET name = source.name FROM incoming AS source WHERE target.id = source.id',
+            'users',
+            ['id', 'name'],
+            ['id'],
+        );
+
+        self::assertSame(
+            'SELECT source.name AS "name", "target"."id", "target"."id" AS "__ztd_original_id" FROM "users" AS "target", incoming AS source WHERE target.id = source.id',
+            $projection,
+        );
+    }
+
+    public function testBuildProjectionWithoutAliasOrFromHasNoExtraSourceSyntax(): void
+    {
+        $parser = new SqliteParser();
+        $selectTransformer = new SelectTransformer();
+        $transformer = new UpdateTransformer($parser, $selectTransformer);
+
+        $projection = $transformer->buildProjection(
+            "UPDATE users SET name = 'Bob' WHERE id = 1",
+            'users',
+            ['id', 'name'],
+            ['id'],
+        );
+
+        self::assertSame(
+            'SELECT \'Bob\' AS "name", "users"."id", "users"."id" AS "__ztd_original_id" FROM "users" WHERE id = 1',
+            $projection,
+        );
+    }
+
     public function testBuildProjectionNoColumnsUsesStarFallback(): void
     {
         $parser = new SqliteParser();


### PR DESCRIPTION
## What changed

- parse SQLite UPDATE target aliases from the lossless token stream
- preserve UPDATE FROM sources in the simulated result-select
- qualify untouched columns and mutation row identity with the original target alias
- generate aliased UPDATE statements in SQLite correctness fuzzing
- fail fuzz inputs when native UPDATE succeeds but ZTD alone errors

## Root cause

The SQLite UPDATE transformer rebuilt the selection as `FROM target` regardless of the original UPDATE namespace. Target aliases used by WHERE expressions disappeared, and UPDATE FROM expressions referenced source tables that were never included in the result-select.

## Impact

SQLite UPDATE FROM and aliased UPDATE statements now select and mutate the same rows and values as native SQLite while keeping physical tables unchanged.

## Validation

- SQLite Unit: 1,226 tests / 2,155 assertions
- PDO Unit: 275 tests / 342 assertions
- SQLite Integration: 122 tests / 423 assertions
- SQLite and PDO lint/PHPStan
- 200 deterministic SQLite UPDATE fuzz inputs

Fixes #72
Fixes #79