### PR TITLE
fix: preserve CTAS result schemas

### DIFF
--- a/.github/workflows/ztd-query-pdo-adapter-fuzz.yml
+++ b/.github/workflows/ztd-query-pdo-adapter-fuzz.yml
@@ -190,6 +190,7 @@ jobs:
           - { name: insert, script: fuzz_correctness_pg_insert.php, corpus: correctness-pg-insert }
           - { name: update, script: fuzz_correctness_pg_update.php, corpus: correctness-pg-update }
           - { name: delete, script: fuzz_correctness_pg_delete.php, corpus: correctness-pg-delete }
+          - { name: ctas, script: fuzz_correctness_pg_ctas.php, corpus: correctness-pg-ctas }
     defaults:
       run:
         working-directory: packages/ztd-query-pdo-adapter

--- a/packages/sql-faker/fuzz/Target/PgSyntaxTarget.php
+++ b/packages/sql-faker/fuzz/Target/PgSyntaxTarget.php
@@ -53,7 +53,9 @@ final class PgSyntaxTarget
         $seed = $this->inputToSeed($input);
         $this->faker->seed($seed);
 
-        $sql = $this->provider->sql(maxDepth: $this->maxDepth);
+        $sql = $seed % 4 === 0
+            ? $this->provider->createTableAsStatement(maxDepth: $this->maxDepth)
+            : $this->provider->sql(maxDepth: $this->maxDepth);
 
         $this->validateSyntax($sql, $seed);
     }

--- a/packages/sql-faker/src/PostgreSql/StatementType.php
+++ b/packages/sql-faker/src/PostgreSql/StatementType.php
@@ -16,6 +16,7 @@ enum StatementType: string
     case Update = 'UpdateStmt';
     case Delete = 'DeleteStmt';
     case CreateTable = 'CreateStmt';
+    case CreateTableAs = 'CreateAsStmt';
     case AlterTable = 'AlterTableStmt';
     case DropTable = 'DropStmt';
     case SimpleStatement = 'stmt';

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -117,6 +117,16 @@ final class PostgreSqlProvider extends Base
     }
 
     /**
+     * Generate a PostgreSQL CREATE TABLE AS statement.
+     *
+     * @return non-empty-string
+     */
+    public function createTableAsStatement(int $maxDepth = PHP_INT_MAX): string
+    {
+        return $this->generateRequired(StatementType::CreateTableAs->value, $maxDepth);
+    }
+
+    /**
      * Generate a PostgreSQL ALTER TABLE statement.
      *
      * @return non-empty-string

--- a/packages/sql-faker/tests/Unit/PostgreSql/StatementTypeTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/StatementTypeTest.php
@@ -16,8 +16,13 @@ final class StatementTypeTest extends TestCase
         self::assertSame('SelectStmt', StatementType::Select->value);
     }
 
+    public function testCreateTableAsHasExpectedValue(): void
+    {
+        self::assertSame('CreateAsStmt', StatementType::CreateTableAs->value);
+    }
+
     public function testCasesCount(): void
     {
-        self::assertCount(8, StatementType::cases());
+        self::assertCount(9, StatementType::cases());
     }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -171,6 +171,20 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertStringContainsString('TABLE', $result);
     }
 
+    public function testCreateTableAsStatement(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new PostgreSqlProvider($faker);
+
+        $result = $provider->createTableAsStatement(maxDepth: 8);
+
+        self::assertStringContainsString('CREATE', $result);
+        self::assertStringContainsString('TABLE', $result);
+        self::assertStringContainsString('AS', $result);
+        self::assertMatchesRegularExpression('/\b(?:SELECT|VALUES|TABLE)\b/', $result);
+    }
+
     public function testAlterTableStatement(): void
     {
         $faker = Factory::create();
@@ -783,6 +797,7 @@ final class PostgreSqlProviderTest extends TestCase
         yield 'Update' => [StatementType::Update];
         yield 'Delete' => [StatementType::Delete];
         yield 'CreateTable' => [StatementType::CreateTable];
+        yield 'CreateTableAs' => [StatementType::CreateTableAs];
         yield 'AlterTable' => [StatementType::AlterTable];
         yield 'DropTable' => [StatementType::DropTable];
     }

--- a/packages/ztd-query-core/src/Connection/ResultColumn.php
+++ b/packages/ztd-query-core/src/Connection/ResultColumn.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Connection;
+
+use ZtdQuery\Schema\ColumnType;
+
+/**
+ * Driver-reported metadata for one result-set column.
+ */
+final class ResultColumn
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly ColumnType $type,
+    ) {
+    }
+}

--- a/packages/ztd-query-core/src/Connection/ResultSet.php
+++ b/packages/ztd-query-core/src/Connection/ResultSet.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Connection;
+
+/**
+ * Buffered rows together with metadata that remains available for an empty result.
+ */
+final class ResultSet
+{
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @param list<ResultColumn> $columns
+     */
+    public function __construct(
+        public readonly array $rows,
+        public readonly array $columns,
+    ) {
+    }
+}

--- a/packages/ztd-query-core/src/Connection/StatementInterface.php
+++ b/packages/ztd-query-core/src/Connection/StatementInterface.php
@@ -29,6 +29,15 @@ interface StatementInterface
     public function fetchAll(): array;
 
     /**
+     * Return result-set columns in projection order.
+     *
+     * Metadata must remain available when the result contains no rows.
+     *
+     * @return list<ResultColumn>
+     */
+    public function resultColumns(): array;
+
+    /**
      * Return the number of affected rows.
      */
     public function rowCount(): int;

--- a/packages/ztd-query-core/src/ResultSelectRunner.php
+++ b/packages/ztd-query-core/src/ResultSelectRunner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ZtdQuery;
 
