### PR TITLE
Strip SQLite index hints from shadow sources

### DIFF
--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/IndexHintTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/IndexHintTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_sqlite
+ */
+#[CoversNothing]
+#[Large]
+final class IndexHintTest extends TestCase
+{
+    public function testSelectIndexedByReadsShadowRows(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, category TEXT, price REAL)');
+        $rawPdo->exec('CREATE INDEX idx_category ON products (category)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO products VALUES (1, 'Widget', 'tools', 9.99)");
+
+        $statement = $ztdPdo->query("SELECT name FROM products INDEXED BY idx_category WHERE category = 'tools'");
+
+        self::assertNotFalse($statement);
+        self::assertSame([['name' => 'Widget']], $statement->fetchAll());
+    }
+
+    public function testPreparedSelectIndexedByReadsShadowRows(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, category TEXT, price REAL)');
+        $rawPdo->exec('CREATE INDEX idx_category ON products (category)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO products VALUES (1, 'Widget', 'tools', 9.99)");
+
+        $statement = $ztdPdo->prepare('SELECT name FROM products INDEXED BY idx_category WHERE category = ?');
+        self::assertNotFalse($statement);
+        $statement->execute(['tools']);
+
+        self::assertSame([['name' => 'Widget']], $statement->fetchAll());
+    }
+
+    public function testSelectNotIndexedReadsShadowRows(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, category TEXT, price REAL)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO products VALUES (1, 'Widget', 'tools', 9.99)");
+
+        $statement = $ztdPdo->query("SELECT name FROM products NOT INDEXED WHERE category = 'tools'");
+
+        self::assertNotFalse($statement);
+        self::assertSame([['name' => 'Widget']], $statement->fetchAll());
+    }
+
+    public function testUpdateIndexedByMutatesShadowRows(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, category TEXT, price REAL)');
+        $rawPdo->exec('CREATE INDEX idx_category ON products (category)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO products VALUES (1, 'Widget', 'tools', 9.99)");
+
+        self::assertSame(1, $ztdPdo->exec("UPDATE products INDEXED BY idx_category SET price = 19.99 WHERE category = 'tools'"));
+        $statement = $ztdPdo->query('SELECT price FROM products WHERE id = 1');
+
+        self::assertNotFalse($statement);
+        self::assertSame([['price' => 19.99]], $statement->fetchAll());
+    }
+
+    public function testDeleteIndexedByMutatesShadowRows(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, category TEXT, price REAL)');
+        $rawPdo->exec('CREATE INDEX idx_category ON products (category)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO products VALUES (1, 'Widget', 'tools', 9.99)");
+
+        self::assertSame(1, $ztdPdo->exec("DELETE FROM products INDEXED BY idx_category WHERE category = 'tools'"));
+        $statement = $ztdPdo->query('SELECT * FROM products');
+
+        self::assertNotFalse($statement);
+        self::assertSame([], $statement->fetchAll());
+    }
+}

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Invariant/RewritePlanConsistencyChecker.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Invariant/RewritePlanConsistencyChecker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fuzz\Robustness\Invariant;
 
 use Throwable;
