### PR TITLE
Allow safe SQLite in-memory attachments

### DIFF
--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/InMemoryAttachTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/InMemoryAttachTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_sqlite
+ */
+#[CoversNothing]
+#[Large]
+final class InMemoryAttachTest extends TestCase
+{
+    public function testInMemoryDatabaseIsAttachedToPhysicalConnection(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        $ztdPdo->exec("ATTACH DATABASE ':memory:' AS db2");
+        $statement = $rawPdo->query('PRAGMA database_list');
+
+        self::assertNotFalse($statement);
+        self::assertContains('db2', array_column($statement->fetchAll(), 'name'));
+    }
+
+    public function testPersistentDatabaseAttachIsRejected(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        ]);
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        $this->expectException(\RuntimeException::class);
+
+        $ztdPdo->exec("ATTACH 'test.sqlite' AS db2");
+    }
+}

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Invariant/ClassifyRewriteAgreementChecker.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Invariant/ClassifyRewriteAgreementChecker.php
@@ -7,6 +7,7 @@ namespace Fuzz\Robustness\Invariant;
 use Throwable;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Sqlite\SqliteInMemoryAttachStatement;
 use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -26,19 +27,22 @@ final class ClassifyRewriteAgreementChecker implements InvariantChecker
     public function check(string $sql): ?InvariantViolation
     {
         $diagnostic = SqliteReadOnlyDiagnosticStatement::isSafe($sql);
+        $inMemoryAttach = SqliteInMemoryAttachStatement::isSafe($sql);
+        $protectedPassthrough = $diagnostic || $inMemoryAttach;
+        $passthroughInvariant = $inMemoryAttach ? 'INV-L2-09' : 'INV-L2-06';
 
         try {
             $classifyResult = $this->guard->classify($sql);
         } catch (Throwable $exception) {
-            if ($diagnostic) {
-                return new InvariantViolation('INV-L2-06', 'read-only diagnostic classification threw', $sql, ['exception' => $exception::class]);
+            if ($protectedPassthrough) {
+                return new InvariantViolation($passthroughInvariant, 'safe passthrough classification threw', $sql, ['exception' => $exception::class]);
             }
 
             return null;
         }
 
-        if ($diagnostic && $classifyResult !== QueryKind::READ) {
-            return new InvariantViolation('INV-L2-06', 'read-only diagnostic was not classified as READ', $sql);
+        if ($protectedPassthrough && $classifyResult !== QueryKind::READ) {
+            return new InvariantViolation($passthroughInvariant, 'safe passthrough was not classified as READ', $sql);
         }
 
         if ($classifyResult === null) {
@@ -55,27 +59,27 @@ final class ClassifyRewriteAgreementChecker implements InvariantChecker
         try {
             $plan = $this->rewriter->rewrite($sql);
         } catch (UnknownSchemaException $exception) {
-            if ($diagnostic) {
-                return new InvariantViolation('INV-L2-06', 'read-only diagnostic required schema metadata', $sql, ['exception' => $exception::class]);
+            if ($protectedPassthrough) {
+                return new InvariantViolation($passthroughInvariant, 'safe passthrough required schema metadata', $sql, ['exception' => $exception::class]);
             }
 
             return null;
         } catch (UnsupportedSqlException $exception) {
-            if ($diagnostic) {
-                return new InvariantViolation('INV-L2-06', 'read-only diagnostic was rejected', $sql, ['exception' => $exception::class]);
+            if ($protectedPassthrough) {
+                return new InvariantViolation($passthroughInvariant, 'safe passthrough was rejected', $sql, ['exception' => $exception::class]);
             }
 
             return null;
         } catch (Throwable $exception) {
-            if ($diagnostic) {
-                return new InvariantViolation('INV-L2-06', 'read-only diagnostic rewrite threw', $sql, ['exception' => $exception::class]);
+            if ($protectedPassthrough) {
+                return new InvariantViolation($passthroughInvariant, 'safe passthrough rewrite threw', $sql, ['exception' => $exception::class]);
             }
 
             return null;
         }
 
-        if ($diagnostic && ($plan->kind() !== QueryKind::READ || $plan->sql() !== $sql)) {
-            return new InvariantViolation('INV-L2-06', 'read-only diagnostic was not preserved as an unchanged READ plan', $sql);
+        if ($protectedPassthrough && ($plan->kind() !== QueryKind::READ || $plan->sql() !== $sql)) {
+            return new InvariantViolation($passthroughInvariant, 'safe passthrough was not preserved as an unchanged READ plan', $sql);
         }
 
         if ($plan->kind() !== $classifyResult) {

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RobustnessTarget.php
@@ -185,6 +185,7 @@ final class RobustnessTarget
             fn (): string => 'SELECT * FROM main.users',
             fn (): string => 'SELECT * FROM users INDEXED BY idx_users',
             fn (): string => 'SELECT * FROM users NOT INDEXED',
+            fn (): string => "ATTACH DATABASE ':memory:' AS fuzz_db",
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-sqlite/src/SqliteInMemoryAttachStatement.php
+++ b/packages/ztd-query-sqlite/src/SqliteInMemoryAttachStatement.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class SqliteInMemoryAttachStatement
+{
+    public static function isSafe(string $sql): bool
+    {
+        $stream = SqlTokenStream::tokenize($sql);
+        if (count($stream->splitStatements()) !== 1) {
+            return false;
+        }
+
+        $tokens = $stream->significantTokens();
+        $last = $tokens[count($tokens) - 1] ?? null;
+        if ($last !== null && self::isSymbol($last, ';')) {
+            array_pop($tokens);
+        }
+
+        $index = 0;
+        if (($tokens[$index] ?? null)?->isKeyword('ATTACH') !== true) {
+            return false;
+        }
+        $index++;
+        if (($tokens[$index] ?? null)?->isKeyword('DATABASE') === true) {
+            $index++;
+        }
+
+        $path = $tokens[$index] ?? null;
+        if ($path === null || $path->kind !== SqlTokenKind::String || self::stringValue($path) !== ':memory:') {
+            return false;
+        }
+        $index++;
+        if (($tokens[$index] ?? null)?->isKeyword('AS') !== true) {
+            return false;
+        }
+        $index++;
+
+        $aliasEnd = self::identifierEndIndex($tokens, $index);
+
+        return $aliasEnd !== null && $aliasEnd === count($tokens);
+    }
+
+    private static function stringValue(SqlToken $token): string
+    {
+        $inner = substr($token->text, 1, -1);
+
+        return str_replace("''", "'", $inner);
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function identifierEndIndex(array $tokens, int $index): ?int
+    {
+        $token = $tokens[$index] ?? null;
+        if ($token === null) {
+            return null;
+        }
+        if ($token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier) {
+            return $index + 1;
+        }
+        if (!self::isSymbol($token, '[')) {
+            return null;
+        }
+
+        $name = $tokens[$index + 1] ?? null;
+        $end = $tokens[$index + 2] ?? null;
+        if ($name?->kind !== SqlTokenKind::Word || $end === null || !self::isSymbol($end, ']')) {
+            return null;
+        }
+
+        return $index + 3;
+    }
+
+    private static function isSymbol(SqlToken $token, string $symbol): bool
+    {
+        return $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteInMemoryAttachStatement.php
+++ b/packages/ztd-query-sqlite/src/SqliteInMemoryAttachStatement.php
@@ -12,71 +12,47 @@ final class SqliteInMemoryAttachStatement
 {
     public static function isSafe(string $sql): bool
     {
-        $stream = SqlTokenStream::tokenize($sql);
-        if (count($stream->splitStatements()) !== 1) {
-            return false;
-        }
-
-        $tokens = $stream->significantTokens();
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
         $last = $tokens[count($tokens) - 1] ?? null;
         if ($last !== null && self::isSymbol($last, ';')) {
             array_pop($tokens);
         }
 
-        $index = 0;
-        if (($tokens[$index] ?? null)?->isKeyword('ATTACH') !== true) {
+        if (count($tokens) < 4 || !$tokens[0]->isKeyword('ATTACH')) {
             return false;
         }
-        $index++;
-        if (($tokens[$index] ?? null)?->isKeyword('DATABASE') === true) {
-            $index++;
+
+        $pathIndex = 1;
+        if ($tokens[$pathIndex]->isKeyword('DATABASE')) {
+            $pathIndex++;
         }
 
-        $path = $tokens[$index] ?? null;
-        if ($path === null || $path->kind !== SqlTokenKind::String || self::stringValue($path) !== ':memory:') {
+        $path = $tokens[$pathIndex];
+        if ($path->kind !== SqlTokenKind::String || $path->text !== "':memory:'") {
             return false;
         }
-        $index++;
-        if (($tokens[$index] ?? null)?->isKeyword('AS') !== true) {
+
+        $as = $tokens[$pathIndex + 1];
+        if (!$as->isKeyword('AS')) {
             return false;
         }
-        $index++;
 
-        $aliasEnd = self::identifierEndIndex($tokens, $index);
-
-        return $aliasEnd !== null && $aliasEnd === count($tokens);
-    }
-
-    private static function stringValue(SqlToken $token): string
-    {
-        $inner = substr($token->text, 1, -1);
-
-        return str_replace("''", "'", $inner);
+        return self::isIdentifierSuffix($tokens, $pathIndex + 2);
     }
 
     /**
      * @param list<SqlToken> $tokens
      */
-    private static function identifierEndIndex(array $tokens, int $index): ?int
+    private static function isIdentifierSuffix(array $tokens, int $index): bool
     {
-        $token = $tokens[$index] ?? null;
-        if ($token === null) {
-            return null;
-        }
-        if ($token->kind === SqlTokenKind::Word || $token->kind === SqlTokenKind::QuotedIdentifier) {
-            return $index + 1;
-        }
-        if (!self::isSymbol($token, '[')) {
-            return null;
-        }
-
-        $name = $tokens[$index + 1] ?? null;
-        $end = $tokens[$index + 2] ?? null;
-        if ($name?->kind !== SqlTokenKind::Word || $end === null || !self::isSymbol($end, ']')) {
-            return null;
-        }
-
-        return $index + 3;
+        return match (count($tokens) - $index) {
+            1 => $tokens[$index]->kind === SqlTokenKind::Word
+                || $tokens[$index]->kind === SqlTokenKind::QuotedIdentifier,
+            3 => self::isSymbol($tokens[$index], '[')
+                && $tokens[$index + 1]->kind === SqlTokenKind::Word
+                && self::isSymbol($tokens[$index + 2], ']'),
+            default => false,
+        };
     }
 
     private static function isSymbol(SqlToken $token, string $symbol): bool

--- a/packages/ztd-query-sqlite/src/SqliteQueryGuard.php
+++ b/packages/ztd-query-sqlite/src/SqliteQueryGuard.php
@@ -23,6 +23,9 @@ final class SqliteQueryGuard
      */
     public function classify(string $sql): ?QueryKind
     {
+        if (SqliteInMemoryAttachStatement::isSafe($sql)) {
+            return QueryKind::READ;
+        }
         if (SqliteReadOnlyDiagnosticStatement::isSafe($sql)) {
             return QueryKind::READ;
         }

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -107,6 +107,9 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
 
     private function rewriteStatement(string $stmtSql, string $originalSql): RewritePlan
     {
+        if (SqliteInMemoryAttachStatement::isSafe($stmtSql)) {
+            return new RewritePlan($stmtSql, QueryKind::READ);
+        }
         if (SqliteReadOnlyDiagnosticStatement::isSafe($stmtSql)) {
             return new RewritePlan($stmtSql, QueryKind::READ);
         }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteInMemoryAttachStatementTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteInMemoryAttachStatementTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteInMemoryAttachStatement;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqliteInMemoryAttachStatement::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class SqliteInMemoryAttachStatementTest extends TestCase
 {
     public function testAcceptsOnlyLiteralInMemoryAttachments(): void
@@ -19,6 +17,7 @@ final class SqliteInMemoryAttachStatementTest extends TestCase
         self::assertTrue(SqliteInMemoryAttachStatement::isSafe("ATTACH ':memory:' AS db2"));
         self::assertTrue(SqliteInMemoryAttachStatement::isSafe("ATTACH DATABASE ':memory:' AS \"db2\";"));
         self::assertTrue(SqliteInMemoryAttachStatement::isSafe("ATTACH /* safe */ ':memory:' AS [db2]"));
+        self::assertTrue(SqliteInMemoryAttachStatement::isSafe("attach ':memory:' as `db2`"));
     }
 
     public function testRejectsPersistentOrDynamicAttachments(): void
@@ -27,5 +26,28 @@ final class SqliteInMemoryAttachStatementTest extends TestCase
         self::assertFalse(SqliteInMemoryAttachStatement::isSafe("ATTACH ('file:' || :name) AS db2"));
         self::assertFalse(SqliteInMemoryAttachStatement::isSafe("ATTACH ':memory:' AS db2; DELETE FROM users"));
         self::assertFalse(SqliteInMemoryAttachStatement::isSafe("DETACH DATABASE db2"));
+    }
+
+    #[DataProvider('providerIncompleteOrExtendedAttachmentShapes')]
+    public function testRejectsIncompleteOrExtendedAttachmentShapes(string $sql): void
+    {
+        self::assertFalse(SqliteInMemoryAttachStatement::isSafe($sql));
+    }
+
+    /** @return \Generator<string, array{string}> */
+    public static function providerIncompleteOrExtendedAttachmentShapes(): \Generator
+    {
+        yield 'empty' => [''];
+        yield 'keyword only' => ['ATTACH'];
+        yield 'path without alias' => ["ATTACH ':memory:'"];
+        yield 'missing alias' => ["ATTACH ':memory:' AS"];
+        yield 'database missing alias' => ["ATTACH DATABASE ':memory:' AS"];
+        yield 'missing as' => ["ATTACH ':memory:' db2"];
+        yield 'extra token' => ["ATTACH ':memory:' AS db2 extra"];
+        yield 'string alias' => ["ATTACH ':memory:' AS 'db2'"];
+        yield 'empty bracket alias' => ["ATTACH ':memory:' AS []"];
+        yield 'unterminated bracket alias' => ["ATTACH ':memory:' AS [db2"];
+        yield 'numeric bracket alias' => ["ATTACH ':memory:' AS [42]"];
+        yield 'second statement' => ["ATTACH ':memory:' AS db2; ATTACH ':memory:' AS db3"];
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteInMemoryAttachStatementTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteInMemoryAttachStatementTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteInMemoryAttachStatement;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(SqliteInMemoryAttachStatement::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class SqliteInMemoryAttachStatementTest extends TestCase
+{
+    public function testAcceptsOnlyLiteralInMemoryAttachments(): void
+    {
+        self::assertTrue(SqliteInMemoryAttachStatement::isSafe("ATTACH ':memory:' AS db2"));
+        self::assertTrue(SqliteInMemoryAttachStatement::isSafe("ATTACH DATABASE ':memory:' AS \"db2\";"));
+        self::assertTrue(SqliteInMemoryAttachStatement::isSafe("ATTACH /* safe */ ':memory:' AS [db2]"));
+    }
+
+    public function testRejectsPersistentOrDynamicAttachments(): void
+    {
+        self::assertFalse(SqliteInMemoryAttachStatement::isSafe("ATTACH 'test.sqlite' AS db2"));
+        self::assertFalse(SqliteInMemoryAttachStatement::isSafe("ATTACH ('file:' || :name) AS db2"));
+        self::assertFalse(SqliteInMemoryAttachStatement::isSafe("ATTACH ':memory:' AS db2; DELETE FROM users"));
+        self::assertFalse(SqliteInMemoryAttachStatement::isSafe("DETACH DATABASE db2"));
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteQueryGuardTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteQueryGuardTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\QueryClassifierContractTest;
 use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
+use ZtdQuery\Platform\Sqlite\SqliteInMemoryAttachStatement;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
 use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
 use ZtdQuery\Rewrite\QueryKind;
@@ -16,6 +17,7 @@ use ZtdQuery\Rewrite\QueryKind;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteReadOnlyDiagnosticStatement::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
+#[UsesClass(SqliteInMemoryAttachStatement::class)]
 final class SqliteQueryGuardTest extends QueryClassifierContractTest
 {
     protected function classify(string $sql): ?QueryKind
@@ -121,6 +123,14 @@ final class SqliteQueryGuardTest extends QueryClassifierContractTest
         self::assertSame(QueryKind::READ, $guard->classify('EXPLAIN QUERY PLAN SELECT * FROM users'));
         self::assertSame(QueryKind::READ, $guard->classify('EXPLAIN QUERY PLAN DELETE FROM users'));
         self::assertNull($guard->classify('EXPLAIN ANALYZE DELETE FROM users'));
+    }
+
+    public function testClassifiesOnlyInMemoryAttachAsRead(): void
+    {
+        $guard = new SqliteQueryGuard(new SqliteParser());
+
+        self::assertSame(QueryKind::READ, $guard->classify("ATTACH DATABASE ':memory:' AS db2"));
+        self::assertNull($guard->classify("ATTACH 'test.sqlite' AS db2"));
     }
 
     public function testEmptyReturnsNull(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -46,6 +46,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteReadOnlyDiagnosticStatement::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteTransactionStatementParser::class)]
 #[UsesClass(SqliteReturningProjectionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteInMemoryAttachStatement::class)]
 #[UsesClass(SqliteSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 #[UsesClass(SqliteMutationResolver::class)]
@@ -90,6 +91,26 @@ final class SqliteRewriterTest extends RewriterContractTest
         $this->createRewriter(new ShadowStore(), $registry)->rewrite(
             'WITH users AS (SELECT 1 AS id) SELECT * FROM Users JOIN missing_table ON TRUE',
         );
+    }
+
+    public function testInMemoryAttachPassesThroughUnchanged(): void
+    {
+        $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());
+        $sql = "ATTACH DATABASE ':memory:' AS db2";
+
+        $plan = $rewriter->rewrite($sql);
+
+        self::assertSame(QueryKind::READ, $plan->kind());
+        self::assertSame($sql, $plan->sql());
+    }
+
+    public function testPersistentAttachRemainsUnsupported(): void
+    {
+        $rewriter = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry());
+
+        $this->expectException(UnsupportedSqlException::class);
+
+        $rewriter->rewrite("ATTACH 'test.sqlite' AS db2");
     }
 
     public function testSchemaQualifiedSelectUsesShadowCte(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -10,6 +10,7 @@ use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter;
+use ZtdQuery\Platform\Sqlite\SqliteInMemoryAttachStatement;
 use ZtdQuery\Platform\Sqlite\SqliteMutationResolver;
 use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
@@ -31,6 +32,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
+#[UsesClass(SqliteInMemoryAttachStatement::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteMutationResolver::class)]
 #[UsesClass(SqliteParser::class)]


### PR DESCRIPTION
Stacked on #232.

Root problem

SQLite `ATTACH` was treated as an unsupported statement, including the non-persistent `ATTACH ':memory:' AS alias` form used to create an isolated auxiliary database during tests. Treating every ATTACH as a generic passthrough would be unsafe because attaching a filesystem path can create or modify persistent state.

Fix

- Add a token-stream based recognizer for exactly one literal in-memory attachment: `ATTACH [DATABASE] ':memory:' AS identifier`.
- Preserve that statement unchanged as an executable `READ` plan so it reaches the physical connection.
- Continue rejecting disk paths, dynamic expressions, DETACH, extra clauses, and multi-statements.

Recurrence prevention

- Add recognizer boundary tests, guard tests, and rewriter passthrough/rejection tests.
- Add SQLite PDO integration tests proving the in-memory database is attached and a persistent path remains blocked.
- Add the safe ATTACH case to the SQLite robustness target and invariant `INV-L2-09`: it must classify/rewrite as an unchanged executable plan.
- SQLFaker's official SQLite grammar already generates ATTACH; the missing behavior was a safe semantic policy and invariant.

Validation

- SQLite unit: 1,238 tests passed.
- PDO unit: 275 tests passed.
- SQLite integration: 96 tests passed.
- Lint/PHPStan: affected packages passed.
- Safe ATTACH robustness input passed.

Fixes #157

The schema-qualified half of #157 is fixed by the ancestor PR #231; this PR addresses only the independent ATTACH root problem.