+use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\Connection\StatementInterface;
 
 /**
@@ -19,12 +20,20 @@ final class ResultSelectRunner
      */
     public function run(string $sql, callable $executor): array
     {
+        return $this->runResultSet($sql, $executor)->rows;
+    }
+
+    /**
+     * @param callable(string): (StatementInterface|false) $executor
+     */
+    public function runResultSet(string $sql, callable $executor): ResultSet
+    {
         $statement = $executor($sql);
         if ($statement === false) {
-            return [];
+            return new ResultSet([], []);
         }
 
-        return $statement->fetchAll();
+        return $this->readResultSet($statement);
     }
 
     /**
@@ -37,6 +46,14 @@ final class ResultSelectRunner
     {
         $statement->execute($params);
 
-        return $statement->fetchAll();
+        return $this->readResultSet($statement)->rows;
+    }
+
+    public function readResultSet(StatementInterface $statement): ResultSet
+    {
+        $columns = $statement->resultColumns();
+        $rows = $statement->fetchAll();
+
+        return new ResultSet($rows, $columns);
     }
 }

--- a/packages/ztd-query-core/src/Schema/ColumnType.php
+++ b/packages/ztd-query-core/src/Schema/ColumnType.php
@@ -21,4 +21,38 @@ final class ColumnType
         public readonly string $nativeType,
     ) {
     }
+
+    public static function fromNativeType(string $nativeType): self
+    {
+        $upper = strtoupper($nativeType);
+        $withoutParameters = preg_replace('/\(.*\)/', '', $upper);
+        $baseType = trim(is_string($withoutParameters) ? $withoutParameters : $upper);
+        $withoutArray = preg_replace('/\[\s*\]$/', '', $baseType);
+        $baseType = is_string($withoutArray) ? $withoutArray : $baseType;
+
+        $family = match ($baseType) {
+            'INT', 'INT2', 'INT4', 'INT8', 'INTEGER', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'BIGINT',
+            'SERIAL', 'SMALLSERIAL', 'BIGSERIAL', 'LONG', 'LONGLONG', 'SHORT', 'INT24', 'YEAR', 'BIT'
+                => ColumnTypeFamily::INTEGER,
+            'FLOAT', 'FLOAT4', 'REAL' => ColumnTypeFamily::FLOAT,
+            'DOUBLE', 'FLOAT8', 'DOUBLE PRECISION' => ColumnTypeFamily::DOUBLE,
+            'DECIMAL', 'NEWDECIMAL', 'NUMERIC' => ColumnTypeFamily::DECIMAL,
+            'CHAR', 'CHARACTER', 'BPCHAR', 'VARCHAR', 'CHARACTER VARYING', 'VAR_STRING', 'STRING', 'ENUM', 'SET',
+            'NAME' => ColumnTypeFamily::STRING,
+            'TEXT', 'TINYTEXT', 'MEDIUMTEXT', 'LONGTEXT', 'CITEXT', 'CLOB' => ColumnTypeFamily::TEXT,
+            'BOOL', 'BOOLEAN' => ColumnTypeFamily::BOOLEAN,
+            'DATE', 'NEWDATE' => ColumnTypeFamily::DATE,
+            'TIME', 'TIME2', 'TIMETZ', 'TIME WITH TIME ZONE', 'TIME WITHOUT TIME ZONE'
+                => ColumnTypeFamily::TIME,
+            'DATETIME', 'DATETIME2' => ColumnTypeFamily::DATETIME,
+            'TIMESTAMP', 'TIMESTAMP2', 'TIMESTAMPTZ', 'TIMESTAMP WITH TIME ZONE',
+            'TIMESTAMP WITHOUT TIME ZONE' => ColumnTypeFamily::TIMESTAMP,
+            'BYTEA', 'BINARY', 'VARBINARY', 'BLOB', 'TINYBLOB', 'MEDIUMBLOB', 'LONGBLOB'
+                => ColumnTypeFamily::BINARY,
+            'JSON', 'JSONB' => ColumnTypeFamily::JSON,
+            default => ColumnTypeFamily::UNKNOWN,
+        };
+
+        return new self($family, $nativeType);
+    }
 }

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -11,6 +11,7 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Connection\StatementInterface;
+use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\Exception\SimulationException;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
@@ -21,6 +22,7 @@ use ZtdQuery\Rewrite\RewriteStateCommitter;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\Mutation\MutationImpact;
 use ZtdQuery\Shadow\Mutation\ShadowMutation;
+use ZtdQuery\Shadow\Mutation\ResultSetMutation;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTransactionManager;
 use ZtdQuery\Sql\TransactionStatement;
@@ -248,13 +250,14 @@ final class Session
             return GenericExecuteResult::fromStatement($statement, QueryKind::READ);
         }
 
-        $rows = $statement->fetchAll();
+        $resultSet = $this->resultSelectRunner->readResultSet($statement);
+        $rows = $resultSet->rows;
 
         $mutation = $plan->mutation();
         if ($mutation === null) {
             throw new RuntimeException('ZTD Write Protection: Missing shadow mutation for write simulation.');
         }
-        $impact = $this->applyMutation($mutation, $rows);
+        $impact = $this->applyMutation($mutation, $resultSet);
         $returningProjection = $plan->returningProjection();
         $resultRows = $returningProjection !== null
             ? $returningProjection->project($impact->returningRows())
@@ -286,10 +289,10 @@ final class Session
             throw new RuntimeException('ZTD Write Protection: Missing shadow mutation for write simulation.');
         }
 
-        $rows = $this->resultSelectRunner->run($plan->sql(), $executor);
-        $this->applyMutation($mutation, $rows);
+        $resultSet = $this->resultSelectRunner->runResultSet($plan->sql(), $executor);
+        $this->applyMutation($mutation, $resultSet);
 
-        return $rows;
+        return $resultSet->rows;
     }
 
     /**
@@ -320,8 +323,11 @@ final class Session
             throw new RuntimeException('ZTD Write Protection: Missing shadow mutation for write simulation.');
         }
 
-        $rows = $this->resultSelectRunner->run($plan->sql(), fn (string $s) => $this->connection->query($s));
-        $impact = $this->applyMutation($mutation, $rows);
+        $resultSet = $this->resultSelectRunner->runResultSet(
+            $plan->sql(),
+            fn (string $s) => $this->connection->query($s),
+        );
+        $impact = $this->applyMutation($mutation, $resultSet);
 
         return $impact->affectedRowCount($plan->affectedRowsMode());
     }
@@ -330,21 +336,24 @@ final class Session
      * Apply a mutation without leaking simulation-specific exception types
      * through the connection adapter boundary.
      *
-     * @param array<int, array<string, mixed>> $rows
      * @throws DatabaseException When shadow mutation application fails.
      */
