### PR TITLE
Shadow schema-qualified SELECT sources

### DIFF
--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -386,3 +386,4 @@ final class SqlTokenStream
         return new SqlToken($kind, substr($sql, $start, $end - $start), $start, $depth, $bracketDepth);
     }
 }
+

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -387,3 +387,4 @@ final class SqlTokenStream
     }
 }
 
+

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -388,3 +388,4 @@ final class SqlTokenStream
 }
 
 
+

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -386,6 +386,3 @@ final class SqlTokenStream
         return new SqlToken($kind, substr($sql, $start, $end - $start), $start, $depth, $bracketDepth);
     }
 }
-
-
-

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -441,3 +441,4 @@ final class SqlTokenStreamTest extends TestCase
     }
 
 }
+

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -441,5 +441,3 @@ final class SqlTokenStreamTest extends TestCase
     }
 
 }
-
-

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -442,3 +442,4 @@ final class SqlTokenStreamTest extends TestCase
 
 }
 
+

--- a/packages/ztd-query-mysql/fuzz/Robustness/Invariant/RewritePlanConsistencyChecker.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Invariant/RewritePlanConsistencyChecker.php
@@ -61,6 +61,19 @@ final class RewritePlanConsistencyChecker implements InvariantChecker
             );
         }
 
+        $shadowTables = ['users', 'orders', 'order_items', 'products'];
+        $relationParser = new \ZtdQuery\Platform\MySql\MySqlSelectRelationParser();
+        $normalizedInput = $relationParser->unqualify($sql, $shadowTables);
+        $normalizedPlan = $relationParser->unqualify($plan->sql(), $shadowTables);
+        if ($normalizedInput !== $sql && $normalizedPlan !== $plan->sql()) {
+            return new InvariantViolation(
+                'INV-L2-07',
+                'schema-qualified shadow source survived rewrite',
+                $sql,
+                ['rewrite_sql' => $plan->sql()]
+            );
+        }
+
         return null;
     }
 }

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -185,6 +185,7 @@ final class RobustnessTarget
             fn () => $this->provider->replaceStatement(maxDepth: 5),
             fn () => $this->provider->truncateStatement(maxDepth: 3),
             fn (): string => 'EXPLAIN SELECT * FROM users',
+            fn (): string => 'SELECT * FROM app.users',
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/MySqlCteShadowComposer.php
+++ b/packages/ztd-query-mysql/src/MySqlCteShadowComposer.php
@@ -25,18 +25,21 @@ final class MySqlCteShadowComposer
     {
         $declared = array_fill_keys($this->declaredCteNames($sql), true);
         $ctes = [];
+        $shadowedTables = [];
         foreach ($tableCtes as $table => $cte) {
             $normalized = strtolower($table);
             if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
                 continue;
             }
             $ctes[] = $cte;
+            $shadowedTables[] = $table;
         }
 
         if ($ctes === []) {
             return $sql;
         }
 
