### PR TITLE
test: prevent grouped DML subquery regressions

### DIFF
--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -282,6 +282,60 @@ final class MysqliCteShadowingTest extends TestCase
         }
     }
 
+    public function testGroupedSelfReferencingSubqueryRestrictsUpdate(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $definition = '(id INT PRIMARY KEY, name VARCHAR(50), dept_id INT, salary DECIMAL(10,2), active TINYINT DEFAULT 1)';
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` %s', $table, $definition));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $rows = "VALUES (1, 'Alice', 1, 120000, 1), (2, 'Bob', 1, 110000, 1), (3, 'Charlie', 2, 90000, 1), (4, 'Diana', 3, 95000, 1), (5, 'Eve', 1, 130000, 1)";
+            $ztdMysqli->query(sprintf('INSERT INTO `%s` %s', $table, $rows));
+
+            $ztdMysqli->query(sprintf('UPDATE `%1$s` SET active = 0 WHERE dept_id IN (SELECT dept_id FROM `%1$s` GROUP BY dept_id HAVING AVG(salary) > 100000)', $table));
+
+            $result = $ztdMysqli->query(sprintf('SELECT id, active FROM `%s` ORDER BY id', $table));
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([
+                ['id' => 1, 'active' => 0],
+                ['id' => 2, 'active' => 0],
+                ['id' => 3, 'active' => 1],
+                ['id' => 4, 'active' => 1],
+                ['id' => 5, 'active' => 0],
+            ], $result->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
+    public function testGroupedSelfReferencingSubqueryRestrictsDelete(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $definition = '(id INT PRIMARY KEY, customer_id INT, amount DECIMAL(10,2), status VARCHAR(20))';
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` %s', $table, $definition));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $rows = "VALUES (1, 1, 50, 'completed'), (2, 1, 75, 'completed'), (3, 1, 30, 'cancelled'), (4, 2, 200, 'completed'), (5, 3, 10, 'completed'), (6, 3, 15, 'completed')";
+            $ztdMysqli->query(sprintf('INSERT INTO `%s` %s', $table, $rows));
+
+            $ztdMysqli->query(sprintf("DELETE FROM `%1\$s` WHERE customer_id IN (SELECT customer_id FROM `%1\$s` WHERE status = 'cancelled' GROUP BY customer_id HAVING COUNT(*) >= 1)", $table));
+
+            $result = $ztdMysqli->query(sprintf('SELECT * FROM `%s` ORDER BY id', $table));
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([
+                ['id' => 4, 'customer_id' => 2, 'amount' => '200.00', 'status' => 'completed'],
+                ['id' => 5, 'customer_id' => 3, 'amount' => '10.00', 'status' => 'completed'],
+                ['id' => 6, 'customer_id' => 3, 'amount' => '15.00', 'status' => 'completed'],
+            ], $result->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testAutoIncrementUsesShadowCounterWithoutModifyingPhysicalTable(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaAwareSqlBuilder.php
@@ -143,7 +143,9 @@ final class PgSchemaAwareSqlBuilder
             ]);
         }
 
-        $whereClause = $this->buildPkWhere($schema);
+        $whereClause = $this->faker->boolean(25)
+            ? $this->buildGroupedSubqueryWhere($schema)
+            : $this->buildPkWhere($schema);
 
         return "UPDATE $table SET " . $this->quoteIdentifier($updateCol) . " = $newValue WHERE $whereClause";
     }
@@ -151,7 +153,9 @@ final class PgSchemaAwareSqlBuilder
     public function buildDelete(SchemaDefinition $schema): string
     {
         $table = $this->quoteIdentifier($schema->name);
-        $whereClause = $this->buildPkWhere($schema);
+        $whereClause = $this->faker->boolean(25)
+            ? $this->buildGroupedSubqueryWhere($schema)
+            : $this->buildPkWhere($schema);
 
         return "DELETE FROM $table WHERE $whereClause";
     }
@@ -164,6 +168,14 @@ final class PgSchemaAwareSqlBuilder
             $conditions[] = $this->quoteIdentifier($pk) . " = $literal";
         }
         return implode(' AND ', $conditions);