-    private function applyMutation(ShadowMutation $mutation, array $rows): MutationImpact
+    private function applyMutation(ShadowMutation $mutation, ResultSet $resultSet): MutationImpact
     {
         $before = $this->shadowStore->get($mutation->tableName());
         try {
-            $mutation->apply($this->shadowStore, $rows);
+            if ($mutation instanceof ResultSetMutation) {
+                $mutation->applyResultSet($this->shadowStore, $resultSet);
+            } else {
+                $mutation->apply($this->shadowStore, $resultSet->rows);
+            }
         } catch (SimulationException $e) {
             throw new DatabaseException($e->getMessage(), null, 0, $e);
         }
         $impact = new MutationImpact(
             $mutation,
             $before,
-            $rows,
+            $resultSet->rows,
             $this->shadowStore->get($mutation->tableName()),
         );
         if ($impact->isInsertLike() && $this->rewriter instanceof RewriteStateCommitter) {

--- a/packages/ztd-query-core/src/Shadow/Mutation/CreateTableAsSelectMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/CreateTableAsSelectMutation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Shadow\Mutation;
 
+use ZtdQuery\Connection\ResultColumn;
+use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\TableDefinition;
@@ -14,7 +16,7 @@ use ZtdQuery\Shadow\ShadowStore;
  * Applies CREATE TABLE ... AS SELECT ... operation to the virtual schema.
  * This mutation creates a new table with structure and data from SELECT.
  */
-final class CreateTableAsSelectMutation implements ShadowMutation
+final class CreateTableAsSelectMutation implements ResultSetMutation
 {
     private string $tableName;
 
@@ -47,6 +49,11 @@ final class CreateTableAsSelectMutation implements ShadowMutation
      */
     public function apply(ShadowStore $store, array $rows): void
     {
+        $this->applyResultSet($store, new ResultSet($rows, []));
+    }
+
+    public function applyResultSet(ShadowStore $store, ResultSet $result): void
+    {
         if ($this->registry->has($this->tableName)) {
             if ($this->ifNotExists) {
                 return;
@@ -54,9 +61,13 @@ final class CreateTableAsSelectMutation implements ShadowMutation
             throw new \RuntimeException("Table '{$this->tableName}' already exists.");
         }
 
+        $resultColumns = $result->columns;
         $columns = $this->columnNames;
-        if ($columns === [] && $rows !== []) {
-            $columns = array_keys($rows[0]);
+        if ($columns === []) {
+            $columns = array_map(static fn (ResultColumn $column): string => $column->name, $resultColumns);
+        }
+        if ($columns === [] && $result->rows !== []) {
+            $columns = array_keys($result->rows[0]);
         }
         if ($columns === []) {
             throw new \RuntimeException("Cannot determine columns for CREATE TABLE AS SELECT.");
@@ -65,9 +76,10 @@ final class CreateTableAsSelectMutation implements ShadowMutation
         $columnTypes = [];
         /** @var array<string, ColumnType> $typedColumns */
         $typedColumns = [];
-        foreach ($columns as $column) {
-            $columnTypes[$column] = 'TEXT';
-            $typedColumns[$column] = new ColumnType(ColumnTypeFamily::TEXT, 'TEXT');
+        foreach ($columns as $index => $column) {
+            $type = $resultColumns[$index]->type ?? new ColumnType(ColumnTypeFamily::TEXT, 'TEXT');
+            $columnTypes[$column] = $type->nativeType;
+            $typedColumns[$column] = $type;
         }
 
         $definition = new TableDefinition(
@@ -80,7 +92,7 @@ final class CreateTableAsSelectMutation implements ShadowMutation
         );
 
         $this->registry->register($this->tableName, $definition);
-        $store->set($this->tableName, $rows);
+        $store->set($this->tableName, $result->rows);
     }
 
     /**

--- a/packages/ztd-query-core/src/Shadow/Mutation/ResultSetMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/ResultSetMutation.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+use ZtdQuery\Connection\ResultSet;
+use ZtdQuery\Shadow\ShadowStore;
+
+/**
+ * Mutation whose schema depends on the executed query's result metadata.
+ */
+interface ResultSetMutation extends ShadowMutation
+{
+    public function applyResultSet(ShadowStore $store, ResultSet $result): void;
+}

--- a/packages/ztd-query-core/tests/Fake/FakeStatement.php
+++ b/packages/ztd-query-core/tests/Fake/FakeStatement.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Fake;
 
+use ZtdQuery\Connection\ResultColumn;
 use ZtdQuery\Connection\StatementInterface;
 
 /**
@@ -18,12 +19,17 @@ final class FakeStatement implements StatementInterface
 
     private bool $executed = false;
 
+    /** @var list<ResultColumn> */
+    private array $columns;
+
     /**
      * @param array<int, array<string, mixed>> $rows
+     * @param list<ResultColumn> $columns
      */
-    public function __construct(array $rows = [])
+    public function __construct(array $rows = [], array $columns = [])
     {
         $this->rows = $rows;
+        $this->columns = $columns;
     }
 
     public function execute(?array $params = null): bool
@@ -36,6 +42,11 @@ final class FakeStatement implements StatementInterface
     public function fetchAll(): array
     {
         return $this->rows;
+    }
+
+    public function resultColumns(): array
+    {
+        return $this->columns;
     }
 
     public function rowCount(): int

--- a/packages/ztd-query-core/tests/Fixtures/NativeColumnTypeProvider.php
+++ b/packages/ztd-query-core/tests/Fixtures/NativeColumnTypeProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+final class NativeColumnTypeProvider
+{
+    /** @return iterable<string, array{string, ColumnTypeFamily}> */
+    public static function provide(): iterable
+    {
+        foreach ([
+            'INT', 'INT2', 'INT4', 'INT8', 'INTEGER', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'BIGINT',
+            'SERIAL', 'SMALLSERIAL', 'BIGSERIAL', 'LONG', 'LONGLONG', 'SHORT', 'INT24', 'YEAR', 'BIT',
+            ' int8[] ',
+        ] as $type) {
+            yield "integer $type" => [$type, ColumnTypeFamily::INTEGER];
+        }
+        foreach (['FLOAT', 'FLOAT4', 'REAL'] as $type) {
+            yield "float $type" => [$type, ColumnTypeFamily::FLOAT];
+        }
+        foreach (['DOUBLE', 'FLOAT8', 'DOUBLE PRECISION'] as $type) {
+            yield "double $type" => [$type, ColumnTypeFamily::DOUBLE];
+        }
+        foreach (['DECIMAL', 'NEWDECIMAL', 'NUMERIC', 'numeric(10, 2)'] as $type) {
+            yield "decimal $type" => [$type, ColumnTypeFamily::DECIMAL];
+        }
+        foreach ([
+            'CHAR', 'CHARACTER', 'BPCHAR', 'VARCHAR', 'CHARACTER VARYING', 'VAR_STRING', 'STRING',
+            'ENUM', 'SET', 'NAME',
+        ] as $type) {
+            yield "string $type" => [$type, ColumnTypeFamily::STRING];
+        }
+        foreach (['TEXT', 'TINYTEXT', 'MEDIUMTEXT', 'LONGTEXT', 'CITEXT', 'CLOB'] as $type) {
+            yield "text $type" => [$type, ColumnTypeFamily::TEXT];
+        }
+        foreach (['BOOL', 'BOOLEAN'] as $type) {
+            yield "boolean $type" => [$type, ColumnTypeFamily::BOOLEAN];
+        }
+        foreach (['DATE', 'NEWDATE'] as $type) {
+            yield "date $type" => [$type, ColumnTypeFamily::DATE];
+        }
+        foreach (['TIME', 'TIME2', 'TIMETZ', 'TIME WITH TIME ZONE', 'TIME WITHOUT TIME ZONE'] as $type) {
+            yield "time $type" => [$type, ColumnTypeFamily::TIME];
+        }
+        foreach (['DATETIME', 'DATETIME2'] as $type) {
+            yield "datetime $type" => [$type, ColumnTypeFamily::DATETIME];
+        }
+        foreach ([
+            'TIMESTAMP', 'TIMESTAMP2', 'TIMESTAMPTZ', 'TIMESTAMP WITH TIME ZONE',
+            'TIMESTAMP WITHOUT TIME ZONE',
+        ] as $type) {
+            yield "timestamp $type" => [$type, ColumnTypeFamily::TIMESTAMP];
+        }
+        foreach (['BYTEA', 'BINARY', 'VARBINARY', 'BLOB', 'TINYBLOB', 'MEDIUMBLOB', 'LONGBLOB'] as $type) {
+            yield "binary $type" => [$type, ColumnTypeFamily::BINARY];
+        }
+        foreach (['JSON', 'JSONB'] as $type) {
+            yield "json $type" => [$type, ColumnTypeFamily::JSON];
+        }
+        yield 'unknown native type' => ['custom_domain', ColumnTypeFamily::UNKNOWN];
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Connection/ResultColumnTest.php
+++ b/packages/ztd-query-core/tests/Unit/Connection/ResultColumnTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Connection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Connection\ResultColumn;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+#[CoversClass(ResultColumn::class)]
+#[UsesClass(ColumnType::class)]
+final class ResultColumnTest extends TestCase
+{
+    public function testCarriesNameAndType(): void
+    {
+        $type = new ColumnType(ColumnTypeFamily::INTEGER, 'int4');
+        $column = new ResultColumn('id', $type);
+
+        self::assertSame('id', $column->name);
+        self::assertSame($type, $column->type);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Connection/ResultSetTest.php
+++ b/packages/ztd-query-core/tests/Unit/Connection/ResultSetTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Connection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Connection\ResultColumn;
+use ZtdQuery\Connection\ResultSet;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+#[CoversClass(ResultSet::class)]
+#[UsesClass(ColumnType::class)]
+#[UsesClass(ResultColumn::class)]
+final class ResultSetTest extends TestCase
+{
+    public function testCarriesEmptyRowsAndColumnsIndependently(): void
+    {
+        $column = new ResultColumn('id', new ColumnType(ColumnTypeFamily::INTEGER, 'int4'));
+        $result = new ResultSet([], [$column]);
+
+        self::assertSame([], $result->rows);
+        self::assertSame([$column], $result->columns);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/ResultSelectRunnerTest.php
+++ b/packages/ztd-query-core/tests/Unit/ResultSelectRunnerTest.php
@@ -5,11 +5,19 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Tests\Fake\FakeStatement;
+use ZtdQuery\Connection\ResultColumn;
+use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\ResultSelectRunner;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(ResultSelectRunner::class)]
+#[UsesClass(ColumnType::class)]
+#[UsesClass(ResultColumn::class)]
+#[UsesClass(ResultSet::class)]
 final class ResultSelectRunnerTest extends TestCase
 {
     public function testRunReturnsRowsFromExecutor(): void
@@ -40,5 +48,30 @@ final class ResultSelectRunnerTest extends TestCase
         $result = $runner->runStatement($statement);
 
         self::assertSame($rows, $result);
+        self::assertTrue($statement->isExecuted());
+    }
+
+    public function testRunResultSetRetainsColumnsWhenRowsAreEmpty(): void
+    {
+        $runner = new ResultSelectRunner();
+        $column = new ResultColumn('id', new ColumnType(ColumnTypeFamily::INTEGER, 'int4'));
+
+        $result = $runner->runResultSet('SELECT id FROM users WHERE FALSE', fn () => new FakeStatement([], [$column]));
+
+        self::assertInstanceOf(ResultSet::class, $result);
+        self::assertSame([], $result->rows);
+        self::assertSame([$column], $result->columns);
+    }
+
+    public function testReadResultSetReadsMetadataBeforeRows(): void
+    {
+        $runner = new ResultSelectRunner();
+        $column = new ResultColumn('id', new ColumnType(ColumnTypeFamily::INTEGER, 'int4'));
+        $statement = new FakeStatement([['id' => 1]], [$column]);
+
+        $result = $runner->readResultSet($statement);
+
+        self::assertSame([['id' => 1]], $result->rows);
+        self::assertSame([$column], $result->columns);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/ColumnTypeTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ColumnTypeTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Schema;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\NativeColumnTypeProvider;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
-use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ColumnType::class)]
 final class ColumnTypeTest extends TestCase
@@ -27,5 +29,20 @@ final class ColumnTypeTest extends TestCase
 
         self::assertSame(ColumnTypeFamily::TEXT, $text->family);
         self::assertSame(ColumnTypeFamily::BOOLEAN, $bool->family);
+    }
+
+    #[DataProviderExternal(NativeColumnTypeProvider::class, 'provide')]
+    public function testCreatesTypeFamiliesFromDriverNativeNames(
+        string $nativeType,
+        ColumnTypeFamily $expectedFamily,
+    ): void {
+        self::assertSame($expectedFamily, ColumnType::fromNativeType($nativeType)->family);
+    }
+
+    public function testPreservesNativeTypeForDialectRendering(): void
+    {
+        $type = ColumnType::fromNativeType('numeric(10, 2)');
+
+        self::assertSame('numeric(10, 2)', $type->nativeType);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -12,6 +12,7 @@ use Tests\Fake\FakeSqlRewriter;
 use Tests\Fake\FakeStatement;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\Exception\DatabaseException;
+use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\Exception\MissingPrimaryKeyException;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
@@ -31,6 +32,7 @@ use ZtdQuery\Shadow\ShadowTransactionManager;
 #[UsesClass(TableDefinitionRegistry::class)]
 #[UsesClass(TableDefinition::class)]
 #[UsesClass(ResultSelectRunner::class)]
+#[UsesClass(ResultSet::class)]
 #[UsesClass(DatabaseException::class)]
 #[UsesClass(RewritePlan::class)]
 #[UsesClass(UpdateMutation::class)]

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/CreateTableAsSelectMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/CreateTableAsSelectMutationTest.php
@@ -13,8 +13,13 @@ use ZtdQuery\Shadow\ShadowStore;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Connection\ResultColumn;
+use ZtdQuery\Connection\ResultSet;
 
 #[UsesClass(ColumnType::class)]
+#[UsesClass(ResultColumn::class)]
+#[UsesClass(ResultSet::class)]
 #[UsesClass(TableDefinition::class)]
 #[UsesClass(TableDefinitionRegistry::class)]
 #[UsesClass(ShadowStore::class)]
@@ -141,7 +146,7 @@ final class CreateTableAsSelectMutationTest extends TestCase
         self::assertContains('email', $definition->columns);
     }
 
-    public function testApplyThrowsExceptionWhenNoColumnsCanBeDetermined(): void
+    public function testApplyResultSetCreatesEmptyTableFromMetadata(): void
     {
         $registry = new TableDefinitionRegistry();
         $store = new ShadowStore();
@@ -152,9 +157,67 @@ final class CreateTableAsSelectMutationTest extends TestCase
             $registry
         );
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot determine columns for CREATE TABLE AS SELECT.');
+        $result = new ResultSet([], [
+            new ResultColumn('id', new ColumnType(ColumnTypeFamily::INTEGER, 'int4')),
+            new ResultColumn('name', new ColumnType(ColumnTypeFamily::TEXT, 'text')),
+        ]);
 
-        $mutation->apply($store, []);
+        $mutation->applyResultSet($store, $result);
+
+        $definition = $registry->get('users_copy');
+        self::assertNotNull($definition);
+        self::assertSame(['id', 'name'], $definition->columns);
+        self::assertSame(ColumnTypeFamily::INTEGER, $definition->typedColumns['id']->family);
+        self::assertSame(ColumnTypeFamily::TEXT, $definition->typedColumns['name']->family);
+        self::assertSame([], $store->get('users_copy'));
+    }
+
+    public function testApplyResultSetUsesMetadataTypesInsteadOfTextFallback(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $store = new ShadowStore();
+        $mutation = new CreateTableAsSelectMutation('users_copy', ['id'], $registry);
+        $result = new ResultSet(
+            [['id' => 1]],
+            [new ResultColumn('id', new ColumnType(ColumnTypeFamily::INTEGER, 'int4'))],
+        );
+
+        $mutation->applyResultSet($store, $result);
+
+        $definition = $registry->get('users_copy');
+        self::assertNotNull($definition);
+        self::assertSame('int4', $definition->columnTypes['id']);
+        self::assertSame(ColumnTypeFamily::INTEGER, $definition->typedColumns['id']->family);
+    }
+
+    public function testApplyResultSetKeepsExplicitColumnNamesWithMetadataTypes(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $store = new ShadowStore();
+        $mutation = new CreateTableAsSelectMutation('users_copy', ['display_id'], $registry);
+        $result = new ResultSet(
+            [['source_id' => 1]],
+            [new ResultColumn('source_id', new ColumnType(ColumnTypeFamily::INTEGER, 'int4'))],
+        );
+
+        $mutation->applyResultSet($store, $result);
+
+        $definition = $registry->get('users_copy');
+        self::assertNotNull($definition);
+        self::assertSame(['display_id'], $definition->columns);
+        self::assertSame(ColumnTypeFamily::INTEGER, $definition->typedColumns['display_id']->family);
+    }
+
+    public function testApplyKeepsParsedProjectionNamesWhenMetadataIsUnavailable(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $store = new ShadowStore();
+        $mutation = new CreateTableAsSelectMutation('users_copy', ['display_name'], $registry);
+
+        $mutation->apply($store, [['source_name' => 'Alice']]);
+
+        $definition = $registry->get('users_copy');
+        self::assertNotNull($definition);
+        self::assertSame(['display_name'], $definition->columns);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/ResultSetMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/ResultSetMutationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Shadow\Mutation\CreateTableAsSelectMutation;
+use ZtdQuery\Shadow\Mutation\ResultSetMutation;
+
+#[CoversNothing]
+final class ResultSetMutationTest extends TestCase
+{
+    public function testCreateTableAsSelectImplementsResultSetContract(): void
+    {
+        $mutation = new CreateTableAsSelectMutation('copy', [], new TableDefinitionRegistry());
+
+        self::assertInstanceOf(ResultSetMutation::class, $mutation);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
@@ -9,6 +9,7 @@ use Tests\Fake\FixedRewriter;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\Exception\DatabaseException;
+use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\ResultSelectRunner;
@@ -30,6 +31,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(UnsupportedSqlException::class)]
 #[UsesClass(RewritePlan::class)]
 #[UsesClass(ResultSelectRunner::class)]
+#[UsesClass(ResultSet::class)]
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(MutationImpact::class)]
 #[UsesClass(CandidateKeySet::class)]

--- a/packages/ztd-query-mysqli-adapter/src/MysqliResultColumnExtractor.php
+++ b/packages/ztd-query-mysqli-adapter/src/MysqliResultColumnExtractor.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Mysqli;
+
+use mysqli_result;
+use ZtdQuery\Connection\ResultColumn;
+use ZtdQuery\Schema\ColumnType;
+
+final class MysqliResultColumnExtractor
+{
+    /** @return list<ResultColumn> */
+    public static function extract(mysqli_result $result): array
+    {
+        $columns = [];
+        foreach ($result->fetch_fields() as $field) {
+            $nativeType = match ($field->type) {
+                MYSQLI_TYPE_TINY => 'TINYINT',
+                MYSQLI_TYPE_SHORT => 'SMALLINT',
+                MYSQLI_TYPE_LONG => 'INTEGER',
+                MYSQLI_TYPE_LONGLONG => 'BIGINT',
+                MYSQLI_TYPE_INT24 => 'MEDIUMINT',
+                MYSQLI_TYPE_YEAR => 'YEAR',
+                MYSQLI_TYPE_BIT => 'BIT',
+                MYSQLI_TYPE_FLOAT => 'FLOAT',
+                MYSQLI_TYPE_DOUBLE => 'DOUBLE',
+                MYSQLI_TYPE_DECIMAL, MYSQLI_TYPE_NEWDECIMAL => 'DECIMAL',
+                MYSQLI_TYPE_DATE, MYSQLI_TYPE_NEWDATE => 'DATE',
+                MYSQLI_TYPE_TIME => 'TIME',
+                MYSQLI_TYPE_DATETIME => 'DATETIME',
+                MYSQLI_TYPE_TIMESTAMP => 'TIMESTAMP',
+                MYSQLI_TYPE_JSON => 'JSON',
+                MYSQLI_TYPE_TINY_BLOB, MYSQLI_TYPE_MEDIUM_BLOB, MYSQLI_TYPE_LONG_BLOB,
+                MYSQLI_TYPE_BLOB => self::isBinaryCharset($field->charsetnr) ? 'BLOB' : 'TEXT',
+                MYSQLI_TYPE_VAR_STRING, MYSQLI_TYPE_STRING,
+                MYSQLI_TYPE_ENUM, MYSQLI_TYPE_SET => 'VARCHAR',
+                default => '',
+            };
+            $columns[] = new ResultColumn($field->name, ColumnType::fromNativeType($nativeType));
+        }
+
+        return $columns;
+    }
+
+    private static function isBinaryCharset(int|string $charsetNumber): bool
+    {
+        return $charsetNumber === 63 || $charsetNumber === '63';
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/src/MysqliResultStatement.php
+++ b/packages/ztd-query-mysqli-adapter/src/MysqliResultStatement.php
@@ -53,6 +53,18 @@ final class MysqliResultStatement implements StatementInterface
     /**
      * {@inheritDoc}
      */
+    public function resultColumns(): array
+    {
+        if ($this->result === null) {
+            return [];
+        }
+
+        return MysqliResultColumnExtractor::extract($this->result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function rowCount(): int
     {
         return $this->affectedRows;

--- a/packages/ztd-query-mysqli-adapter/src/MysqliStatement.php
+++ b/packages/ztd-query-mysqli-adapter/src/MysqliStatement.php
@@ -74,20 +74,18 @@ final class MysqliStatement implements StatementInterface
      */
     public function fetchAll(): array
     {
-        if ($this->result === null) {
-            $this->result = $this->statement->get_result();
-        }
+        $result = $this->loadResult();
 
-        if ($this->result === false) {
+        if ($result === false) {
             $this->statement->close();
             return [];
         }
 
         /** @var array<int, array<string, mixed>> $rows */
-        $rows = $this->result->fetch_all(MYSQLI_ASSOC);
+        $rows = $result->fetch_all(MYSQLI_ASSOC);
 
         // Free the result to avoid "Commands out of sync" errors
-        $this->result->free();
+        $result->free();
         $this->result = null;
 
         $this->statement->close();
@@ -98,8 +96,30 @@ final class MysqliStatement implements StatementInterface
     /**
      * {@inheritDoc}
      */
+    public function resultColumns(): array
+    {
+        $result = $this->loadResult();
+        if ($result === false) {
+            return [];
+        }
+
+        return MysqliResultColumnExtractor::extract($result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function rowCount(): int
     {
         return (int) $this->statement->affected_rows;
+    }
+
+    private function loadResult(): mysqli_result|false
+    {
+        if ($this->result === null) {
+            $this->result = $this->statement->get_result();
+        }
+
+        return $this->result;
     }
 }

--- a/packages/ztd-query-mysqli-adapter/tests/Fixtures/MysqliFieldTypeProvider.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Fixtures/MysqliFieldTypeProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+final class MysqliFieldTypeProvider
+{
+    /** @return iterable<string, array{int, int|string, ColumnTypeFamily}> */
+    public static function provide(): iterable
+    {
+        foreach ([
+            MYSQLI_TYPE_TINY,
+            MYSQLI_TYPE_SHORT,
+            MYSQLI_TYPE_LONG,
+            MYSQLI_TYPE_LONGLONG,
+            MYSQLI_TYPE_INT24,
+            MYSQLI_TYPE_YEAR,
+            MYSQLI_TYPE_BIT,
+        ] as $type) {
+            yield "integer $type" => [$type, 255, ColumnTypeFamily::INTEGER];
+        }
+        yield 'float' => [MYSQLI_TYPE_FLOAT, 255, ColumnTypeFamily::FLOAT];
+        yield 'double' => [MYSQLI_TYPE_DOUBLE, 255, ColumnTypeFamily::DOUBLE];
+        yield 'decimal' => [MYSQLI_TYPE_DECIMAL, 255, ColumnTypeFamily::DECIMAL];
+        yield 'new decimal' => [MYSQLI_TYPE_NEWDECIMAL, 255, ColumnTypeFamily::DECIMAL];
+        yield 'date' => [MYSQLI_TYPE_DATE, 255, ColumnTypeFamily::DATE];
+        yield 'new date' => [MYSQLI_TYPE_NEWDATE, 255, ColumnTypeFamily::DATE];
+        yield 'time' => [MYSQLI_TYPE_TIME, 255, ColumnTypeFamily::TIME];
+        yield 'datetime' => [MYSQLI_TYPE_DATETIME, 255, ColumnTypeFamily::DATETIME];
+        yield 'timestamp' => [MYSQLI_TYPE_TIMESTAMP, 255, ColumnTypeFamily::TIMESTAMP];
+        yield 'json' => [MYSQLI_TYPE_JSON, 255, ColumnTypeFamily::JSON];
+        foreach ([
+            MYSQLI_TYPE_TINY_BLOB,
+            MYSQLI_TYPE_MEDIUM_BLOB,
+            MYSQLI_TYPE_LONG_BLOB,
+            MYSQLI_TYPE_BLOB,
+        ] as $type) {
+            yield "binary $type" => [$type, 63, ColumnTypeFamily::BINARY];
+        }
+        yield 'text blob' => [MYSQLI_TYPE_BLOB, 255, ColumnTypeFamily::TEXT];
+        foreach ([MYSQLI_TYPE_VAR_STRING, MYSQLI_TYPE_STRING, MYSQLI_TYPE_ENUM, MYSQLI_TYPE_SET] as $type) {
+            yield "string $type" => [$type, 255, ColumnTypeFamily::STRING];
+        }
+        yield 'unknown' => [MYSQLI_TYPE_NULL, 255, ColumnTypeFamily::UNKNOWN];
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/tests/Fixtures/StubMysqliField.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Fixtures/StubMysqliField.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+final class StubMysqliField
+{
+    public function __construct(
+        public string $name,
+        public int $type,
+        public int|string $charsetnr,
+    ) {
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/tests/Fixtures/StubMysqliResult.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Fixtures/StubMysqliResult.php
@@ -21,14 +21,19 @@ class StubMysqliResult extends mysqli_result
     /** @var array<int, array<string, mixed>> */
     private array $rows = [];
 
+    /** @var list<StubMysqliField> */
+    private array $fields = [];
+
     /**
      * @param array<int, array<string, mixed>> $rows
+     * @param list<StubMysqliField> $fields
      */
-    public static function create(array $rows = []): self
+    public static function create(array $rows = [], array $fields = []): self
     {
         /** @var self $instance */
         $instance = (new ReflectionClass(self::class))->newInstanceWithoutConstructor();
         $instance->rows = $rows;
+        $instance->fields = $fields;
 
         return $instance;
     }
@@ -39,5 +44,11 @@ class StubMysqliResult extends mysqli_result
     public function fetch_all(int $mode = MYSQLI_NUM): array
     {
         return $this->rows;
+    }
+
+    /** @return list<StubMysqliField> */
+    public function fetch_fields(): array
+    {
+        return $this->fields;
     }
 }

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultColumnExtractorTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultColumnExtractorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MysqliFieldTypeProvider;
+use Tests\Fixtures\StubMysqliField;
+use Tests\Fixtures\StubMysqliResult;
+use ZtdQuery\Adapter\Mysqli\MysqliResultColumnExtractor;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+#[CoversClass(MysqliResultColumnExtractor::class)]
+final class MysqliResultColumnExtractorTest extends TestCase
+{
+    public function testExtractPreservesEveryResultColumn(): void
+    {
+        $result = StubMysqliResult::create([], [
+            new StubMysqliField('id', MYSQLI_TYPE_LONG, 63),
+            new StubMysqliField('name', MYSQLI_TYPE_VAR_STRING, 255),
+        ]);
+
+        $columns = MysqliResultColumnExtractor::extract($result);
+
+        self::assertSame(['id', 'name'], array_map(static fn ($column) => $column->name, $columns));
+    }
+
+    #[DataProviderExternal(MysqliFieldTypeProvider::class, 'provide')]
+    public function testExtractMapsEveryMysqliFieldType(
+        int $fieldType,
+        int|string $charsetNumber,
+        ColumnTypeFamily $expectedFamily,
+    ): void {
+        $field = new StubMysqliField('value', $fieldType, $charsetNumber);
+        $result = StubMysqliResult::create([], [$field]);
+
+        $columns = MysqliResultColumnExtractor::extract($result);
+
+        self::assertSame('value', $columns[0]->name);
+        self::assertSame($expectedFamily, $columns[0]->type->family);
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultStatementTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultStatementTest.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\StubMysqliField;
 use Tests\Fixtures\StubMysqliResult;
 use ZtdQuery\Adapter\Mysqli\MysqliResultStatement;
+use ZtdQuery\Adapter\Mysqli\MysqliResultColumnExtractor;
 use ZtdQuery\Connection\StatementInterface;
+use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(MysqliResultStatement::class)]
+#[UsesClass(MysqliResultColumnExtractor::class)]
 final class MysqliResultStatementTest extends TestCase
 {
     public function testImplementsStatementInterface(): void
@@ -62,4 +67,27 @@ final class MysqliResultStatementTest extends TestCase
 
         self::assertSame(0, $stmt->rowCount());
     }
+
+    public function testResultColumnsReturnsEmptyArrayWithoutResult(): void
+    {
+        $stmt = new MysqliResultStatement(null, 0);
+
+        self::assertSame([], $stmt->resultColumns());
+    }
+
+    public function testResultColumnsMapMysqliFieldMetadata(): void
+    {
+        $integer = new StubMysqliField('id', MYSQLI_TYPE_LONG, '63');
+        $text = new StubMysqliField('description', MYSQLI_TYPE_BLOB, '255');
+        $binary = new StubMysqliField('payload', MYSQLI_TYPE_BLOB, '63');
+        $result = StubMysqliResult::create([], [$integer, $text, $binary]);
+
+        $columns = (new MysqliResultStatement($result, 0))->resultColumns();
+
+        self::assertSame(['id', 'description', 'payload'], array_map(static fn ($column) => $column->name, $columns));
+        self::assertSame(ColumnTypeFamily::INTEGER, $columns[0]->type->family);
+        self::assertSame(ColumnTypeFamily::TEXT, $columns[1]->type->family);
+        self::assertSame(ColumnTypeFamily::BINARY, $columns[2]->type->family);
+    }
+
 }

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliStatementTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliStatementTest.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Tests\Fixtures\StubMysqli;
+use Tests\Fixtures\StubMysqliField;
+use Tests\Fixtures\StubMysqliResult;
 use Tests\Fixtures\StubMysqliStmt;
+use ZtdQuery\Adapter\Mysqli\MysqliResultColumnExtractor;
 use ZtdQuery\Adapter\Mysqli\MysqliStatement;
 use ZtdQuery\Connection\StatementInterface;
+use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(MysqliStatement::class)]
+#[UsesClass(MysqliResultColumnExtractor::class)]
 final class MysqliStatementTest extends TestCase
 {
     public function testImplementsStatementInterface(): void
@@ -22,5 +28,17 @@ final class MysqliStatementTest extends TestCase
         $statement = new MysqliStatement($stmt, $mysqli);
 
         self::assertInstanceOf(StatementInterface::class, $statement);
+    }
+
+    public function testResultColumnsLoadPreparedResultMetadata(): void
+    {
+        $field = new StubMysqliField('id', MYSQLI_TYPE_LONG, '63');
+        $stmt = StubMysqliStmt::create();
+        $stmt->getResultReturn = StubMysqliResult::create([], [$field]);
+
+        $columns = (new MysqliStatement($stmt, new StubMysqli()))->resultColumns();
+
+        self::assertSame('id', $columns[0]->name);
+        self::assertSame(ColumnTypeFamily::INTEGER, $columns[0]->type->family);
     }
 }

--- a/packages/ztd-query-pdo-adapter/composer.json
+++ b/packages/ztd-query-pdo-adapter/composer.json
@@ -94,7 +94,8 @@
             "@fuzz:correctness:pg:select",
             "@fuzz:correctness:pg:insert",
             "@fuzz:correctness:pg:update",
-            "@fuzz:correctness:pg:delete"
+            "@fuzz:correctness:pg:delete",
+            "@fuzz:correctness:pg:ctas"
         ],
         "fuzz:robustness": "php-fuzzer fuzz fuzz/fuzz_robustness_execute.php fuzz/corpus/robustness-execute/",
         "fuzz:correctness:select": "php-fuzzer fuzz fuzz/fuzz_correctness_select.php fuzz/corpus/correctness-select/",
@@ -110,6 +111,7 @@
         "fuzz:correctness:pg:insert": "php-fuzzer fuzz fuzz/fuzz_correctness_pg_insert.php fuzz/corpus/correctness-insert/",
         "fuzz:correctness:pg:update": "php-fuzzer fuzz fuzz/fuzz_correctness_pg_update.php fuzz/corpus/correctness-update/",
         "fuzz:correctness:pg:delete": "php-fuzzer fuzz fuzz/fuzz_correctness_pg_delete.php fuzz/corpus/correctness-delete/",
+        "fuzz:correctness:pg:ctas": "php-fuzzer fuzz fuzz/fuzz_correctness_pg_ctas.php fuzz/corpus/correctness-pg-ctas/",
         "infection": "infection --threads=max --show-mutations --no-progress"
     },
     "config": {

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/CreateTableAsCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/CreateTableAsCorrectnessTarget.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fuzz\Correctness\Postgres\Target;
+
+use Error;
+use Faker\Generator;
+use Fuzz\Correctness\Postgres\PgCorrectnessHarness;
+use Fuzz\Correctness\Postgres\PgSchemaPool;
+use Fuzz\Correctness\ResultComparator;
+use Fuzz\Correctness\SchemaDefinition;
+use PDO;
+use PDOException;
+use Throwable;
+
+final class CreateTableAsCorrectnessTarget
+{
+    public function __construct(
+        private readonly PgCorrectnessHarness $harness,
+        private readonly Generator $faker,
+        private readonly ResultComparator $comparator = new ResultComparator(),
+    ) {
+    }
+
+    public function __invoke(string $input): void
+    {
+        $seed = crc32(str_pad($input, 4, "\0"));
+        $this->faker->seed($seed);
+        $schema = PgSchemaPool::random($this->faker);
+        $this->harness->setup($schema, $seed);
+        $copy = '_ztd_ctas_copy';
+        $case = $this->buildCase($schema, $copy);
+
+        try {
+            $this->harness->getRawPdo()->exec('DROP TABLE IF EXISTS ' . $this->quote($copy));
+            $this->harness->getRawPdo()->exec($case['sql']);
+
+            try {
+                $this->harness->getZtdPdo()->exec($case['sql']);
+            } catch (Throwable $exception) {
+                throw new Error("ZTD CTAS failed after native success\nSeed: $seed\nSQL: {$case['sql']}", 0, $exception);
+            }
+
+            $this->compareQuery('SELECT * FROM ' . $this->quote($copy), $case['sql'], $seed, $schema);
+            $this->compareQuery(
+                'SELECT * FROM ' . $this->quote($copy) . ' WHERE ' . $case['predicate'],
+                $case['sql'],
+                $seed,
+                $schema,
+            );
+        } catch (PDOException) {
+            return;
+        } finally {
+            $this->harness->getRawPdo()->exec('DROP TABLE IF EXISTS ' . $this->quote($copy));
+            $this->harness->teardown();
+        }
+    }
+
+    /**
+     * @return array{sql: string, predicate: string}
+     */
+    private function buildCase(SchemaDefinition $schema, string $copy): array
+    {
+        $table = $this->quote($schema->name);
+        $target = $this->quote($copy);
+        $key = $schema->primaryKeys[0] ?? $schema->columns[0];
+        $quotedKey = $this->quote($key);
+
+        return match ($this->faker->numberBetween(0, 4)) {
+            0 => [
+                'sql' => "CREATE TABLE $target AS SELECT * FROM $table WHERE FALSE",
+                'predicate' => "$quotedKey = 1",
+            ],
+            1 => [
+                'sql' => "CREATE TABLE $target AS SELECT * FROM $table",
+                'predicate' => "$quotedKey = 1",
+            ],
+            2 => [
+                'sql' => "CREATE TABLE $target AS SELECT $quotedKey FROM $table WHERE $quotedKey >= 1",
+                'predicate' => "$quotedKey = 1",
+            ],
+            3 => [
+                'sql' => "CREATE TABLE $target AS SELECT $quotedKey + 1 AS ztd_value FROM $table",
+                'predicate' => 'ztd_value = 2',
+            ],
+            default => [
+                'sql' => "CREATE TABLE $target AS SELECT $quotedKey AS ztd_alias FROM $table WHERE FALSE",
+                'predicate' => 'ztd_alias = 1',
+            ],
+        };
+    }
+
+    private function compareQuery(string $query, string $createSql, int $seed, SchemaDefinition $schema): void
+    {
+        $rawRows = $this->normalizeFixedCharacterRows(
+            $this->fetchAll($this->harness->getRawPdo(), $query),
+            $schema,
+        );
+        try {
+            $ztdRows = $this->normalizeFixedCharacterRows(
+                $this->fetchAll($this->harness->getZtdPdo(), $query),
+                $schema,
+            );
+        } catch (Throwable $exception) {
+            throw new Error(
+                "ZTD CTAS query failed after native success\nSeed: $seed\nSQL: $createSql\nQuery: $query",
+                0,
+                $exception,
+            );
+        }
+
+        if (!$this->comparator->compareRows($rawRows, $ztdRows, [], [], true)) {
+            throw new Error(
+                "CTAS result mismatch\n"
+                . "Seed: $seed\n"
+                . "SQL: $createSql\n"
+                . "Query: $query\n"
+                . 'Native: ' . json_encode($rawRows, JSON_THROW_ON_ERROR) . "\n"
+                . 'ZTD: ' . json_encode($ztdRows, JSON_THROW_ON_ERROR),
+            );
+        }
+    }
+
+    /**
+     * PostgreSQL pads CHAR values when reading a physical table, while the existing
+     * shadow source stores their semantically equivalent unpadded representation.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeFixedCharacterRows(array $rows, SchemaDefinition $schema): array
+    {
+        if ($schema->name !== 'text_types') {
+            return $rows;
+        }
+
+        foreach ($rows as $index => $row) {
+            $value = $row['col_char'] ?? null;
+            if (is_string($value)) {
+                $rows[$index]['col_char'] = rtrim($value, ' ');
+            }
+        }
+
+        return $rows;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function fetchAll(PDO $pdo, string $query): array
+    {
+        $statement = $pdo->query($query);
+        if ($statement === false) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            if (!is_array($row)) {
+                throw new Error('CTAS correctness query returned a non-array row');
+            }
+            $normalized = [];
+            foreach ($row as $column => $value) {
+                if (!is_string($column)) {
+                    throw new Error('CTAS correctness query returned a non-string column');
+                }
+                $normalized[$column] = $value;
+            }
+            $rows[] = $normalized;
+        }
+
+        return $rows;
+    }
+
+    private function quote(string $identifier): string
+    {
+        return '"' . str_replace('"', '""', $identifier) . '"';
+    }
+}

--- a/packages/ztd-query-pdo-adapter/fuzz/fuzz_correctness_pg_ctas.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/fuzz_correctness_pg_ctas.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+register_shutdown_function(static function (): void {
+    if (function_exists('pcntl_alarm')) {
+        pcntl_alarm(0);
+    }
+});
+
+use Faker\Factory;
+use Fuzz\Container\PostgreSqlContainer;
+use Fuzz\Correctness\Postgres\PgCorrectnessHarness;
+use Fuzz\Correctness\Postgres\Target\CreateTableAsCorrectnessTarget;
+use Testcontainers\Testcontainers;
+
+$instance = Testcontainers::run(PostgreSqlContainer::class);
+$port = $instance->getMappedPort(5432);
+assert(is_int($port));
+$host = str_replace('localhost', '127.0.0.1', $instance->getHost());
+
+$faker = Factory::create();
+$harness = new PgCorrectnessHarness($host, $port, 'fuzz_test', 'test', 'test');
+$target = new CreateTableAsCorrectnessTarget($harness, $faker);
+
+/** @var \PhpFuzzer\Config $config */
+$config->setTarget(\Closure::fromCallable($target));

--- a/packages/ztd-query-pdo-adapter/src/PdoStatement.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoStatement.php
@@ -8,7 +8,9 @@ use PDO;
 use PDOException;
 use PDOStatement as NativePdoStatement;
 use ZtdQuery\Connection\Exception\DatabaseException;
+use ZtdQuery\Connection\ResultColumn;
 use ZtdQuery\Connection\StatementInterface;
+use ZtdQuery\Schema\ColumnType;
 
 /**
  * PDO statement implementing StatementInterface for ZTD layer.
@@ -53,6 +55,56 @@ final class PdoStatement implements StatementInterface
         $rows = $this->statement->fetchAll(PDO::FETCH_ASSOC);
 
         return $rows;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resultColumns(): array
+    {
+        $columns = [];
+        for ($index = 0; $index < $this->statement->columnCount(); $index++) {
+            $metadata = $this->statement->getColumnMeta($index);
+            if (!is_array($metadata)) {
+                continue;
+            }
+
+            $columns[] = new ResultColumn(
+                $metadata['name'],
+                ColumnType::fromNativeType($this->nativeType($metadata)),
+            );
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function nativeType(array $metadata): string
+    {
+        $declaredType = array_key_exists('sqlite:decl_type', $metadata)
+            ? $metadata['sqlite:decl_type']
+            : null;
+        if (is_string($declaredType)) {
+            return $declaredType;
+        }
+
+        $nativeType = array_key_exists('native_type', $metadata) ? $metadata['native_type'] : '';
+        if (!is_string($nativeType)) {
+            return '';
+        }
+
+        $length = array_key_exists('len', $metadata) ? $metadata['len'] : null;
+        if (is_int($length) && $length > 0 && !str_contains($nativeType, '(')) {
+            $nativeType = match (strtoupper($nativeType)) {
+                'VARCHAR' => "VARCHAR($length)",
+                'BPCHAR' => "CHAR($length)",
+                default => $nativeType,
+            };
+        }
+
+        return $nativeType;
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/CreateTableTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/CreateTableTest.php
@@ -89,4 +89,62 @@ final class CreateTableTest extends TestCase
             $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
         }
     }
+
+    public function testCreateTableAsSelectPreservesColumnsForEmptyResult(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $source = 'source_' . bin2hex(random_bytes(8));
+        $copy = 'copy_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$source} (id INTEGER, name TEXT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+            $ztdPdo->exec("INSERT INTO {$source} VALUES (1, 'Alice')");
+
+            self::assertSame(0, $ztdPdo->exec("CREATE TABLE {$copy} AS SELECT * FROM {$source} WHERE FALSE"));
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO {$copy} VALUES (2, 'Bob')"));
+
+            $statement = $ztdPdo->query("SELECT * FROM {$copy} WHERE id = 2");
+            self::assertNotFalse($statement);
+            self::assertSame([['id' => 2, 'name' => 'Bob']], $statement->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
+    public function testCreateTableAsSelectPreservesProjectedPostgreSqlTypes(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $source = 'source_' . bin2hex(random_bytes(8));
+        $copy = 'copy_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$source} (id INTEGER, name VARCHAR(40), score NUMERIC(8, 2))");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo, null);
+            $ztdPdo->exec("INSERT INTO {$source} VALUES (1, 'Alice', 95.25)");
+
+            $ztdPdo->exec(
+                "CREATE TABLE {$copy} AS SELECT id + 1 AS next_id, name, score FROM {$source}"
+            );
+
+            $statement = $ztdPdo->query("SELECT next_id, name, score FROM {$copy} WHERE next_id = 2");
+            self::assertNotFalse($statement);
+            self::assertSame(
+                [['next_id' => 2, 'name' => 'Alice', 'score' => '95.25']],
+                $statement->fetchAll(),
+            );
+
+            $typeStatement = $ztdPdo->query(
+                "SELECT pg_typeof(next_id)::text AS id_type, pg_typeof(name)::text AS name_type, "
+                . "pg_typeof(score)::text AS score_type FROM {$copy} LIMIT 1"
+            );
+            self::assertNotFalse($typeStatement);
+            self::assertSame(
+                [['id_type' => 'integer', 'name_type' => 'character varying', 'score_type' => 'numeric']],
+                $typeStatement->fetchAll(),
+            );
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoStatementTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoStatementTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\PdoStatement;
 use ZtdQuery\Connection\StatementInterface;
+use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(PdoStatement::class)]
 final class PdoStatementTest extends TestCase
@@ -70,5 +71,20 @@ final class PdoStatementTest extends TestCase
         $stmt = new PdoStatement($nativeStmt);
 
         self::assertTrue($stmt->execute());
+    }
+
+    public function testResultColumnsUseDeclaredTypesForEmptyResult(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE t (id INTEGER, name TEXT, score REAL)');
+        $nativeStmt = $pdo->query('SELECT * FROM t WHERE 1 = 0');
+        self::assertNotFalse($nativeStmt);
+
+        $columns = (new PdoStatement($nativeStmt))->resultColumns();
+
+        self::assertSame(['id', 'name', 'score'], array_map(static fn ($column) => $column->name, $columns));
+        self::assertSame(ColumnTypeFamily::INTEGER, $columns[0]->type->family);
+        self::assertSame(ColumnTypeFamily::TEXT, $columns[1]->type->family);
+        self::assertSame(ColumnTypeFamily::FLOAT, $columns[2]->type->family);
     }
 }

--- a/packages/ztd-query-postgres/src/PgSqlCastRenderer.php
+++ b/packages/ztd-query-postgres/src/PgSqlCastRenderer.php
@@ -95,6 +95,10 @@ final class PgSqlCastRenderer implements CastRenderer
             return "VARCHAR({$matches[1]})";
         }
 
+        if ($upper === 'VARCHAR' || $upper === 'CHARACTER VARYING') {
+            return 'VARCHAR';
+        }
+
         return 'TEXT';
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCastRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCastRendererTest.php
@@ -413,6 +413,20 @@ final class PgSqlCastRendererTest extends CastRendererContractTest
     {
         $renderer = new PgSqlCastRenderer();
         $type = new ColumnType(ColumnTypeFamily::STRING, 'VARCHAR');
+        self::assertSame("CAST('hi' AS VARCHAR)", $renderer->renderCast("'hi'", $type));
+    }
+
+    public function testRenderCastCharacterVaryingWithoutLength(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+        $type = new ColumnType(ColumnTypeFamily::STRING, 'CHARACTER VARYING');
+        self::assertSame("CAST('hi' AS VARCHAR)", $renderer->renderCast("'hi'", $type));
+    }
+
+    public function testRenderCastUnknownStringNativeTypeFallsBackToText(): void
+    {
+        $renderer = new PgSqlCastRenderer();
+        $type = new ColumnType(ColumnTypeFamily::STRING, 'CUSTOM_STRING');
         self::assertSame("CAST('hi' AS TEXT)", $renderer->renderCast("'hi'", $type));
     }
 


### PR DESCRIPTION
## Summary
- carry ordered result-column metadata with buffered rows across the core execution boundary
- create CTAS shadow definitions from driver-reported names and native types, including empty results
- implement PDO and mysqli metadata adapters with centralized native-type classification
- preserve PostgreSQL unbounded VARCHAR casts instead of degrading them to TEXT

## Root cause
The result-select contract returned rows only. CTAS therefore inferred columns from the first row and hard-coded every type as TEXT. Empty results had no first row, and non-empty PostgreSQL CTAS definitions lost their actual numeric and string types.

## Recurrence prevention
- add core, PDO, mysqli, and PostgreSQL tests for empty metadata, projection order, every supported driver type family, and CTAS type preservation
- add PostgreSQL `CreateAsStmt` generation to SQLFaker and exercise it in syntax fuzzing
- add native-versus-ZTD PostgreSQL CTAS correctness fuzzing for empty, star, projected, expression, and aliased queries
- add the CTAS target to the scheduled PostgreSQL fuzz matrix
- mutation-test the new schema and type paths

## Verification
- core unit: 638 tests, 1123 assertions
- PostgreSQL unit: 1357 tests, 2181 assertions
- PDO unit: 276 tests, 347 assertions
- PDO integration: 236 tests, 805 assertions
- mysqli full: 116 tests, 280 assertions
- SQLFaker unit: 1036 tests, 1837 assertions
- CTAS correctness fuzz: 500 runs
- core CTAS mutation: 19/19 killed, MSI 100%
- mysqli metadata mutation: 36/36 killed, MSI 100%
- PostgreSQL cast mutation: 51/51 killed, MSI 100%
- PDO metadata mutation: 11/11 killed, MSI 100%
- SQLFaker changed-line mutation: 1/1 killed, MSI 100%
- core, PostgreSQL, PDO, mysqli, and SQLFaker lint: passed

Stacked on #236.

Fixes #36
Fixes #37