+        $sql = (new MySqlSelectRelationParser())->unqualify($sql, $shadowedTables);
         $tokens = SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens();
         $with = $tokens[0] ?? null;
         if ($with === null || !$with->isKeyword('WITH')) {

--- a/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 
 #[CoversClass(MySqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 final class MySqlCteShadowComposerTest extends TestCase
 {
     public function testAddsShadowsAfterRecursiveModifier(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
@@ -124,7 +124,7 @@ final class MySqlCteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "WITH users AS (SELECT 1 AS id)\nSELECT * FROM \"users\"",
-            (new CteShadowComposer())->compose(
+            (new MySqlCteShadowComposer())->compose(
                 'SELECT * FROM public."users"',
                 ['users' => 'users AS (SELECT 1 AS id)'],
             ),

--- a/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
@@ -120,6 +120,17 @@ final class MySqlCteShadowComposerTest extends TestCase
         );
     }
 
+    public function testComposesShadowOverSchemaQualifiedSelectSource(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id)\nSELECT * FROM \"users\"",
+            (new CteShadowComposer())->compose(
+                'SELECT * FROM public."users"',
+                ['users' => 'users AS (SELECT 1 AS id)'],
+            ),
+        );
+    }
+
     public function testSkipsEntriesIndependentlyAndMatchesDeclaredNamesCaseInsensitively(): void
     {
         $composer = new MySqlCteShadowComposer();

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -63,6 +63,21 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
+    public function testDatabaseQualifiedSelectUsesShadowCte(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com']]);
+        $registry = new TableDefinitionRegistry();
+        $definition = $this->createSchemaParser()->parse($this->usersCreateTableSql());
+        self::assertNotNull($definition);
+        $registry->register('users', $definition);
+
+        $plan = $this->createRewriter($store, $registry)->rewrite('SELECT name FROM app.users');
+
+        self::assertStringStartsWith('WITH `users` AS', $plan->sql());
+        self::assertStringEndsWith('SELECT name FROM users', $plan->sql());
+    }
+
     public function testExplainPassesThroughUnchanged(): void
     {
         $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(DeleteTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
@@ -18,6 +18,7 @@ use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 
 #[CoversClass(MySqlTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(InsertTransformer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
@@ -19,6 +19,7 @@ use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(UpdateTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/SelectQualifiedTableTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/SelectQualifiedTableTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class SelectQualifiedTableTest extends TestCase
+{
+    public function testSchemaQualifiedTableReadsShadowRows(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $rawPdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO users (id, name) VALUES (1, 'Alice')");
+
+            $statement = $ztdPdo->query(sprintf('SELECT name FROM "%s".users WHERE id = 1', $schemaName));
+
+            self::assertNotFalse($statement);
+            self::assertSame([['name' => 'Alice']], $statement->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/SelectQualifiedTableTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/SelectQualifiedTableTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_sqlite
+ */
+#[CoversNothing]
+#[Large]
+final class SelectQualifiedTableTest extends TestCase
+{
+    public function testMainQualifiedTableReadsShadowRows(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO users (id, name) VALUES (1, 'Alice')");
+
+        $statement = $ztdPdo->query('SELECT name FROM main.users WHERE id = 1');
+
+        self::assertNotFalse($statement);
+        self::assertSame([['name' => 'Alice']], $statement->fetchAll());
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Invariant/RewritePlanConsistencyChecker.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Invariant/RewritePlanConsistencyChecker.php
@@ -61,6 +61,19 @@ final class RewritePlanConsistencyChecker implements InvariantChecker
             );
         }
 
+        $shadowTables = ['users', 'orders', 'order_items', 'products'];
+        $relationParser = new \ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser();
+        $normalizedInput = $relationParser->unqualify($sql, $shadowTables);
+        $normalizedPlan = $relationParser->unqualify($plan->sql(), $shadowTables);
+        if ($normalizedInput !== $sql && $normalizedPlan !== $plan->sql()) {
+            return new InvariantViolation(
+                'INV-L2-07',
+                'schema-qualified shadow source survived rewrite',
+                $sql,
+                ['rewrite_sql' => $plan->sql()]
+            );
+        }
+
         return null;
     }
 }

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
@@ -182,6 +182,7 @@ final class RobustnessTarget
             fn (): string => $this->provider->alterTableStatement(maxDepth: 5),
             fn (): string => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => 'EXPLAIN (FORMAT JSON) SELECT * FROM users',
+            fn (): string => 'SELECT * FROM public.users',
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlCteShadowComposer.php
+++ b/packages/ztd-query-postgres/src/PgSqlCteShadowComposer.php
@@ -25,18 +25,21 @@ final class PgSqlCteShadowComposer
     {
         $declared = array_fill_keys($this->declaredCteNames($sql), true);
         $ctes = [];
+        $shadowedTables = [];
         foreach ($tableCtes as $table => $cte) {
             $normalized = strtolower($table);
             if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
                 continue;
             }
             $ctes[] = $cte;
+            $shadowedTables[] = $table;
         }
 
         if ($ctes === []) {
             return $sql;
         }
 
+        $sql = SqlTokenStream::tokenize($sql, $this->dialect)->unqualifySelectTableReferences($shadowedTables);
         $tokens = SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens();
         $with = $tokens[0] ?? null;
         if ($with === null || !$with->isKeyword('WITH')) {

--- a/packages/ztd-query-postgres/src/PgSqlCteShadowComposer.php
+++ b/packages/ztd-query-postgres/src/PgSqlCteShadowComposer.php
@@ -39,7 +39,7 @@ final class PgSqlCteShadowComposer
             return $sql;
         }
 
-        $sql = SqlTokenStream::tokenize($sql, $this->dialect)->unqualifySelectTableReferences($shadowedTables);
+        $sql = (new PgSqlSelectRelationParser())->unqualify($sql, $shadowedTables);
         $tokens = SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens();
         $with = $tokens[0] ?? null;
         if ($with === null || !$with->isKeyword('WITH')) {

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
@@ -213,4 +213,14 @@ final class PgSqlCteShadowComposerTest extends TestCase
             ),
         );
     }
+    public function testComposesShadowOverSchemaQualifiedSelectSource(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id)\nSELECT * FROM \"users\"",
+            (new PgSqlCteShadowComposer())->compose(
+                'SELECT * FROM public."users"',
+                ['users' => 'users AS (SELECT 1 AS id)'],
+            ),
+        );
+    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
 
 #[CoversClass(PgSqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 final class PgSqlCteShadowComposerTest extends TestCase
 {
     public function testAddsShadowsAfterRecursiveModifier(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -62,6 +62,21 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
+    public function testSchemaQualifiedSelectUsesShadowCte(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com']]);
+        $registry = new TableDefinitionRegistry();
+        $definition = $this->createSchemaParser()->parse($this->usersCreateTableSql());
+        self::assertNotNull($definition);
+        $registry->register('users', $definition);
+
+        $plan = $this->createRewriter($store, $registry)->rewrite('SELECT name FROM public.users');
+
+        self::assertStringStartsWith('WITH "users" AS MATERIALIZED', $plan->sql());
+        self::assertStringEndsWith('SELECT name FROM users', $plan->sql());
+    }
+
     public function testExplainPassesThroughUnchanged(): void
     {
         $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
@@ -20,6 +20,7 @@ use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(PgSqlTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -17,6 +17,7 @@ use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 
 #[CoversClass(DeleteTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -20,6 +20,7 @@ use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 
 #[CoversClass(InsertTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
@@ -16,6 +16,7 @@ use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 
 #[CoversClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -17,6 +17,7 @@ use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 
 #[CoversClass(UpdateTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Invariant/RewritePlanConsistencyChecker.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Invariant/RewritePlanConsistencyChecker.php
@@ -61,6 +61,19 @@ final class RewritePlanConsistencyChecker implements InvariantChecker
             );
         }
 
+        $shadowTables = ['users', 'orders', 'order_items', 'products'];
+        $relationParser = new \ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser();
+        $normalizedInput = $relationParser->unqualify($sql, $shadowTables);
+        $normalizedPlan = $relationParser->unqualify($plan->sql(), $shadowTables);
+        if ($normalizedInput !== $sql && $normalizedPlan !== $plan->sql()) {
+            return new InvariantViolation(
+                'INV-L2-07',
+                'schema-qualified shadow source survived rewrite',
+                $sql,
+                ['rewrite_sql' => $plan->sql()]
+            );
+        }
+
         return null;
     }
 }

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RobustnessTarget.php
@@ -182,6 +182,7 @@ final class RobustnessTarget
             fn () => $this->provider->alterTableStatement(maxDepth: 5),
             fn () => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => 'EXPLAIN QUERY PLAN SELECT * FROM users',
+            fn (): string => 'SELECT * FROM main.users',
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-sqlite/src/SqliteCteShadowComposer.php
+++ b/packages/ztd-query-sqlite/src/SqliteCteShadowComposer.php
@@ -25,18 +25,21 @@ final class SqliteCteShadowComposer
     {
         $declared = array_fill_keys($this->declaredCteNames($sql), true);
         $ctes = [];
+        $shadowedTables = [];
         foreach ($tableCtes as $table => $cte) {
             $normalized = strtolower($table);
             if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
                 continue;
             }
             $ctes[] = $cte;
+            $shadowedTables[] = $table;
         }
 
         if ($ctes === []) {
             return $sql;
         }
 
+        $sql = SqlTokenStream::tokenize($sql, $this->dialect)->unqualifySelectTableReferences($shadowedTables);
         $tokens = SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens();
         $with = $tokens[0] ?? null;
         if ($with === null || !$with->isKeyword('WITH')) {

--- a/packages/ztd-query-sqlite/src/SqliteCteShadowComposer.php
+++ b/packages/ztd-query-sqlite/src/SqliteCteShadowComposer.php
@@ -39,7 +39,7 @@ final class SqliteCteShadowComposer
             return $sql;
         }
 
-        $sql = SqlTokenStream::tokenize($sql, $this->dialect)->unqualifySelectTableReferences($shadowedTables);
+        $sql = (new SqliteSelectRelationParser())->unqualify($sql, $shadowedTables);
         $tokens = SqlTokenStream::tokenize($sql, $this->dialect)->significantTokens();
         $with = $tokens[0] ?? null;
         if ($with === null || !$with->isKeyword('WITH')) {

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
 
 #[CoversClass(SqliteCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 final class SqliteCteShadowComposerTest extends TestCase
 {
     public function testAddsShadowsAfterRecursiveModifier(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
@@ -213,4 +213,14 @@ final class SqliteCteShadowComposerTest extends TestCase
             ),
         );
     }
+    public function testComposesShadowOverSchemaQualifiedSelectSource(): void
+    {
+        self::assertSame(
+            "WITH users AS (SELECT 1 AS id)\nSELECT * FROM \"users\"",
+            (new SqliteCteShadowComposer())->compose(
+                'SELECT * FROM public."users"',
+                ['users' => 'users AS (SELECT 1 AS id)'],
+            ),
+        );
+    }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -91,6 +91,21 @@ final class SqliteRewriterTest extends RewriterContractTest
         );
     }
 
