### PR TITLE
Prevent empty-string UPDATE regressions across adapters

### DIFF
--- a/packages/ztd-query-mysqli-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-mysqli-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
@@ -105,7 +105,9 @@ final class SchemaAwareSqlBuilder
         }
         /** @var string $updateCol */
         $updateCol = $this->faker->randomElement($nonPkCols);
-        $newValue = $this->generateLiteral($updateCol, $schema);
+        $newValue = $this->isTextColumn($updateCol) && $this->faker->boolean(25)
+            ? "''"
+            : $this->generateLiteral($updateCol, $schema);
 
         $whereClause = $this->buildPkWhere($schema);
 
@@ -193,5 +195,17 @@ final class SchemaAwareSqlBuilder
 
         $str = $this->faker->lexify('????');
         return "'" . addslashes($str) . "'";
+    }
+
+    private function isTextColumn(string $column): bool
+    {
+        $column = strtolower($column);
+
+        return str_contains($column, 'name')
+            || str_contains($column, 'email')
+            || str_contains($column, 'status')
+            || str_contains($column, 'text')
+            || str_contains($column, 'varchar')
+            || str_contains($column, 'char');
     }
 }

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -20,6 +20,25 @@ use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
 #[Large]
 final class MysqliCteShadowingTest extends TestCase
 {
+    public function testUpdateReplacesExistingTextWithEmptyString(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, name VARCHAR(100), notes TEXT)', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            self::assertNotFalse($ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (1, 'Alice', 'some notes')", $table)));
+            self::assertNotFalse($ztdMysqli->query(sprintf("UPDATE `%s` SET notes = '' WHERE name = 'Alice'", $table)));
+
+            $result = $ztdMysqli->query(sprintf('SELECT notes FROM `%s` WHERE id = 1', $table));
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([['notes' => '']], $result->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testSelfReferencingUpsertMatchesNativeMySql(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaAwareSqlBuilder.php
@@ -104,7 +104,9 @@ final class PgSchemaAwareSqlBuilder
         /** @var string $updateCol */
         $updateCol = $this->faker->randomElement($nonPkCols);
         $newValue = $this->generateLiteral($updateCol);
-        if ($this->isTextColumn($updateCol) && $this->faker->boolean(35)) {
+        if ($this->isTextColumn($updateCol) && $this->faker->boolean(25)) {
+            $newValue = "''";
+        } elseif ($this->isTextColumn($updateCol) && $this->faker->boolean(35)) {
             $column = $this->quoteIdentifier($updateCol);
             /** @var string $newValue */
             $newValue = $this->faker->randomElement([

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
@@ -105,7 +105,9 @@ final class SchemaAwareSqlBuilder
         }
         /** @var string $updateCol */
         $updateCol = $this->faker->randomElement($nonPkCols);
-        $newValue = $this->generateLiteral($updateCol, $schema);
+        $newValue = $this->isTextColumn($updateCol) && $this->faker->boolean(25)
+            ? "''"
+            : $this->generateLiteral($updateCol, $schema);
 
         $whereClause = $this->buildPkWhere($schema);
 
@@ -195,5 +197,17 @@ final class SchemaAwareSqlBuilder
 
         $str = $this->faker->lexify('????');
         return "'" . addslashes($str) . "'";
+    }
+
+    private function isTextColumn(string $column): bool
+    {
+        $column = strtolower($column);
+
+        return str_contains($column, 'name')
+            || str_contains($column, 'email')
+            || str_contains($column, 'status')
+            || str_contains($column, 'text')
+            || str_contains($column, 'varchar')
+            || str_contains($column, 'char');
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpdateEmptyStringTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpdateEmptyStringTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class UpdateEmptyStringTest extends TestCase
+{
+    public function testUpdateReplacesExistingTextWithEmptyString(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$table}` (id INT PRIMARY KEY, name VARCHAR(100), notes TEXT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$table}` VALUES (1, 'Alice', 'some notes')");
+
+            self::assertSame(1, $ztdPdo->exec("UPDATE `{$table}` SET notes = '' WHERE name = 'Alice'"));
+
+            $statement = $ztdPdo->query("SELECT notes FROM `{$table}` WHERE id = 1");
+            self::assertNotFalse($statement);
+            self::assertSame('', $statement->fetchColumn());
+
+            $physical = $rawPdo->query("SELECT notes FROM `{$table}`");
+            self::assertNotFalse($physical);
+            self::assertSame([], $physical->fetchAll(PDO::FETCH_COLUMN));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/UpdateBasicTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/UpdateBasicTest.php
@@ -19,6 +19,26 @@ use ZtdQuery\Adapter\Pdo\ZtdPdo;
 #[Large]
 final class UpdateBasicTest extends TestCase
 {
+    public function testUpdateReplacesExistingTextWithEmptyString(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$table} (id INTEGER PRIMARY KEY, name TEXT, notes TEXT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO {$table} VALUES (1, 'Alice', 'some notes')");
+
+            self::assertSame(1, $ztdPdo->exec("UPDATE {$table} SET notes = '' WHERE name = 'Alice'"));
+
+            $statement = $ztdPdo->query("SELECT notes FROM {$table} WHERE id = 1");
+            self::assertNotFalse($statement);
+            self::assertSame('', $statement->fetchColumn());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
     public function testUpdateSingleRow(): void
     {
         [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();


### PR DESCRIPTION
## Problem

UPDATE assignments to an empty string were not represented in the correctness fuzz input space, and MySQL PDO had no direct integration regression for the reported behavior.

## Change

- add real-database regressions for MySQL PDO, PostgreSQL PDO, and MySQLi
- assert the shadow value becomes the empty string and physical MySQL state remains untouched
- generate empty-string assignments for text columns in MySQL PDO, PostgreSQL PDO, and MySQLi correctness fuzz builders

## Verification

- all three reported adapter paths pass against real MySQL/PostgreSQL containers
- PDO adapter lint passes
- MySQLi adapter lint passes

Stacked on #233.

Fixes #179