### PR TITLE
test: lock prepared upsert shadow state

### DIFF
--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/PreparedUpsertTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/PreparedUpsertTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class PreparedUpsertTest extends TestCase
+{
+    public function testPreparedReplaceRemovesExistingPrimaryKey(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$table}` (id INT PRIMARY KEY, name VARCHAR(50), value INT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$table}` VALUES (1, 'original', 100)");
+            $statement = $ztdPdo->prepare("REPLACE INTO `{$table}` VALUES (?, ?, ?)");
+            self::assertNotFalse($statement);
+
+            self::assertTrue($statement->execute([1, 'replaced', 999]));
+
+            $rows = $ztdPdo->query("SELECT * FROM `{$table}` WHERE id = 1");
+            self::assertNotFalse($rows);
+            self::assertSame([['id' => 1, 'name' => 'replaced', 'value' => 999]], $rows->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
+    public function testPreparedOnDuplicateKeyUpdateReplacesExistingValues(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$table}` (id INT PRIMARY KEY, name VARCHAR(50))");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$table}` VALUES (1, 'original')");
+            $statement = $ztdPdo->prepare(
+                "INSERT INTO `{$table}` VALUES (?, ?) ON DUPLICATE KEY UPDATE name = VALUES(name)"
+            );
+            self::assertNotFalse($statement);
+
+            self::assertTrue($statement->execute(['1', 'updated']));
+
+            $rows = $ztdPdo->query("SELECT * FROM `{$table}` WHERE id = 1");
+            self::assertNotFalse($rows);
+            self::assertSame([['id' => 1, 'name' => 'updated']], $rows->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/InsertOnConflictTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/InsertOnConflictTest.php
@@ -19,6 +19,30 @@ use ZtdQuery\Adapter\Pdo\ZtdPdo;
 #[Large]
 final class InsertOnConflictTest extends TestCase
 {
+    public function testPreparedOnConflictDoUpdateReplacesExistingRow(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$table} (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO {$table} VALUES (1, 'original')");
+            $statement = $ztdPdo->prepare(
+                "INSERT INTO {$table} VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name"
+            );
+            self::assertNotFalse($statement);
+
+            self::assertTrue($statement->execute(['1', 'updated']));
+
+            $rows = $ztdPdo->query("SELECT * FROM {$table} WHERE id = 1");
+            self::assertNotFalse($rows);
+            self::assertSame([['id' => 1, 'name' => 'updated']], $rows->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
     public function testOnConflictDoNothing(): void
     {
         [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/InsertOrReplaceTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/InsertOrReplaceTest.php
@@ -16,6 +16,25 @@ use ZtdQuery\Adapter\Pdo\ZtdPdo;
 #[Large]
 final class InsertOrReplaceTest extends TestCase
 {
+    public function testPreparedInsertOrReplaceRemovesExistingPrimaryKey(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, value INTEGER)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO users VALUES (1, 'original', 100)");
+
+        $statement = $ztdPdo->prepare('INSERT OR REPLACE INTO users VALUES (?, ?, ?)');
+        self::assertNotFalse($statement);
+        self::assertTrue($statement->execute(['1', 'replaced', 999]));
+
+        $rows = $ztdPdo->query('SELECT * FROM users WHERE id = 1');
+        self::assertNotFalse($rows);
+        self::assertSame([['id' => 1, 'name' => 'replaced', 'value' => 999]], $rows->fetchAll());
+    }
+
     public function testInsertOrReplace(): void
     {
         $rawPdo = new \PDO('sqlite::memory:', null, null, [


### PR DESCRIPTION
## Summary
- add PDO regression coverage for prepared MySQL REPLACE and ON DUPLICATE KEY UPDATE
- add prepared PostgreSQL ON CONFLICT DO UPDATE coverage
- add prepared SQLite INSERT OR REPLACE coverage
- assert candidate-key replacement leaves exactly one updated shadow row

## Root cause
Prepared statements previously reused a rewrite plan captured before execution. Their result-select and mutation state could therefore be stale when resolving candidate-key conflicts. The runtime recompilation and typed binding fix is already part of the stack in #221; these issue-specific cases were not covered there.

## Recurrence prevention
The new integration tests exercise positional parameters, string-to-key coercion, and the resulting shadow table state across all PDO dialects. They fail if an old row is retained or a duplicate primary key is appended.

## Verification
- targeted prepared upsert integration: 4 tests, 16 assertions
- full PDO integration: 240 tests, 821 assertions
- PDO lint: passed

Stacked on #237. The production fix is in ancestor #221.

Fixes #17
Fixes #55