### PR TITLE
test: prevent PostgreSQL no-PK join regressions

### DIFF
--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaAwareSqlBuilder.php
@@ -55,6 +55,34 @@ final class PgSchemaAwareSqlBuilder
         }
     }
 
+    public function buildJoinSelect(SchemaDefinition $left, SchemaDefinition $right): string
+    {
+        $leftTable = $this->quoteIdentifier($left->name);
+        $rightTable = $this->quoteIdentifier($right->name);
+        $leftKey = $left->primaryKeys[0] ?? $left->columns[0];
+        $rightKey = $right->columns[0];
+        /** @var string $leftColumn */
+        $leftColumn = $this->faker->randomElement($left->columns);
+        /** @var string $rightColumn */
+        $rightColumn = $this->faker->randomElement($right->columns);
+        /** @var string $join */
+        $join = $this->faker->randomElement([
+            'JOIN',
+            'INNER JOIN',
+            'LEFT JOIN',
+            'RIGHT JOIN',
+            'FULL OUTER JOIN',
+        ]);
+
+        return 'SELECT l.' . $this->quoteIdentifier($leftColumn) . ' AS "left_value", '
+            . 'r.' . $this->quoteIdentifier($rightColumn) . ' AS "right_value" '
+            . "FROM $leftTable AS l $join $rightTable AS r "
+            . 'ON l.' . $this->quoteIdentifier($leftKey) . ' = r.' . $this->quoteIdentifier($rightKey) . ' '
+            . 'ORDER BY l.' . $this->quoteIdentifier($leftKey) . ' NULLS LAST, '
+            . 'r.' . $this->quoteIdentifier($rightKey) . ' NULLS LAST, '
+            . '"left_value" NULLS LAST, "right_value" NULLS LAST';
+    }
+
     public function buildInsert(SchemaDefinition $schema): string
     {
         $table = $this->quoteIdentifier($schema->name);

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/SelectCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/SelectCorrectnessTarget.php
@@ -42,16 +42,40 @@ final class SelectCorrectnessTarget
 
         $schema = PgSchemaPool::random($this->faker);
         $this->harness->setup($schema, $seed);
+        $joinSchema = new SchemaDefinition(
+            '_ztd_join_no_pk',
+            'CREATE TABLE "_ztd_join_no_pk" (item_id INTEGER NOT NULL, tag VARCHAR(50) NOT NULL)',
+            ['item_id', 'tag'],
+            [],
+        );
 
         try {
+            $this->setupJoinTable($joinSchema);
+            $this->compareSelect($this->sqlBuilder->buildJoinSelect($schema, $joinSchema), $schema, $seed);
+
             $queryCount = $this->faker->numberBetween(1, 5);
             for ($i = 0; $i < $queryCount; $i++) {
                 $sql = $this->sqlBuilder->buildSelect($schema);
                 $this->compareSelect($sql, $schema, $seed);
             }
         } finally {
+            $this->harness->getRawPdo()->exec('DROP TABLE IF EXISTS "_ztd_join_no_pk" CASCADE');
             $this->harness->teardown();
         }
+    }
+
+    private function setupJoinTable(SchemaDefinition $schema): void
+    {
+        $this->harness->getRawPdo()->exec('DROP TABLE IF EXISTS "_ztd_join_no_pk" CASCADE');
+        $this->harness->getRawPdo()->exec($schema->sql);
+        $this->harness->getRawPdo()->exec(
+            "INSERT INTO \"_ztd_join_no_pk\" VALUES (1, 'new'), (1, 'sale'), (2, 'blue'), (99, 'orphan')",
+        );
+
+        $this->harness->getZtdPdo()->exec($schema->sql);
+        $this->harness->getZtdPdo()->exec(
+            "INSERT INTO \"_ztd_join_no_pk\" VALUES (1, 'new'), (1, 'sale'), (2, 'blue'), (99, 'orphan')",
+        );
     }
 
     private function compareSelect(string $sql, SchemaDefinition $schema, int $seed): void

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/SelectJoinTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/SelectJoinTest.php
@@ -234,4 +234,34 @@ final class SelectJoinTest extends TestCase
             $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
         }
     }
+
+    public function testJoinWithTableWithoutPrimaryKey(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $items = 'prefix_' . bin2hex(random_bytes(8));
+        $tags = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("CREATE TABLE {$items} (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+            $ztdPdo->exec("CREATE TABLE {$tags} (item_id INTEGER NOT NULL, tag VARCHAR(50) NOT NULL)");
+            $ztdPdo->exec("INSERT INTO {$items} VALUES (1, 'book'), (2, 'pen')");
+            $ztdPdo->exec("INSERT INTO {$tags} VALUES (1, 'new'), (1, 'sale'), (2, 'blue')");
+
+            $sql = "SELECT i.name, t.tag FROM {$items} i JOIN {$tags} t ON i.id = t.item_id ORDER BY i.id, t.tag";
+
+            $stmt = $ztdPdo->query($sql);
+            self::assertNotFalse($stmt);
+            /** @var list<array<string, mixed>> */
+            $ztdRows = $stmt->fetchAll();
+
+            self::assertSame([
+                ['name' => 'book', 'tag' => 'new'],
+                ['name' => 'book', 'tag' => 'sale'],
+                ['name' => 'pen', 'tag' => 'blue'],
+            ], $ztdRows);
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
 }


### PR DESCRIPTION
## Root problem

PostgreSQL SELECT correctness fuzzing only generated single-table queries, so JOINs between a primary-key table and a shadow table without a primary key were outside the regression surface. The reported reproduction already succeeds on current `main`, but had no persistent integration or native-vs-ZTD fuzz guard.

## Changes

- add the exact virtual-schema JOIN regression for a PK table and a no-PK table
- add schema-aware PostgreSQL JOIN generation for INNER, LEFT, RIGHT, and FULL joins
- exercise the no-PK companion table on every PostgreSQL SELECT correctness fuzz input, including duplicate, matching, and orphan rows
- retain SQLFaker unchanged because its PostgreSQL provider already supports joined-table grammar generation

## Verification

- `composer lint`
- `composer test:unit` (276 tests, 347 assertions)
- `vendor/bin/phpunit tests/Integration/PostgreSql` (77 tests, 255 assertions)
- PostgreSQL SELECT correctness fuzz: 100 runs

Fixes #66