### PR TITLE
Support SQLite STRICT table schemas

### DIFF
--- a/packages/sql-faker/src/Sqlite/LexicalGrammar.php
+++ b/packages/sql-faker/src/Sqlite/LexicalGrammar.php
@@ -18,6 +18,8 @@ use SqlFaker\Grammar\TokenJoiner;
  */
 final class LexicalGrammar implements LexicalGrammarContract
 {
+    public const STRICT_TABLE_OPTION = 'STRICT_TABLE_OPTION';
+
     /** @var array<string, list<string>> */
     private array $keywords;
 
@@ -56,7 +58,9 @@ final class LexicalGrammar implements LexicalGrammarContract
 
     public function supports(string $terminal): bool
     {
-        return $this->allowSyntheticTerminals || $this->catalog->supports($terminal);
+        return $terminal === self::STRICT_TABLE_OPTION
+            || $this->allowSyntheticTerminals
+            || $this->catalog->supports($terminal);
     }
 
     /**
@@ -64,7 +68,14 @@ final class LexicalGrammar implements LexicalGrammarContract
      */
     public function assertTerminalsCovered(array $terminals): void
     {
-        $this->catalog->assertTerminalsCovered($terminals);
+        $catalogTerminals = [];
+        foreach ($terminals as $terminal) {
+            if ($terminal !== self::STRICT_TABLE_OPTION) {
+                $catalogTerminals[] = $terminal;
+            }
+        }
+
+        $this->catalog->assertTerminalsCovered($catalogTerminals);
     }
 
     public function realize(array $terminals): string
@@ -175,6 +186,10 @@ final class LexicalGrammar implements LexicalGrammarContract
     {
         if (!$this->supports($terminal)) {
             throw new LexicalException("Unsupported SQLite terminal for {$this->profileVersion}: {$terminal}");
+        }
+
+        if ($terminal === self::STRICT_TABLE_OPTION) {
+            return ['STRICT', ['ID']];
         }
 
         if (!$this->allowSyntheticTerminals) {

--- a/packages/sql-faker/src/Sqlite/SqlGenerator.php
+++ b/packages/sql-faker/src/Sqlite/SqlGenerator.php
@@ -191,11 +191,11 @@ final class SqlGenerator
      */
     private function augmentGrammar(Grammar $grammar): Grammar
     {
-        $ruleMap = $grammar->ruleMap;
+        $ruleMap = $this->addStrictTableOption($grammar->ruleMap);
         $cmd = $ruleMap['cmd'] ?? null;
 
         if ($cmd === null) {
-            return $grammar;
+            return new Grammar($grammar->startSymbol, $ruleMap);
         }
 
         $ruleMap = $this->filterExprRule($ruleMap);
@@ -203,6 +203,29 @@ final class SqlGenerator
         $ruleMap = $this->extractStatementRules($ruleMap, $cmd);
 
         return new Grammar($grammar->startSymbol, $ruleMap);
+    }
+
+    /**
+     * SQLite's grammar represents STRICT as a generic table-option identifier.
+     * Add a fixed lexical witness so fuzz generation can deliberately reach it.
+     *
+     * @param array<string, ProductionRule> $ruleMap
+     * @return array<string, ProductionRule>
+     */
+    private function addStrictTableOption(array $ruleMap): array
+    {
+        $tableOption = $ruleMap['table_option'] ?? null;
+        if ($tableOption === null) {
+            return $ruleMap;
+        }
+
+        $alternatives = $tableOption->alternatives;
+        $alternatives[] = new Production([
+            new Terminal(LexicalGrammar::STRICT_TABLE_OPTION),
+        ]);
+        $ruleMap['table_option'] = new ProductionRule('table_option', $alternatives);
+
+        return $ruleMap;
     }
 
     /**

--- a/packages/sql-faker/tests/Unit/Sqlite/LexicalGrammarTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/LexicalGrammarTest.php
@@ -85,6 +85,18 @@ SQL;
         $lexical->assertTerminalsCovered(['NOT_A_TERMINAL']);
     }
 
+    public function testRealizesStrictTableOptionAsIdentifierToken(): void
+    {
+        $lexical = new LexicalGrammar(Factory::create(), 'sqlite-3.47.2');
+
+        self::assertTrue($lexical->supports(LexicalGrammar::STRICT_TABLE_OPTION));
+        $lexical->assertTerminalsCovered(['ID', LexicalGrammar::STRICT_TABLE_OPTION]);
+        $sql = $lexical->realize([LexicalGrammar::STRICT_TABLE_OPTION]);
+        self::assertStringContainsString('STRICT', $sql);
+        self::assertSame(['ID'], $lexical->tokenize($sql));
+        self::assertSame(['ID'], $lexical->tokenize('STRICT'));
+    }
+
     #[DataProvider('providerInvalidSql')]
     public function testRejectsInvalidSql(string $sql, string $message): void
     {

--- a/packages/sql-faker/tests/Unit/Sqlite/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/SqlGeneratorTest.php
@@ -65,6 +65,22 @@ final class SqlGeneratorTest extends TestCase
         self::assertSame('SELECT foo', $result);
     }
 
+    public function testGenerateCanDeliberatelyProduceStrictTableOption(): void
+    {
+        $grammar = new Grammar('table_option', [
+            'table_option' => new ProductionRule('table_option', []),
+        ]);
+        $faker = Factory::create();
+        $generator = new SqlGenerator(
+            $grammar,
+            $faker,
+            new SqliteProvider($faker),
+            'sqlite-3.47.2',
+        );
+
+        self::assertStringContainsString('STRICT', $generator->generate('table_option'));
+    }
+
     public function testVersionBoundGeneratorRejectsAnUnknownGrammarTerminal(): void
     {
         $grammar = new Grammar('stmt', [

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/StrictTableTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/StrictTableTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+final class StrictTableTest extends TestCase
+{
+    public function testStrictTableSupportsPreparedAndLiteralDml(): void
+    {
+        $rawPdo = new PDO('sqlite::memory:', null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE measurements (id INTEGER PRIMARY KEY, sensor TEXT NOT NULL, reading REAL NOT NULL, count INTEGER NOT NULL) STRICT');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        $insert = $ztdPdo->prepare('INSERT INTO measurements VALUES (?, ?, ?, ?)');
+        self::assertNotFalse($insert);
+        self::assertTrue($insert->execute([1, 'temp', 23.5, 100]));
+        self::assertTrue($insert->execute([2, 'humidity', 60.0, 50]));
+
+        self::assertSame(1, $ztdPdo->exec('UPDATE measurements SET count = count + 1 WHERE id = 1'));
+        $delete = $ztdPdo->prepare('DELETE FROM measurements WHERE reading > ?');
+        self::assertNotFalse($delete);
+        self::assertTrue($delete->execute([50]));
+
+        $statement = $ztdPdo->query('SELECT * FROM measurements ORDER BY id');
+        self::assertNotFalse($statement);
+        self::assertSame([
+            ['id' => 1, 'sensor' => 'temp', 'reading' => 23.5, 'count' => 101],
+        ], $statement->fetchAll());
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
@@ -9,13 +9,13 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
 /**
  * SQLite implementation of SchemaParser.
  *
- * Parses CREATE TABLE statements using regex-based parsing
- * appropriate for SQLite's simpler DDL syntax.
+ * Parses CREATE TABLE statements while preserving nested SQL expressions.
  */
 final class SqliteSchemaParser implements SchemaParser
 {
@@ -26,11 +26,10 @@ final class SqliteSchemaParser implements SchemaParser
     {
         $trimmed = trim($createTableSql);
 
-        if (preg_match('/^CREATE\s+(?:TEMPORARY\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s(]+)\s*\((.+)\)\s*(?:WITHOUT\s+ROWID\s*)?;?\s*$/is', $trimmed, $matches) !== 1) {
+        $body = $this->tableBody($trimmed);
+        if ($body === null) {
             return null;
         }
-
-        $body = $matches[1];
 
         $columns = [];
         $columnTypes = [];
@@ -165,6 +164,84 @@ final class SqliteSchemaParser implements SchemaParser
             $columnDefaults,
             $identityStrategies,
         );
+    }
+
+    private function tableBody(string $sql): ?string
+    {
+        $tablePrefix = '/^CREATE\s+(?:(?:TEMP|TEMPORARY)\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s(]+)\s*\(/is';
+        if (preg_match($tablePrefix, $sql, $matches) !== 1) {
+            return null;
+        }
+
+        $openingOffset = strlen($matches[0]) - 1;
+        $closing = null;
+        foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
+            if ($token->isTopLevel()
+                && $token->kind === SqlTokenKind::Symbol
+                && $token->text === ')'
+            ) {
+                $closing = $token;
+                break;
+            }
+        }
+        if ($closing === null) {
+            return null;
+        }
+
+        $suffix = substr($sql, $closing->endOffset());
+        if (!self::hasValidTableOptions($suffix)) {
+            return null;
+        }
+
+        return substr($sql, $openingOffset + 1, $closing->offset - $openingOffset - 1);
+    }
+
+    private static function hasValidTableOptions(string $suffix): bool
+    {
+        $tokens = SqlTokenStream::tokenize($suffix)->significantTokens();
+        $last = $tokens[count($tokens) - 1] ?? null;
+        if ($last !== null
+            && $last->kind === SqlTokenKind::Symbol
+            && $last->text === ';'
+        ) {
+            array_pop($tokens);
+        }
+        if ($tokens === []) {
+            return true;
+        }
+
+        $seen = [];
+        $index = 0;
+        while ($index < count($tokens)) {
+            if ($tokens[$index]->isKeyword('STRICT')) {
+                $option = 'STRICT';
+                $index++;
+            } elseif ($tokens[$index]->isKeyword('WITHOUT')
+                && ($tokens[$index + 1] ?? null)?->isKeyword('ROWID') === true
+            ) {
+                $option = 'WITHOUT ROWID';
+                $index += 2;
+            } else {
+                return false;
+            }
+
+            if (isset($seen[$option])) {
+                return false;
+            }
+            $seen[$option] = $option;
+
+            if ($index === count($tokens)) {
+                return true;
+            }
+            if ($tokens[$index]->kind !== SqlTokenKind::Symbol
+                || $tokens[$index]->text !== ','
+            ) {
+                return false;
+            }
+            $index++;
+        }
+
+        return false;
     }
 
     private static function hasWithoutRowid(string $sql): bool

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\SchemaParserContractTest;
 use ZtdQuery\Platform\SchemaParser;
@@ -174,6 +175,69 @@ final class SqliteSchemaParserTest extends SchemaParserContractTest
 
         self::assertNotNull($definition);
         self::assertSame([], $definition->identityStrategies);
+    }
+
+    public function testStrictTableRetainsColumnsTypesAndRowidIdentity(): void
+    {
+        $definition = (new SqliteSchemaParser())->parse(
+            'CREATE TABLE measurements (id INTEGER PRIMARY KEY, sensor TEXT NOT NULL, reading REAL NOT NULL) STRICT'
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame(['id', 'sensor', 'reading'], $definition->columns);
+        self::assertSame([
+            'id' => 'INTEGER',
+            'sensor' => 'TEXT',
+            'reading' => 'REAL',
+        ], $definition->columnTypes);
+        self::assertSame(['id' => IdentityGenerationStrategy::MaxValue], $definition->identityStrategies);
+    }
+
+    public function testStrictAndWithoutRowidOptionsAreAcceptedInEitherOrder(): void
+    {
+        $strictLast = (new SqliteSchemaParser())->parse(
+            'CREATE TABLE events (id INTEGER PRIMARY KEY, payload BLOB) WITHOUT ROWID, STRICT;'
+        );
+        $withoutLast = (new SqliteSchemaParser())->parse(
+            'CREATE TABLE events (id INTEGER PRIMARY KEY, payload BLOB) STRICT, WITHOUT ROWID'
+        );
+
+        self::assertNotNull($strictLast);
+        self::assertNotNull($withoutLast);
+        self::assertSame([], $strictLast->identityStrategies);
+        self::assertSame([], $withoutLast->identityStrategies);
+    }
+
+    public function testTempStrictTableIsAcceptedWithTriviaBeforeOption(): void
+    {
+        $definition = (new SqliteSchemaParser())->parse(
+            "CREATE TEMP TABLE events (id INTEGER PRIMARY KEY, payload BLOB) /* option */ STRICT\n"
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame(['id', 'payload'], $definition->columns);
+    }
+
+    #[DataProvider('providerInvalidTableOptionSuffixes')]
+    public function testRejectsInvalidTableOptionSuffix(string $suffix): void
+    {
+        self::assertNull((new SqliteSchemaParser())->parse(
+            'CREATE TABLE events (id INTEGER PRIMARY KEY) ' . $suffix
+        ));
+    }
+
+    /** @return \Generator<string, array{string}> */
+    public static function providerInvalidTableOptionSuffixes(): \Generator
+    {
+        yield 'unknown option' => ['COMPRESS'];
+        yield 'missing rowid' => ['WITHOUT'];
+        yield 'missing comma' => ['STRICT WITHOUT ROWID'];
+        yield 'symbol instead of comma' => ['STRICT + WITHOUT ROWID'];
+        yield 'trailing comma' => ['STRICT,'];
+        yield 'duplicate strict' => ['STRICT, STRICT'];
+        yield 'duplicate without rowid' => ['WITHOUT ROWID, WITHOUT ROWID'];
+        yield 'extra closing parenthesis' => [') STRICT'];
+        yield 'statement after semicolon' => ['STRICT; SELECT 1'];
     }
 
     public function testLowercaseWithoutRowidIsNotIdentity(): void


### PR DESCRIPTION
## Root problem

SQLite schema reflection matched the entire CREATE TABLE statement with one regular expression and only accepted WITHOUT ROWID after the column list. A valid STRICT table therefore had no TableDefinition, so ZTD DML could not build a correctly typed shadow table.

## Fix

- locate the table-body closing boundary with SqlTokenStream instead of a greedy DDL expression
- validate STRICT and WITHOUT ROWID as structured, comma-separated table options
- add a dedicated SQLFaker lexical witness so grammar fuzzing deliberately reaches STRICT instead of relying on a random identifier
- cover malformed option sequences, TEMP tables, option ordering, identity semantics, and real SQLite prepared/literal DML

## Validation

- SQLite unit: 1274 tests, 2225 assertions
- SQLFaker unit: 1032 tests, 1830 assertions
- PDO adapter unit: 275 tests, 342 assertions
- SQLite, SQLFaker, and PDO adapter lint/PHPStan
- SQLite changed-line mutation: 79/79 killed
- SQLFaker changed-line mutation: 20 mutants, covered MSI 100%

## Stack

Base: #234

Fixes #156