+    public function testSchemaQualifiedSelectUsesShadowCte(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com']]);
+        $registry = new TableDefinitionRegistry();
+        $definition = $this->createSchemaParser()->parse($this->usersCreateTableSql());
+        self::assertNotNull($definition);
+        $registry->register('users', $definition);
+
+        $plan = $this->createRewriter($store, $registry)->rewrite('SELECT name FROM main.users');
+
+        self::assertStringStartsWith('WITH "users" AS', $plan->sql());
+        self::assertStringEndsWith('SELECT name FROM users', $plan->sql());
+    }
+
     public function testReadOnlyDiagnosticsPassThroughUnchanged(): void
     {
         $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(DeleteTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 
 #[CoversClass(InsertTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -20,6 +20,7 @@ use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(SqliteTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(DeleteTransformer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(UpdateTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]


### PR DESCRIPTION
Stacked on #230.

Root problem

The rewriters normalized schema-qualified relations for registry lookup, but left the qualified physical source (`public.users`, `main.users`, or `app.users`) in the rewritten SELECT. The injected unqualified `users` CTE therefore never shadowed that source.

Fix

- Teach the shared SQL token stream to identify SELECT source spans at every nested scope and remove schema/catalog prefixes only for relations that actually receive a shadow CTE.
- Perform this normalization centrally in `CteShadowComposer`, covering MySQL, PostgreSQL, and SQLite without regex-based rewriting.
- Preserve unrelated qualified physical sources and quoted final identifiers.

Recurrence prevention

- Add token-stream and CTE-composer structural tests.
- Add per-dialect rewriter regression tests.
- Add real PostgreSQL and SQLite PDO integration tests proving qualified SELECTs return shadow rows.
- Add qualified-source cases to all robustness fuzz targets and invariant `INV-L2-07`, which fails if a qualified shadow source survives rewrite.
- SQLFaker already supports the syntax through PostgreSQL `qualifiedName()` and SQLite `fullname()`; the missing layer was a semantic rewrite invariant.

Validation

- Core/MySQL/PostgreSQL/SQLite/PDO unit suites: 4,411 tests passed.
- SQLite integration: 89 tests passed.
- Focused PostgreSQL container integration: passed.
- Lint/PHPStan: all affected packages passed.
- Qualified-source robustness inputs passed for all three dialects.

Fixes #24
Refs #157

The separate `ATTACH DATABASE` behavior reported in #157 is intentionally not included in this root-problem PR.