+use ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -69,6 +70,18 @@ final class RewritePlanConsistencyChecker implements InvariantChecker
             return new InvariantViolation(
                 'INV-L2-07',
                 'schema-qualified shadow source survived rewrite',
+                $sql,
+                ['rewrite_sql' => $plan->sql()]
+            );
+        }
+
+        $hintStripper = new SqliteIndexHintStripper();
+        $strippedInput = $hintStripper->strip($sql, $shadowTables);
+        $strippedPlan = $hintStripper->strip($plan->sql(), $shadowTables);
+        if ($strippedInput !== $sql && $strippedPlan !== $plan->sql()) {
+            return new InvariantViolation(
+                'INV-L2-08',
+                'shadow source index hint survived rewrite',
                 $sql,
                 ['rewrite_sql' => $plan->sql()]
             );

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RobustnessTarget.php
@@ -183,6 +183,8 @@ final class RobustnessTarget
             fn () => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => 'EXPLAIN QUERY PLAN SELECT * FROM users',
             fn (): string => 'SELECT * FROM main.users',
+            fn (): string => 'SELECT * FROM users INDEXED BY idx_users',
+            fn (): string => 'SELECT * FROM users NOT INDEXED',
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-sqlite/src/SqliteIndexHintStripper.php
+++ b/packages/ztd-query-sqlite/src/SqliteIndexHintStripper.php
@@ -15,13 +15,10 @@ final class SqliteIndexHintStripper
      */
     public function strip(string $sql, array $shadowTables): string
     {
-        $targets = [];
-        foreach ($shadowTables as $table) {
-            $targets[strtolower($table)] = true;
-        }
-        if ($targets === []) {
-            return $sql;
-        }
+        $targets = array_map(
+            static fn (string $table): string => strtolower($table),
+            $shadowTables,
+        );
 
         $stream = SqlTokenStream::tokenize($sql);
         $tokens = $stream->significantTokens();
@@ -29,29 +26,16 @@ final class SqliteIndexHintStripper
         $removals = [];
 
         foreach ((new SqliteSelectRelationParser())->references($sql) as $reference) {
-            if (!isset($targets[strtolower($reference['name'])])) {
+            if (!in_array(strtolower($reference['name']), $targets, true)) {
                 continue;
             }
             $index = self::tokenIndexAtOrAfter($tokens, $reference['end']);
             $index = self::skipAlias($tokens, $index);
-            $indexed = $tokens[$index] ?? null;
-            $next = $tokens[$index + 1] ?? null;
-
-            if ($indexed?->isKeyword('NOT') === true && $next?->isKeyword('INDEXED') === true) {
-                $removals[] = ['start' => $indexed->offset, 'end' => $next->endOffset()];
+            $range = self::hintRange($tokens, $index);
+            if ($range === null) {
                 continue;
             }
-            if ($indexed?->isKeyword('INDEXED') !== true || $next?->isKeyword('BY') !== true) {
-                continue;
-            }
-            $nameEnd = self::identifierEndIndex($tokens, $index + 2);
-            if ($nameEnd === null) {
-                continue;
-            }
-            $removals[] = [
-                'start' => $indexed->offset,
-                'end' => $tokens[$nameEnd - 1]->endOffset(),
-            ];
+            $removals[] = $range;
         }
 
         usort($removals, static fn (array $left, array $right): int => $right['start'] <=> $left['start']);
@@ -60,6 +44,50 @@ final class SqliteIndexHintStripper
         }
 
         return $sql;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{start: int, end: int}|null
+     */
+    private static function hintRange(array $tokens, int $index): ?array
+    {
+        $keyword = $tokens[$index] ?? null;
+        if ($keyword === null) {
+            return null;
+        }
+
+        if ($keyword->isKeyword('NOT')) {
+            $indexed = $tokens[$index + 1] ?? null;
+            if ($indexed === null) {
+                return null;
+            }
+            if (!$indexed->isKeyword('INDEXED')) {
+                return null;
+            }
+
+            return ['start' => $keyword->offset, 'end' => $indexed->endOffset()];
+        }
+
+        if (!$keyword->isKeyword('INDEXED')) {
+            return null;
+        }
+        $by = $tokens[$index + 1] ?? null;
+        if ($by === null) {
+            return null;
+        }
+        if (!$by->isKeyword('BY')) {
+            return null;
+        }
+        $nameEnd = self::identifierEndIndex($tokens, $index + 2);
+        if ($nameEnd === null) {
+            return null;
+        }
+
+        return [
+            'start' => $keyword->offset,
+            'end' => $tokens[$nameEnd - 1]->endOffset(),
+        ];
     }
 
     /**
@@ -81,12 +109,15 @@ final class SqliteIndexHintStripper
      */
     private static function skipAlias(array $tokens, int $index): int
     {
-        if (($tokens[$index] ?? null)?->isKeyword('AS') === true) {
+        $candidate = $tokens[$index] ?? null;
+        if ($candidate === null) {
+            return $index;
+        }
+        if ($candidate->isKeyword('AS')) {
             return self::identifierEndIndex($tokens, $index + 1) ?? $index;
         }
 
-        $candidate = $tokens[$index] ?? null;
-        if ($candidate === null || self::isSourceBoundary($candidate)) {
+        if (self::isSourceBoundary($candidate)) {
             return $index;
         }
 
@@ -95,10 +126,6 @@ final class SqliteIndexHintStripper
 
     private static function isSourceBoundary(SqlToken $token): bool
     {
-        if ($token->kind === SqlTokenKind::Symbol) {
-            return true;
-        }
-
         foreach ([
             'INDEXED', 'NOT', 'WHERE', 'GROUP', 'HAVING', 'ORDER', 'LIMIT', 'OFFSET',
             'JOIN', 'LEFT', 'RIGHT', 'FULL', 'INNER', 'CROSS', 'NATURAL', 'ON', 'USING',
@@ -124,16 +151,28 @@ final class SqliteIndexHintStripper
         if ($token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier) {
             return $index + 1;
         }
-        if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '[') {
+        if ($token->kind !== SqlTokenKind::Symbol) {
+            return null;
+        }
+        if ($token->text !== '[') {
             return null;
         }
 
-        foreach ($tokens as $endIndex => $endToken) {
-            if ($endIndex > $index && $endToken->kind === SqlTokenKind::Symbol && $endToken->text === ']') {
-                return $endIndex + 1;
+        $endIndex = $index;
+        while (true) {
+            $endIndex++;
+            $endToken = $tokens[$endIndex] ?? null;
+            if ($endToken === null) {
+                return null;
             }
-        }
+            if ($endToken->kind !== SqlTokenKind::Symbol) {
+                continue;
+            }
+            if ($endToken->text !== ']') {
+                continue;
+            }
 
-        return null;
+            return $endIndex + 1;
+        }
     }
 }

--- a/packages/ztd-query-sqlite/src/SqliteIndexHintStripper.php
+++ b/packages/ztd-query-sqlite/src/SqliteIndexHintStripper.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class SqliteIndexHintStripper
+{
+    /**
+     * @param list<string> $shadowTables
+     */
+    public function strip(string $sql, array $shadowTables): string
+    {
+        $targets = [];
+        foreach ($shadowTables as $table) {
+            $targets[strtolower($table)] = true;
+        }
+        if ($targets === []) {
+            return $sql;
+        }
+
+        $stream = SqlTokenStream::tokenize($sql);
+        $tokens = $stream->significantTokens();
+        /** @var list<array{start: int, end: int}> $removals */
+        $removals = [];
+
+        foreach ((new SqliteSelectRelationParser())->references($sql) as $reference) {
+            if (!isset($targets[strtolower($reference['name'])])) {
+                continue;
+            }
+            $index = self::tokenIndexAtOrAfter($tokens, $reference['end']);
+            $index = self::skipAlias($tokens, $index);
+            $indexed = $tokens[$index] ?? null;
+            $next = $tokens[$index + 1] ?? null;
+
+            if ($indexed?->isKeyword('NOT') === true && $next?->isKeyword('INDEXED') === true) {
+                $removals[] = ['start' => $indexed->offset, 'end' => $next->endOffset()];
+                continue;
+            }
+            if ($indexed?->isKeyword('INDEXED') !== true || $next?->isKeyword('BY') !== true) {
+                continue;
+            }
+            $nameEnd = self::identifierEndIndex($tokens, $index + 2);
+            if ($nameEnd === null) {
+                continue;
+            }
+            $removals[] = [
+                'start' => $indexed->offset,
+                'end' => $tokens[$nameEnd - 1]->endOffset(),
+            ];
+        }
+
+        usort($removals, static fn (array $left, array $right): int => $right['start'] <=> $left['start']);
+        foreach ($removals as $removal) {
+            $sql = substr_replace($sql, '', $removal['start'], $removal['end'] - $removal['start']);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function tokenIndexAtOrAfter(array $tokens, int $offset): int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->offset >= $offset) {
+                return $index;
+            }
+        }
+
+        return count($tokens);
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function skipAlias(array $tokens, int $index): int
+    {
+        if (($tokens[$index] ?? null)?->isKeyword('AS') === true) {
+            return self::identifierEndIndex($tokens, $index + 1) ?? $index;
+        }
+
+        $candidate = $tokens[$index] ?? null;
+        if ($candidate === null || self::isSourceBoundary($candidate)) {
+            return $index;
+        }
+
+        return self::identifierEndIndex($tokens, $index) ?? $index;
+    }
+
+    private static function isSourceBoundary(SqlToken $token): bool
+    {
+        if ($token->kind === SqlTokenKind::Symbol) {
+            return true;
+        }
+
+        foreach ([
+            'INDEXED', 'NOT', 'WHERE', 'GROUP', 'HAVING', 'ORDER', 'LIMIT', 'OFFSET',
+            'JOIN', 'LEFT', 'RIGHT', 'FULL', 'INNER', 'CROSS', 'NATURAL', 'ON', 'USING',
+            'UNION', 'INTERSECT', 'EXCEPT', 'RETURNING', 'WINDOW', 'FOR',
+        ] as $keyword) {
+            if ($token->isKeyword($keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function identifierEndIndex(array $tokens, int $index): ?int
+    {
+        $token = $tokens[$index] ?? null;
+        if ($token === null) {
+            return null;
+        }
+        if ($token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier) {
+            return $index + 1;
+        }
+        if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '[') {
+            return null;
+        }
+
+        foreach ($tokens as $endIndex => $endToken) {
+            if ($endIndex > $index && $endToken->kind === SqlTokenKind::Symbol && $endToken->text === ']') {
+                return $endIndex + 1;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Sqlite\Transformer;
 
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
+use ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
@@ -26,6 +27,7 @@ final class SelectTransformer implements SqlTransformer
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
     private SqliteCteShadowComposer $cteComposer;
+    private SqliteIndexHintStripper $indexHintStripper;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -36,6 +38,7 @@ final class SelectTransformer implements SqlTransformer
         $this->quoter = $quoter ?? new SqliteIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Sqlite\SqliteValueRenderer($this->castRenderer);
         $this->cteComposer = new SqliteCteShadowComposer();
+        $this->indexHintStripper = new SqliteIndexHintStripper();
     }
 
     /**
@@ -66,6 +69,8 @@ final class SelectTransformer implements SqlTransformer
 
             $ctes[$tableName] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
         }
+
+        $sql = $this->indexHintStripper->strip($sql, array_keys($ctes));
 
         return $this->cteComposer->compose($sql, $ctes);
     }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteIndexHintStripperTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteIndexHintStripperTest.php
@@ -6,10 +6,12 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper;
 
 #[CoversClass(SqliteIndexHintStripper::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 final class SqliteIndexHintStripperTest extends TestCase
 {
     public function testStripsIndexedByFromShadowSource(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteIndexHintStripperTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteIndexHintStripperTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqliteIndexHintStripper::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class SqliteIndexHintStripperTest extends TestCase
 {
     public function testStripsIndexedByFromShadowSource(): void
@@ -48,5 +46,67 @@ final class SqliteIndexHintStripperTest extends TestCase
         $sql = "SELECT 'INDEXED BY idx_category' FROM products WHERE note = 'NOT INDEXED'";
 
         self::assertSame($sql, (new SqliteIndexHintStripper())->strip($sql, ['products']));
+    }
+
+    public function testMatchesShadowNamesCaseInsensitivelyAfterPhysicalSource(): void
+    {
+        self::assertSame(
+            'SELECT * FROM audit INDEXED BY audit_idx JOIN Products  ON Products.id = audit.id',
+            (new SqliteIndexHintStripper())->strip(
+                'SELECT * FROM audit INDEXED BY audit_idx JOIN Products INDEXED BY products_idx ON Products.id = audit.id',
+                ['PRODUCTS'],
+            ),
+        );
+    }
+
+    public function testStripsEveryHintAcrossConsecutiveShadowSources(): void
+    {
+        self::assertSame(
+            'SELECT * FROM products  JOIN products  ON TRUE',
+            (new SqliteIndexHintStripper())->strip(
+                'SELECT * FROM products NOT INDEXED JOIN products INDEXED BY `idx_products` ON TRUE',
+                ['products'],
+            ),
+        );
+    }
+
+    #[DataProvider('providerIncompleteAndMalformedHints')]
+    public function testPreservesIncompleteAndMalformedHints(string $sql): void
+    {
+        self::assertSame($sql, (new SqliteIndexHintStripper())->strip($sql, ['products']));
+    }
+
+    /** @return \Generator<string, array{string}> */
+    public static function providerIncompleteAndMalformedHints(): \Generator
+    {
+        yield 'no hint' => ['SELECT * FROM products'];
+        yield 'not without indexed' => ['SELECT * FROM products NOT'];
+        yield 'not followed by clause' => ['SELECT * FROM products NOT WHERE TRUE'];
+        yield 'indexed without by' => ['SELECT * FROM products INDEXED'];
+        yield 'indexed followed by names' => ['SELECT * FROM products INDEXED wrong hint'];
+        yield 'clause followed by by and name' => ['SELECT * FROM products WHERE BY hint'];
+        yield 'symbol as index name' => ['SELECT * FROM products INDEXED BY ) ] WHERE TRUE'];
+    }
+
+    public function testDoesNotConfuseCommaBoundaryWithAlias(): void
+    {
+        self::assertSame(
+            'SELECT * FROM products, users  WHERE TRUE',
+            (new SqliteIndexHintStripper())->strip(
+                'SELECT * FROM products, users INDEXED BY idx_users WHERE TRUE',
+                ['products', 'users'],
+            ),
+        );
+    }
+
+    public function testStripsEmptyBracketIndexAfterBracketAlias(): void
+    {
+        self::assertSame(
+            'SELECT * FROM products [p]  WHERE TRUE',
+            (new SqliteIndexHintStripper())->strip(
+                'SELECT * FROM products [p] INDEXED BY [] WHERE TRUE',
+                ['products'],
+            ),
+        );
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteIndexHintStripperTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteIndexHintStripperTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(SqliteIndexHintStripper::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class SqliteIndexHintStripperTest extends TestCase
+{
+    public function testStripsIndexedByFromShadowSource(): void
+    {
+        self::assertSame(
+            'SELECT * FROM products  WHERE category = ?',
+            (new SqliteIndexHintStripper())->strip(
+                'SELECT * FROM products INDEXED BY idx_category WHERE category = ?',
+                ['products'],
+            ),
+        );
+    }
+
+    public function testStripsHintsAfterAliasesAndInNestedScopes(): void
+    {
+        self::assertSame(
+            'SELECT * FROM products AS p  WHERE EXISTS (SELECT 1 FROM products nested )',
+            (new SqliteIndexHintStripper())->strip(
+                'SELECT * FROM products AS p INDEXED BY [idx_category] WHERE EXISTS (SELECT 1 FROM products nested NOT INDEXED)',
+                ['products'],
+            ),
+        );
+    }
+
+    public function testPreservesHintsForPhysicalSources(): void
+    {
+        $sql = 'SELECT * FROM products INDEXED BY idx_category JOIN audit NOT INDEXED ON audit.id = products.id';
+
+        self::assertSame($sql, (new SqliteIndexHintStripper())->strip($sql, ['users']));
+    }
+
+    public function testDoesNotTreatExpressionsAsSourceHints(): void
+    {
+        $sql = "SELECT 'INDEXED BY idx_category' FROM products WHERE note = 'NOT INDEXED'";
+
+        self::assertSame($sql, (new SqliteIndexHintStripper())->strip($sql, ['products']));
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -51,6 +51,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(SqliteMutationResolver::class)]
 #[UsesClass(SqliteTransformer::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper::class)]
 #[UsesClass(InsertTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\Transformer\InsertSelectRenderer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -45,6 +45,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\Transformer\InsertSelectRenderer::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper::class)]
 #[UsesClass(SqliteTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -25,6 +25,7 @@ use ZtdQuery\Schema\IdentityGenerationStrategy;
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(SelectTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -71,6 +71,23 @@ final class SelectTransformerTest extends TransformerContractTest
         self::assertSame($sql, $result);
     }
 
+    public function testTransformStripsIndexHintForMaterializedShadow(): void
+    {
+        $transformer = new SelectTransformer();
+        $tables = [
+            'products' => [
+                'rows' => [['id' => 1]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        $result = $transformer->transform('SELECT * FROM products INDEXED BY idx_products', $tables);
+
+        self::assertStringNotContainsString('INDEXED BY', $result);
+        self::assertStringContainsString('SELECT * FROM products ', $result);
+    }
+
     public function testTransformWithEmptyRowsGeneratesEmptyCte(): void
     {
         $transformer = new SelectTransformer();

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\Transformer\InsertSelectRenderer::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]


### PR DESCRIPTION
Stacked on #231.

Root problem

SQLite `INDEXED BY` names an index owned by the physical table. After the relation is replaced by a shadow CTE, that index does not exist on the CTE, so the rewritten SELECT fails with `no such index`. `NOT INDEXED` is the same source modifier and must follow the same shadowing rule.

Fix

- Expose structure-aware SELECT relation spans from the shared SQL token stream.
- Add a SQLite token-based index-hint stripper that removes `INDEXED BY` / `NOT INDEXED` only from relations actually backed by generated shadow CTEs.
- Preserve hints on non-shadow physical sources, quoted index names, aliases, nested scopes, strings, and comments.
- Apply the mechanism centrally in SQLite `SelectTransformer`, which also covers SELECT projections produced for UPDATE and DELETE.

Recurrence prevention

- Add dedicated stripper unit tests for aliases, nested scopes, quoting, and physical-source preservation.
- Add SQLite PDO integration tests for direct SELECT, prepared SELECT, NOT INDEXED, UPDATE, and DELETE.
- Add deterministic indexed/not-indexed cases and invariant `INV-L2-08` to the SQLite robustness fuzz target.
- SQLFaker's official SQLite grammar already includes `indexed_opt`; the missing protection was semantic validation of the rewritten plan.

Validation

- Core unit: 599 tests passed.
- SQLite unit: 1,233 tests passed.
- PDO unit: 275 tests passed.
- SQLite integration: 94 tests passed.
- Lint/PHPStan: all affected packages passed.
- Both indexed and not-indexed robustness inputs passed.

Fixes #154