### PR TITLE
fix(pg): apply every multi-table TRUNCATE target

### DIFF
--- a/packages/ztd-query-core/src/Shadow/Mutation/MultiTruncateMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MultiTruncateMutation.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+use ZtdQuery\Shadow\ShadowStore;
+
+/**
+ * Applies a single TRUNCATE statement to every target shadow table.
+ */
+final class MultiTruncateMutation implements ShadowMutation
+{
+    /** @param list<string> $tableNames */
+    public function __construct(
+        private readonly array $tableNames,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function apply(ShadowStore $store, array $rows): void
+    {
+        foreach ($this->tableNames as $tableName) {
+            $store->set($tableName, []);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tableName(): string
+    {
+        return $this->tableNames[0] ?? '';
+    }
+
+    /** @return list<string> */
+    public function tableNames(): array
+    {
+        return $this->tableNames;
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MultiTruncateMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MultiTruncateMutationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
+use ZtdQuery\Shadow\ShadowStore;
+
+#[UsesClass(ShadowStore::class)]
+#[CoversClass(MultiTruncateMutation::class)]
+final class MultiTruncateMutationTest extends TestCase
+{
+    public function testApplyClearsEveryTargetTable(): void
+    {
+        $store = new ShadowStore();
+        $store->set('alpha', [['id' => 1]]);
+        $store->set('beta', [['id' => 2]]);
+        $store->set('untouched', [['id' => 3]]);
+
+        $mutation = new MultiTruncateMutation(['alpha', 'beta']);
+        $mutation->apply($store, [['id' => 99]]);
+
+        self::assertSame([], $store->get('alpha'));
+        self::assertSame([], $store->get('beta'));
+        self::assertSame([['id' => 3]], $store->get('untouched'));
+    }
+
+    public function testTableAccessorsPreserveStatementOrder(): void
+    {
+        $mutation = new MultiTruncateMutation(['alpha', 'beta']);
+
+        self::assertSame('alpha', $mutation->tableName());
+        self::assertSame(['alpha', 'beta'], $mutation->tableNames());
+    }
+
+    public function testEmptyTargetsHaveEmptyPrimaryTable(): void
+    {
+        $mutation = new MultiTruncateMutation([]);
+
+        self::assertSame('', $mutation->tableName());
+        self::assertSame([], $mutation->tableNames());
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/TruncateTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/TruncateTest.php
@@ -108,4 +108,37 @@ final class TruncateTest extends TestCase
             $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
         }
     }
+
+    public function testTruncateMultipleTables(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $alpha = 'prefix_' . bin2hex(random_bytes(8));
+        $beta = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE {$alpha} (id INTEGER PRIMARY KEY, name TEXT)");
+            $rawPdo->exec("CREATE TABLE {$beta} (id INTEGER PRIMARY KEY, name TEXT)");
+            $rawPdo->exec("INSERT INTO {$alpha} VALUES (1, 'alpha')");
+            $rawPdo->exec("INSERT INTO {$beta} VALUES (2, 'beta')");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO {$alpha} VALUES (1, 'alpha')");
+            $ztdPdo->exec("INSERT INTO {$beta} VALUES (2, 'beta')");
+
+            $rawPdo->exec("TRUNCATE TABLE {$alpha}, {$beta}");
+            $ztdPdo->exec("TRUNCATE TABLE {$alpha}, {$beta}");
+
+            $rawAlpha = $rawPdo->query("SELECT * FROM {$alpha}");
+            $rawBeta = $rawPdo->query("SELECT * FROM {$beta}");
+            $shadowAlpha = $ztdPdo->query("SELECT * FROM {$alpha}");
+            $shadowBeta = $ztdPdo->query("SELECT * FROM {$beta}");
+            self::assertNotFalse($rawAlpha);
+            self::assertNotFalse($rawBeta);
+            self::assertNotFalse($shadowAlpha);
+            self::assertNotFalse($shadowBeta);
+            self::assertSame($rawAlpha->fetchAll(), $shadowAlpha->fetchAll());
+            self::assertSame($rawBeta->fetchAll(), $shadowBeta->fetchAll());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
 }

--- a/packages/ztd-query-postgres/fuzz/Robustness/Invariant/TruncateTargetConsistencyChecker.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Invariant/TruncateTargetConsistencyChecker.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fuzz\Robustness\Invariant;
+
+use Throwable;
+use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class TruncateTargetConsistencyChecker implements InvariantChecker
+{
+    public function __construct(
+        private readonly SqlRewriter $rewriter,
+    ) {
+    }
+
+    public function check(string $sql): ?InvariantViolation
+    {
+        $expectedCount = $this->targetCount($sql);
+        if ($expectedCount === null || $expectedCount < 2) {
+            return null;
+        }
+
+        try {
+            $mutation = $this->rewriter->rewrite($sql)->mutation();
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (!$mutation instanceof MultiTruncateMutation) {
+            return new InvariantViolation(
+                'PG-TRUNCATE-TARGETS',
+                'multi-table TRUNCATE did not produce a multi-target mutation',
+                $sql,
+                ['expected_targets' => $expectedCount],
+            );
+        }
+
+        $actualCount = count($mutation->tableNames());
+        if ($actualCount !== $expectedCount) {
+            return new InvariantViolation(
+                'PG-TRUNCATE-TARGETS',
+                'TRUNCATE mutation target count differs from the SQL target list',
+                $sql,
+                ['expected_targets' => $expectedCount, 'actual_targets' => $actualCount],
+            );
+        }
+
+        return null;
+    }
+
+    private function targetCount(string $sql): ?int
+    {
+        $stream = SqlTokenStream::tokenize($sql);
+        if ($stream->firstTopLevelKeyword() !== 'TRUNCATE') {
+            return null;
+        }
+
+        $targetList = $stream->topLevelClause(
+            ['TRUNCATE'],
+            [['RESTART', 'IDENTITY'], ['CONTINUE', 'IDENTITY'], ['CASCADE'], ['RESTRICT']],
+        );
+        if ($targetList === null || $targetList === '') {
+            return 0;
+        }
+
+        return count(SqlTokenStream::tokenize($targetList)->splitTopLevel());
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -11,6 +11,7 @@ use Fuzz\Robustness\Invariant\ClassifyRewriteAgreementChecker;
 use Fuzz\Robustness\Invariant\InvariantChecker;
 use Fuzz\Robustness\Invariant\RewriteExceptionTypeChecker;
 use Fuzz\Robustness\Invariant\RewritePlanConsistencyChecker;
+use Fuzz\Robustness\Invariant\TruncateTargetConsistencyChecker;
 use SqlFaker\PostgreSqlProvider;
 use ZtdQuery\Platform\Postgres\PgSqlMutationResolver;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
@@ -60,6 +61,7 @@ final class RewriteTarget
             new RewriteExceptionTypeChecker($rewriter),
             new RewritePlanConsistencyChecker($rewriter),
             new ClassifyRewriteAgreementChecker($guard, $rewriter),
+            new TruncateTargetConsistencyChecker($rewriter),
         ];
     }
 
@@ -131,6 +133,7 @@ final class RewriteTarget
             fn (): string => $this->provider->createTableStatement(maxDepth: 5),
             fn (): string => $this->provider->alterTableStatement(maxDepth: 5),
             fn (): string => $this->provider->dropTableStatement(maxDepth: 3),
+            fn (): string => $this->provider->truncateStatement(maxDepth: 8),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -15,6 +15,7 @@ use ZtdQuery\Shadow\Mutation\CreateTableMutation;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\DropTableMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
 use ZtdQuery\Shadow\Mutation\ShadowMutation;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
@@ -152,12 +153,15 @@ final class PgSqlMutationResolver
 
     private function resolveTruncate(string $sql): ShadowMutation
     {
-        $tableName = $this->parser->extractTruncateTable($sql);
-        if ($tableName === null) {
+        $tableNames = $this->parser->extractTruncateTables($sql);
+        if ($tableNames === []) {
             throw new UnsupportedSqlException($sql, 'Cannot resolve TRUNCATE target');
         }
+        if (count($tableNames) > 1) {
+            return new MultiTruncateMutation($tableNames);
+        }
 
-        return new TruncateMutation($tableName);
+        return new TruncateMutation($tableNames[0]);
     }
 
     private function resolveCreateTable(string $sql): ShadowMutation

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Platform\Postgres;
 
+use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
 /**
@@ -314,12 +315,74 @@ final class PgSqlParser
      */
     public function extractTruncateTable(string $sql): ?string
     {
-        $sql = $this->maskComments($sql);
-        if (preg_match('/TRUNCATE\s+(?:TABLE\s+)?(?:ONLY\s+)?("[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)/i', $sql, $m) === 1) {
-            return $this->unquoteIdentifier($this->stripSchemaPrefix($m[1]));
+        return $this->extractTruncateTables($sql)[0] ?? null;
+    }
+
+    /** @return list<string> */
+    public function extractTruncateTables(string $sql): array
+    {
+        $stream = SqlTokenStream::tokenize($sql);
+        $tokens = $stream->significantTokens();
+        if (!(($tokens[0] ?? null)?->isKeyword('TRUNCATE') ?? false)) {
+            return [];
         }
 
-        return null;
+        $index = 1;
+        if (($tokens[$index] ?? null)?->isKeyword('TABLE') ?? false) {
+            $index++;
+        }
+
+        $tableNames = [];
+        while (isset($tokens[$index])) {
+            if ($tokens[$index]->isKeyword('ONLY')) {
+                $index++;
+            }
+
+            $identifier = $this->truncateIdentifierAt($stream, $index);
+            if ($identifier === null) {
+                break;
+            }
+            $tableName = $identifier['name'];
+            $index = $identifier['next'];
+
+            while (($tokens[$index] ?? null)?->text === '.') {
+                $identifier = $this->truncateIdentifierAt($stream, $index + 1);
+                if ($identifier === null) {
+                    break 2;
+                }
+                $tableName = $identifier['name'];
+                $index = $identifier['next'];
+            }
+
+            if (($tokens[$index] ?? null)?->text === '*') {
+                $index++;
+            }
+            $tableNames[] = $tableName;
+
+            if (($tokens[$index] ?? null)?->text !== ',') {
+                break;
+            }
+            $index++;
+        }
+
+        return $tableNames;
+    }
+
+    /** @return array{name: string, next: int}|null */
+    private function truncateIdentifierAt(SqlTokenStream $stream, int $index): ?array
+    {
+        $tokens = $stream->significantTokens();
+        if ((($tokens[$index] ?? null)?->isKeyword('U') ?? false)
+            && ($tokens[$index + 1] ?? null)?->text === '&'
+            && ($tokens[$index + 2] ?? null)?->kind === SqlTokenKind::QuotedIdentifier
+        ) {
+            return [
+                'name' => $this->unquoteIdentifier($tokens[$index + 2]->text),
+                'next' => $index + 3,
+            ];
+        }
+
+        return $stream->identifierAt($index);
     }
 
     /**

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -323,12 +323,13 @@ final class PgSqlParser
     {
         $stream = SqlTokenStream::tokenize($sql);
         $tokens = $stream->significantTokens();
-        if (!(($tokens[0] ?? null)?->isKeyword('TRUNCATE') ?? false)) {
+        if ($stream->firstTopLevelKeyword() !== 'TRUNCATE') {
             return [];
         }
 
         $index = 1;
-        if (($tokens[$index] ?? null)?->isKeyword('TABLE') ?? false) {
+        $tableKeyword = $tokens[$index] ?? null;
+        if ($tableKeyword !== null && $tableKeyword->isKeyword('TABLE')) {
             $index++;
         }
 
@@ -372,14 +373,23 @@ final class PgSqlParser
     private function truncateIdentifierAt(SqlTokenStream $stream, int $index): ?array
     {
         $tokens = $stream->significantTokens();
-        if ((($tokens[$index] ?? null)?->isKeyword('U') ?? false)
-            && ($tokens[$index + 1] ?? null)?->text === '&'
-            && ($tokens[$index + 2] ?? null)?->kind === SqlTokenKind::QuotedIdentifier
-        ) {
-            return [
-                'name' => $this->unquoteIdentifier($tokens[$index + 2]->text),
-                'next' => $index + 3,
-            ];
+        $prefix = $tokens[$index] ?? null;
+        if ($prefix === null) {
+            return null;
+        }
+        if ($prefix->isKeyword('U')) {
+            $ampersand = $tokens[$index + 1] ?? null;
+            if ($ampersand !== null && $ampersand->text === '&') {
+                $quotedIdentifier = $tokens[$index + 2] ?? null;
+                if ($quotedIdentifier === null || $quotedIdentifier->kind !== SqlTokenKind::QuotedIdentifier) {
+                    return null;
+                }
+
+                return [
+                    'name' => $this->unquoteIdentifier($quotedIdentifier->text),
+                    'next' => $index + 3,
+                ];
+            }
         }
 
         return $stream->identifierAt($index);

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -19,6 +19,7 @@ use ZtdQuery\Shadow\Mutation\CreateTableMutation;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\DropTableMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
@@ -317,6 +318,25 @@ final class PgSqlMutationResolverTest extends TestCase
         );
 
         self::assertInstanceOf(TruncateMutation::class, $mutation);
+    }
+
+    public function testResolveMultiTableTruncateReturnsMultiTruncateMutation(): void
+    {
+        $resolver = new PgSqlMutationResolver(
+            new ShadowStore(),
+            new TableDefinitionRegistry(),
+            new PgSqlSchemaParser(),
+            new PgSqlParser(),
+        );
+
+        $mutation = $resolver->resolve(
+            'TRUNCATE TABLE alpha, beta RESTART IDENTITY',
+            'TRUNCATE',
+            QueryKind::WRITE_SIMULATED,
+        );
+
+        self::assertInstanceOf(MultiTruncateMutation::class, $mutation);
+        self::assertSame(['alpha', 'beta'], $mutation->tableNames());
     }
 
     public function testResolveTruncateWithoutTableThrows(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -264,6 +264,28 @@ SELECT * FROM users'));
         self::assertSame('users', $parser->extractTruncateTable('TRUNCATE TABLE users CASCADE'));
     }
 
+    public function testExtractTruncateTablesPreservesEveryTarget(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertSame(
+            ['Alpha', 'beta', 'gamma'],
+            $parser->extractTruncateTables(
+                'TRUNCATE TABLE ONLY public."Alpha" *, /* next */ ONLY beta, gamma RESTART IDENTITY CASCADE',
+            ),
+        );
+    }
+
+    public function testExtractTruncateTablesSupportsUnicodeQuotedIdentifiers(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertSame(
+            ['select', 'second', 'third'],
+            $parser->extractTruncateTables('TRUNCATE TABLE U&"select", public.U&"second", "third"'),
+        );
+    }
+
     public function testExtractCreateTableName(): void
     {
         $parser = new PgSqlParser();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -286,6 +286,17 @@ SELECT * FROM users'));
         );
     }
 
+    public function testExtractTruncateTablesRejectsNonTruncateAndIncompleteTargets(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertSame([], $parser->extractTruncateTables('SELECT users'));
+        self::assertSame([], $parser->extractTruncateTables('TRUNCATE TABLE'));
+        self::assertSame(['u'], $parser->extractTruncateTables('TRUNCATE u'));
+        self::assertSame([], $parser->extractTruncateTables('TRUNCATE TABLE U&'));
+        self::assertSame([], $parser->extractTruncateTables('TRUNCATE TABLE U&users'));
+    }
+
     public function testExtractCreateTableName(): void
     {
         $parser = new PgSqlParser();


### PR DESCRIPTION
Stacked on #241.

## Problem
PostgreSQL accepts multiple relations in one TRUNCATE statement, but the parser and mutation resolver retained only the first target. The shadow state therefore diverged from PostgreSQL for all remaining tables.

## Fix
- parse every top-level TRUNCATE target with token-stream structure, including ONLY, schema qualification, inheritance markers, comments, and Unicode-quoted identifiers
- represent the statement as a multi-target truncate mutation that clears every shadow table
- add unit and PostgreSQL integration regressions
- add a SQLFaker-backed rewrite generator and invariant that compares SQL target count with mutation target count

## Verification
- core unit + lint/PHPStan
- PostgreSQL unit + fuzz tests + lint/PHPStan
- PostgreSQL TRUNCATE integration tests
- 1,000-run rewrite Fuzz plus saved crash replay
- core and PostgreSQL Infection thresholds

Fixes #29