+    }
+
+    private function buildGroupedSubqueryWhere(SchemaDefinition $schema): string
+    {
+        $table = $this->quoteIdentifier($schema->name);
+        $key = $this->quoteIdentifier($schema->primaryKeys[0] ?? $schema->columns[0]);
+
+        return "$key IN (SELECT $key FROM $table GROUP BY $key HAVING COUNT(*) > 1)";
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaPool.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/PgSchemaPool.php
@@ -38,7 +38,9 @@ final class PgSchemaPool
             'text_types',
             'CREATE TABLE text_types (id SERIAL PRIMARY KEY, col_text TEXT, col_varchar VARCHAR(255), col_char CHAR(10))',
             ['id', 'col_text', 'col_varchar', 'col_char'],
-            ['id']
+            ['id'],
+            [],
+            ['col_char' => 'CHAR(10)'],
         );
 
         self::$schemas['boolean_type'] = new SchemaDefinition(

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/CreateTableAsCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/CreateTableAsCorrectnessTarget.php
@@ -93,15 +93,9 @@ final class CreateTableAsCorrectnessTarget
 
     private function compareQuery(string $query, string $createSql, int $seed, SchemaDefinition $schema): void
     {
-        $rawRows = $this->normalizeFixedCharacterRows(
-            $this->fetchAll($this->harness->getRawPdo(), $query),
-            $schema,
-        );
+        $rawRows = $this->fetchAll($this->harness->getRawPdo(), $query);
         try {
-            $ztdRows = $this->normalizeFixedCharacterRows(
-                $this->fetchAll($this->harness->getZtdPdo(), $query),
-                $schema,
-            );
+            $ztdRows = $this->fetchAll($this->harness->getZtdPdo(), $query);
         } catch (Throwable $exception) {
             throw new Error(
                 "ZTD CTAS query failed after native success\nSeed: $seed\nSQL: $createSql\nQuery: $query",
@@ -110,7 +104,7 @@ final class CreateTableAsCorrectnessTarget
             );
         }
 
-        if (!$this->comparator->compareRows($rawRows, $ztdRows, [], [], true)) {
+        if (!$this->comparator->compareRows($rawRows, $ztdRows, [], $schema->columnTypes, true)) {
             throw new Error(
                 "CTAS result mismatch\n"
                 . "Seed: $seed\n"
@@ -120,29 +114,6 @@ final class CreateTableAsCorrectnessTarget
                 . 'ZTD: ' . json_encode($ztdRows, JSON_THROW_ON_ERROR),
             );
         }
-    }
-
-    /**
-     * PostgreSQL pads CHAR values when reading a physical table, while the existing
-     * shadow source stores their semantically equivalent unpadded representation.
-     *
-     * @param array<int, array<string, mixed>> $rows
-     * @return array<int, array<string, mixed>>
-     */
-    private function normalizeFixedCharacterRows(array $rows, SchemaDefinition $schema): array
-    {
-        if ($schema->name !== 'text_types') {
-            return $rows;
-        }
-
-        foreach ($rows as $index => $row) {
-            $value = $row['col_char'] ?? null;
-            if (is_string($value)) {
-                $rows[$index]['col_char'] = rtrim($value, ' ');
-            }
-        }
-
-        return $rows;
     }
 
     /** @return array<int, array<string, mixed>> */

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/DeleteCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/DeleteCorrectnessTarget.php
@@ -55,10 +55,11 @@ final class DeleteCorrectnessTarget
 
             try {
                 $this->harness->getZtdPdo()->exec($sql);
-            } catch (UnsupportedSqlException | UnknownSchemaException) {
-                return;
-            } catch (DatabaseException | PDOException) {
-                return;
+            } catch (UnsupportedSqlException | UnknownSchemaException | DatabaseException | PDOException $e) {
+                if ($rawError !== null) {
+                    return;
+                }
+                throw new Error("ZTD DELETE failed after native success\nSeed: $seed\nSQL: $sql", 0, $e);
             }
 
             if ($rawError !== null) {
@@ -80,7 +81,7 @@ final class DeleteCorrectnessTarget
         /** @var array<int, array<string, mixed>> $ztdRows */
         $ztdRows = $stmt !== false ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
 
-        if (!$this->comparator->compareRows($rawRows, $ztdRows, $schema->primaryKeys)) {
+        if (!$this->comparator->compareRows($rawRows, $ztdRows, $schema->primaryKeys, $schema->columnTypes)) {
             throw new Error(
                 "DELETE table state mismatch\n" .
                 "Seed: $seed\n" .

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/InsertCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/InsertCorrectnessTarget.php
@@ -80,7 +80,7 @@ final class InsertCorrectnessTarget
         /** @var array<int, array<string, mixed>> $ztdRows */
         $ztdRows = $stmt !== false ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
 
-        if (!$this->comparator->compareRows($rawRows, $ztdRows, $schema->primaryKeys)) {
+        if (!$this->comparator->compareRows($rawRows, $ztdRows, $schema->primaryKeys, $schema->columnTypes)) {
             throw new Error(
                 "INSERT table state mismatch\n" .
                 "Seed: $seed\n" .

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/SelectCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/SelectCorrectnessTarget.php
@@ -120,7 +120,7 @@ final class SelectCorrectnessTarget
             /** @var array<int, array<string, mixed>> $rawResult */
             /** @var array<int, array<string, mixed>> $ztdResult */
             $hasOrderBy = stripos($sql, 'ORDER BY') !== false;
-            if (!$this->comparator->compareRows($rawResult, $ztdResult, $schema->primaryKeys, [], !$hasOrderBy)) {
+            if (!$this->comparator->compareRows($rawResult, $ztdResult, $schema->primaryKeys, $schema->columnTypes, !$hasOrderBy)) {
                 throw new Error(
                     "SELECT result mismatch\n" .
                     "Seed: $seed\n" .

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/UpdateCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Postgres/Target/UpdateCorrectnessTarget.php
@@ -55,10 +55,11 @@ final class UpdateCorrectnessTarget
 
             try {
                 $this->harness->getZtdPdo()->exec($sql);
-            } catch (UnsupportedSqlException | UnknownSchemaException) {
-                return;
-            } catch (DatabaseException | PDOException) {
-                return;
+            } catch (UnsupportedSqlException | UnknownSchemaException | DatabaseException | PDOException $e) {
+                if ($rawError !== null) {
+                    return;
+                }
+                throw new Error("ZTD UPDATE failed after native success\nSeed: $seed\nSQL: $sql", 0, $e);
             }
 
             if ($rawError !== null) {
@@ -80,7 +81,7 @@ final class UpdateCorrectnessTarget
         /** @var array<int, array<string, mixed>> $ztdRows */
         $ztdRows = $stmt !== false ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
 
-        if (!$this->comparator->compareRows($rawRows, $ztdRows, $schema->primaryKeys)) {
+        if (!$this->comparator->compareRows($rawRows, $ztdRows, $schema->primaryKeys, $schema->columnTypes)) {
             throw new Error(
                 "UPDATE table state mismatch\n" .
                 "Seed: $seed\n" .

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/ResultComparator.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/ResultComparator.php
@@ -99,6 +99,10 @@ final class ResultComparator
             return $this->compareSet($expectedStr, $actualStr);
         }
 
+        if (str_starts_with($type, 'CHAR')) {
+            return rtrim($expectedStr, ' ') === rtrim($actualStr, ' ');
+        }
+
         return $expectedStr === $actualStr;
     }
 

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/SchemaAwareSqlBuilder.php
@@ -109,7 +109,9 @@ final class SchemaAwareSqlBuilder
             ? "''"
             : $this->generateLiteral($updateCol, $schema);
 
-        $whereClause = $this->buildPkWhere($schema);
+        $whereClause = $this->faker->boolean(25)
+            ? $this->buildGroupedSubqueryWhere($schema)
+            : $this->buildPkWhere($schema);
 
         return "UPDATE `$table` SET `$updateCol` = $newValue WHERE $whereClause";
     }
@@ -117,7 +119,9 @@ final class SchemaAwareSqlBuilder
     public function buildDelete(SchemaDefinition $schema): string
     {
         $table = $schema->name;
-        $whereClause = $this->buildPkWhere($schema);
+        $whereClause = $this->faker->boolean(25)
+            ? $this->buildGroupedSubqueryWhere($schema)
+            : $this->buildPkWhere($schema);
 
         return "DELETE FROM `$table` WHERE $whereClause";
     }
@@ -130,6 +134,15 @@ final class SchemaAwareSqlBuilder
             $conditions[] = "`$pk` = $literal";
         }
         return implode(' AND ', $conditions);
+    }
+
+    private function buildGroupedSubqueryWhere(SchemaDefinition $schema): string
+    {
+        $table = $schema->name;
+        $key = $schema->primaryKeys[0] ?? $schema->columns[0];
+
+        return "`$key` IN (SELECT `_ztd_grouped`.`$key` FROM "
+            . "(SELECT `$key` FROM `$table` GROUP BY `$key` HAVING COUNT(*) > 1) AS `_ztd_grouped`)";
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/SchemaDefinition.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/SchemaDefinition.php
@@ -15,10 +15,14 @@ final class SchemaDefinition
     /** @var array<int, string> */
     public readonly array $defaultColumns;
 
+    /** @var array<string, string> */
+    public readonly array $columnTypes;
+
     /**
      * @param array<int, string> $columns
      * @param array<int, string> $primaryKeys
      * @param array<int, string> $defaultColumns
+     * @param array<string, string> $columnTypes
      */
     public function __construct(
         public readonly string $name,
@@ -26,9 +30,11 @@ final class SchemaDefinition
         array $columns,
         array $primaryKeys,
         array $defaultColumns = [],
+        array $columnTypes = [],
     ) {
         $this->columns = $columns;
         $this->primaryKeys = $primaryKeys;
         $this->defaultColumns = $defaultColumns;
+        $this->columnTypes = $columnTypes;
     }
 }

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Sqlite/SqliteSchemaAwareSqlBuilder.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Sqlite/SqliteSchemaAwareSqlBuilder.php
@@ -99,8 +99,11 @@ final class SqliteSchemaAwareSqlBuilder
         $updateCol = $this->faker->randomElement($nonPkCols);
         $newValue = $this->generateLiteral($updateCol);
 
-        $alias = $this->faker->boolean(35) ? '_ztd_target' : null;
-        $whereClause = $this->buildPkWhere($schema, $alias);
+        $groupedSubquery = $this->faker->boolean(25);
+        $alias = !$groupedSubquery && $this->faker->boolean(35) ? '_ztd_target' : null;
+        $whereClause = $groupedSubquery
+            ? $this->buildGroupedSubqueryWhere($schema)
+            : $this->buildPkWhere($schema, $alias);
         $target = $alias === null ? $table : "$table AS " . $this->quoteIdentifier($alias);
 
         return "UPDATE $target SET " . $this->quoteIdentifier($updateCol) . " = $newValue WHERE $whereClause";
@@ -109,7 +112,9 @@ final class SqliteSchemaAwareSqlBuilder
     public function buildDelete(SchemaDefinition $schema): string
     {
         $table = $this->quoteIdentifier($schema->name);
-        $whereClause = $this->buildPkWhere($schema);
+        $whereClause = $this->faker->boolean(25)
+            ? $this->buildGroupedSubqueryWhere($schema)
+            : $this->buildPkWhere($schema);
 
         return "DELETE FROM $table WHERE $whereClause";
     }
@@ -126,6 +131,14 @@ final class SqliteSchemaAwareSqlBuilder
             $conditions[] = $column . " = $literal";
         }
         return implode(' AND ', $conditions);
+    }
+
+    private function buildGroupedSubqueryWhere(SchemaDefinition $schema): string
+    {
+        $table = $this->quoteIdentifier($schema->name);
+        $key = $this->quoteIdentifier($schema->primaryKeys[0] ?? $schema->columns[0]);
+
+        return "$key IN (SELECT $key FROM $table GROUP BY $key HAVING COUNT(*) > 1)";
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Sqlite/Target/DeleteCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Sqlite/Target/DeleteCorrectnessTarget.php
@@ -55,10 +55,11 @@ final class DeleteCorrectnessTarget
 
             try {
                 $this->harness->getZtdPdo()->exec($sql);
-            } catch (UnsupportedSqlException | UnknownSchemaException) {
-                return;
-            } catch (DatabaseException | PDOException) {
-                return;
+            } catch (UnsupportedSqlException | UnknownSchemaException | DatabaseException | PDOException $e) {
+                if ($rawError !== null) {
+                    return;
+                }
+                throw new Error("ZTD DELETE failed after native success\nSeed: $seed\nSQL: $sql", 0, $e);
             }
 
             if ($rawError !== null) {

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Target/DeleteCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Target/DeleteCorrectnessTarget.php
@@ -54,10 +54,11 @@ final class DeleteCorrectnessTarget
 
             try {
                 $this->harness->getZtdPdo()->exec($sql);
-            } catch (UnsupportedSqlException | UnknownSchemaException) {
-                return;
-            } catch (DatabaseException | PDOException) {
-                return;
+            } catch (UnsupportedSqlException | UnknownSchemaException | DatabaseException | PDOException $e) {
+                if ($rawError !== null) {
+                    return;
+                }
+                throw new Error("ZTD DELETE failed after native success\nSeed: $seed\nSQL: $sql", 0, $e);
             }
 
             if ($rawError !== null) {

--- a/packages/ztd-query-pdo-adapter/fuzz/Correctness/Target/UpdateCorrectnessTarget.php
+++ b/packages/ztd-query-pdo-adapter/fuzz/Correctness/Target/UpdateCorrectnessTarget.php
@@ -54,10 +54,11 @@ final class UpdateCorrectnessTarget
 
             try {
                 $this->harness->getZtdPdo()->exec($sql);
-            } catch (UnsupportedSqlException | UnknownSchemaException) {
-                return;
-            } catch (DatabaseException | PDOException) {
-                return;
+            } catch (UnsupportedSqlException | UnknownSchemaException | DatabaseException | PDOException $e) {
+                if ($rawError !== null) {
+                    return;
+                }
+                throw new Error("ZTD UPDATE failed after native success\nSeed: $seed\nSQL: $sql", 0, $e);
             }
 
             if ($rawError !== null) {

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/UpdateBasicTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/UpdateBasicTest.php
@@ -154,4 +154,32 @@ final class UpdateBasicTest extends TestCase
             $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
         }
     }
+
+    public function testUpdateWithGroupedInSubquery(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $users = 'prefix_' . bin2hex(random_bytes(8));
+        $orders = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$users} (id INTEGER PRIMARY KEY, name TEXT, tier TEXT)");
+            $rawPdo->exec("CREATE TABLE {$orders} (id INTEGER PRIMARY KEY, user_id INTEGER, total NUMERIC, status TEXT)");
+            $rawPdo->exec("INSERT INTO {$users} VALUES (1, 'Alice', 'standard'), (2, 'Bob', 'standard')");
+            $rawPdo->exec("INSERT INTO {$orders} VALUES (1, 1, 500, 'completed'), (2, 1, 300, 'completed'), (3, 2, 100, 'completed')");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO {$users} VALUES (1, 'Alice', 'standard'), (2, 'Bob', 'standard')");
+            $ztdPdo->exec("INSERT INTO {$orders} VALUES (1, 1, 500, 'completed'), (2, 1, 300, 'completed'), (3, 2, 100, 'completed')");
+
+            $sql = "UPDATE {$users} SET tier = 'premium' WHERE id IN (SELECT user_id FROM {$orders} WHERE status = 'completed' GROUP BY user_id HAVING SUM(total) > 400)";
+            self::assertSame($rawPdo->exec($sql), $ztdPdo->exec($sql));
+
+            $raw = $rawPdo->query("SELECT * FROM {$users} ORDER BY id");
+            $shadow = $ztdPdo->query("SELECT * FROM {$users} ORDER BY id");
+            self::assertNotFalse($raw);
+            self::assertNotFalse($shadow);
+            self::assertSame($raw->fetchAll(), $shadow->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/DeleteBasicTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/DeleteBasicTest.php
@@ -117,4 +117,28 @@ final class DeleteBasicTest extends TestCase
 
         self::assertSame($rawRows, $ztdRows);
     }
+
+    public function testDeleteWithGroupedInSubquery(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $rawPdo->exec('CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT)');
+        $rawPdo->exec('CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER, amount REAL, status TEXT)');
+        $rawPdo->exec("INSERT INTO customers VALUES (1, 'Alice'), (2, 'Bob')");
+        $rawPdo->exec("INSERT INTO orders VALUES (1, 1, 50, 'completed'), (2, 1, 75, 'completed'), (3, 2, 10, 'completed')");
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO customers VALUES (1, 'Alice'), (2, 'Bob')");
+        $ztdPdo->exec("INSERT INTO orders VALUES (1, 1, 50, 'completed'), (2, 1, 75, 'completed'), (3, 2, 10, 'completed')");
+
+        $sql = "DELETE FROM customers WHERE id IN (SELECT customer_id FROM orders WHERE status = 'completed' GROUP BY customer_id HAVING SUM(amount) < 50)";
+        self::assertSame($rawPdo->exec($sql), $ztdPdo->exec($sql));
+
+        $raw = $rawPdo->query('SELECT * FROM customers ORDER BY id');
+        $shadow = $ztdPdo->query('SELECT * FROM customers ORDER BY id');
+        self::assertNotFalse($raw);
+        self::assertNotFalse($shadow);
+        self::assertSame($raw->fetchAll(), $shadow->fetchAll());
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateBasicTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/UpdateBasicTest.php
@@ -97,4 +97,25 @@ final class UpdateBasicTest extends TestCase
         self::assertNotFalse($statement);
         self::assertSame([], $statement->fetchAll());
     }
+
+    public function testUpdateWithGroupedInSubquery(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:', null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION, \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC]);
+        $rawPdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, tier TEXT)');
+        $rawPdo->exec('CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total REAL, status TEXT)');
+        $rawPdo->exec("INSERT INTO users VALUES (1, 'Alice', 'standard'), (2, 'Bob', 'standard')");
+        $rawPdo->exec("INSERT INTO orders VALUES (1, 1, 500, 'completed'), (2, 1, 300, 'completed'), (3, 2, 100, 'completed')");
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec("INSERT INTO users VALUES (1, 'Alice', 'standard'), (2, 'Bob', 'standard')");
+        $ztdPdo->exec("INSERT INTO orders VALUES (1, 1, 500, 'completed'), (2, 1, 300, 'completed'), (3, 2, 100, 'completed')");
+
+        $sql = "UPDATE users SET tier = 'premium' WHERE id IN (SELECT user_id FROM orders WHERE status = 'completed' GROUP BY user_id HAVING SUM(total) > 400)";
+        self::assertSame($rawPdo->exec($sql), $ztdPdo->exec($sql));
+
+        $raw = $rawPdo->query('SELECT * FROM users ORDER BY id');
+        $shadow = $ztdPdo->query('SELECT * FROM users ORDER BY id');
+        self::assertNotFalse($raw);
+        self::assertNotFalse($shadow);
+        self::assertSame($raw->fetchAll(), $shadow->fetchAll());
+    }
 }


### PR DESCRIPTION
## Root problem

Schema-aware UPDATE/DELETE correctness fuzzing generated only simple primary-key predicates. It never exercised `IN (SELECT ... GROUP BY ... HAVING ...)`, and most DML targets also discarded ZTD exceptions even when the native database accepted the SQL. The reported executions now succeed on the current stack, but the shared regression gap covered all four issues.

## Changes

- add exact SQLite UPDATE/DELETE, PostgreSQL UPDATE, and MySQL self-referencing UPDATE/DELETE regressions
- generate grouped IN-subquery predicates for MySQL, PostgreSQL, and SQLite UPDATE/DELETE fuzzing
- fail correctness fuzzing when native execution succeeds but ZTD rejects the same DML
- carry comparison type metadata and compare PostgreSQL fixed-length CHAR padding semantically, replacing the CTAS-only special case
- leave SQLFaker unchanged because its dialect grammars already generate GROUP BY and HAVING clauses

## Verification

- PDO adapter lint and PHPStan
- PDO unit: 276 tests, 347 assertions
- PDO integration suite
- MySQLi adapter lint and full test suite
- exact grouped-subquery integration regressions on all three platforms
- six grouped-subquery fuzz seeds via `run-single`
- UPDATE/DELETE correctness fuzz across MySQL, PostgreSQL, and SQLite: 300 runs per target

Fixes #9
Fixes #11
Fixes #58
Fixes #59