### PR TITLE
refactor(sql-faker): control empty rows through generation plans

### DIFF
--- a/packages/sql-faker/fuzz/Target/MySqlSyntaxTarget.php
+++ b/packages/sql-faker/fuzz/Target/MySqlSyntaxTarget.php
@@ -53,7 +53,7 @@ final class MySqlSyntaxTarget
         $seed = $this->inputToSeed($input);
         $this->faker->seed($seed);
 
-        $sql = $this->provider->sql(maxDepth: $this->maxDepth);
+        $sql = $this->provider->sqlWithoutEmptyRows(maxDepth: $this->maxDepth);
 
         $this->validateSyntax($sql, $seed);
     }
@@ -123,8 +123,8 @@ final class MySqlSyntaxTarget
                 3709 => true,
                 // SQLSTATE[HY000]: General error: 1525 Incorrect nth factor value
                 1525 => true,
-                // SQLSTATE[42000]: Syntax error or access violation: 3942 VALUES clause must have at least one column
-                3942 => true,
+                // SQLSTATE[42000]: Error 3942 identifies an empty table value constructor
+                3942 => false,
                 // SQLSTATE[42S02]: Base table or view not found: 1051
                 1051 => true,
                 // SQLSTATE[42000]: Syntax error or access violation: 3980 Invalid json attribute

--- a/packages/sql-faker/src/Grammar/GenerationPlan.php
+++ b/packages/sql-faker/src/Grammar/GenerationPlan.php
@@ -11,11 +11,13 @@ final class GenerationPlan
 {
     /**
      * @param array<string, non-empty-list<ProductionPattern>> $patterns
+     * @param array<string, ProductionPattern> $patternsForEveryOccurrence
      * @param TRequiresNonEmpty $requiresNonEmpty
      */
     private function __construct(
         private readonly ?string $startRule,
         private readonly array $patterns,
+        private readonly array $patternsForEveryOccurrence,
         private readonly bool $requiresNonEmpty,
         private readonly int $maxDepth,
     ) {
@@ -24,7 +26,7 @@ final class GenerationPlan
     /** @return self<false> */
     public static function all(): self
     {
-        return new self(null, [], false, PHP_INT_MAX);
+        return new self(null, [], [], false, PHP_INT_MAX);
     }
 
     /** @return self<false> */
@@ -32,7 +34,7 @@ final class GenerationPlan
     {
         self::assertStartRule($startRule);
 
-        return new self($startRule, [], false, PHP_INT_MAX);
+        return new self($startRule, [], [], false, PHP_INT_MAX);
     }
 
     /**
@@ -46,19 +48,31 @@ final class GenerationPlan
             throw new InvalidArgumentException('A constrained generation plan requires production patterns.');
         }
 
-        return new self($startRule, $patterns, false, PHP_INT_MAX);
+        return new self($startRule, $patterns, [], false, PHP_INT_MAX);
     }
 
     /** @return self<true> */
     public function requiringNonEmpty(): self
     {
-        return new self($this->startRule, $this->patterns, true, $this->maxDepth);
+        return new self(
+            $this->startRule,
+            $this->patterns,
+            $this->patternsForEveryOccurrence,
+            true,
+            $this->maxDepth,
+        );
     }
 
     /** @return self<TRequiresNonEmpty> */
     public function withMaxDepth(int $maxDepth): self
     {
-        return new self($this->startRule, $this->patterns, $this->requiresNonEmpty, max(1, $maxDepth));
+        return new self(
+            $this->startRule,
+            $this->patterns,
+            $this->patternsForEveryOccurrence,
+            $this->requiresNonEmpty,
+            max(1, $maxDepth),
+        );
     }
 
     public function startRule(): ?string
@@ -68,7 +82,23 @@ final class GenerationPlan
 
     public function patternAt(string $rule, int $occurrence): ?ProductionPattern
     {
-        return $this->patterns[$rule][$occurrence] ?? null;
+        return $this->patterns[$rule][$occurrence] ?? $this->patternsForEveryOccurrence[$rule] ?? null;
+    }
+
+    /** @return self<TRequiresNonEmpty> */
+    public function withPatternForEveryOccurrence(string $rule, ProductionPattern $pattern): self
+    {
+        if ($rule === '') {
+            throw new InvalidArgumentException('A generation plan rule must not be empty.');
+        }
+
+        return new self(
+            $this->startRule,
+            $this->patterns,
+            [...$this->patternsForEveryOccurrence, $rule => $pattern],
+            $this->requiresNonEmpty,
+            $this->maxDepth,
+        );
     }
 
     /** @return TRequiresNonEmpty */

--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -10,6 +10,18 @@ use SqlFaker\Grammar\ProductionPattern;
 final class GenerationPlans
 {
     /** @return GenerationPlan<true> */
+    public static function withoutEmptyRows(?string $startRule = null): GenerationPlan
+    {
+        $plan = $startRule === null
+            ? GenerationPlan::all()
+            : GenerationPlan::fromRule($startRule);
+
+        return $plan
+            ->withPatternForEveryOccurrence('opt_values', ProductionPattern::nonEmpty())
+            ->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableUpdateStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('update_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -87,6 +87,16 @@ final class MySqlProvider extends Base
         return $this->generate($startRule?->value, $maxDepth);
     }
 
+    /** Generate SQL while requiring every MySQL row-value production to be non-empty. */
+    public function sqlWithoutEmptyRows(
+        ?StatementType $startRule = null,
+        int $maxDepth = PHP_INT_MAX,
+    ): string {
+        return $this->sql->generate(
+            GenerationPlans::withoutEmptyRows($startRule?->value)->withMaxDepth($maxDepth),
+        );
+    }
+
     /**
      * Generate a SELECT statement.
      *

--- a/packages/sql-faker/tests/Unit/Grammar/GenerationPlanTest.php
+++ b/packages/sql-faker/tests/Unit/Grammar/GenerationPlanTest.php
@@ -45,6 +45,41 @@ final class GenerationPlanTest extends TestCase
         self::assertNull($plan->patternAt('unknown', 0));
     }
 
+    public function testPatternForEveryOccurrenceProducesANewPlanAndActsAsFallback(): void
+    {
+        $specific = ProductionPattern::exactly();
+        $recurring = ProductionPattern::nonEmpty();
+        $plan = GenerationPlan::constrained('insert', ['opt_values' => [$specific]]);
+        $directed = $plan->withPatternForEveryOccurrence('opt_values', $recurring);
+
+        self::assertNotSame($plan, $directed);
+        self::assertNull($plan->patternAt('opt_values', 1));
+        self::assertSame($specific, $directed->patternAt('opt_values', 0));
+        self::assertSame($recurring, $directed->patternAt('opt_values', 1));
+        self::assertSame($recurring, $directed->patternAt('opt_values', 100));
+        self::assertNull($directed->patternAt('unknown', 0));
+    }
+
+    public function testPatternsForEveryOccurrenceAccumulateAcrossRules(): void
+    {
+        $values = ProductionPattern::nonEmpty();
+        $columns = ProductionPattern::containing('IDENT');
+        $plan = GenerationPlan::all()
+            ->withPatternForEveryOccurrence('opt_values', $values)
+            ->withPatternForEveryOccurrence('opt_columns', $columns);
+
+        self::assertSame($values, $plan->patternAt('opt_values', 100));
+        self::assertSame($columns, $plan->patternAt('opt_columns', 100));
+    }
+
+    public function testRejectsAnEmptyRuleForEveryOccurrencePattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('generation plan rule must not be empty');
+
+        GenerationPlan::all()->withPatternForEveryOccurrence('', ProductionPattern::nonEmpty());
+    }
+
     public function testNonEmptyRequirementProducesANewPlan(): void
     {
         $plan = GenerationPlan::fromRule('statement');
@@ -52,6 +87,19 @@ final class GenerationPlanTest extends TestCase
 
         self::assertNotSame($plan, $required);
         self::assertSame('statement', $required->startRule());
+    }
+
+    public function testNonEmptyRequirementHasCorrectRuntimeState(): void
+    {
+        /** @param GenerationPlan<bool> $plan */
+        $requiresNonEmpty = static fn (GenerationPlan $plan): bool => $plan->requiresNonEmpty();
+
+        self::assertFalse($requiresNonEmpty(GenerationPlan::all()));
+        self::assertFalse($requiresNonEmpty(GenerationPlan::fromRule('statement')));
+        self::assertFalse($requiresNonEmpty(GenerationPlan::constrained('statement', [
+            'statement' => [ProductionPattern::nonEmpty()],
+        ])));
+        self::assertTrue($requiresNonEmpty(GenerationPlan::all()->requiringNonEmpty()));
     }
 
     public function testMaxDepthProducesANewPlanAndNormalizesItsLowerBound(): void

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -16,6 +16,25 @@ use SqlFaker\MySql\GenerationPlans;
 #[UsesClass(ProductionPattern::class)]
 final class GenerationPlansTest extends TestCase
 {
+    public function testWithoutEmptyRowsPlanConstrainsEveryOptionalValuesOccurrence(): void
+    {
+        $all = GenerationPlans::withoutEmptyRows();
+        $insert = GenerationPlans::withoutEmptyRows('insert_stmt');
+        $firstPattern = $all->patternAt('opt_values', 0);
+        $laterPattern = $all->patternAt('opt_values', 100);
+        $insertPattern = $insert->patternAt('opt_values', 100);
+
+        self::assertNull($all->startRule());
+        self::assertSame('insert_stmt', $insert->startRule());
+        self::assertNotNull($firstPattern);
+        self::assertNotNull($laterPattern);
+        self::assertNotNull($insertPattern);
+        self::assertFalse($firstPattern->matches([]));
+        self::assertTrue($firstPattern->matches(['values']));
+        self::assertFalse($laterPattern->matches([]));
+        self::assertTrue($insertPattern->matches(['values']));
+    }
+
     public function testMultiTableUpdatePlanRestrictsTheUpdateGrammar(): void
     {
         $plan = GenerationPlans::multiTableUpdateStatement();

--- a/packages/sql-faker/tests/Unit/MySql/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/SqlGeneratorTest.php
@@ -17,6 +17,7 @@ use SqlFaker\MySql\Grammar\Production;
 use SqlFaker\MySql\Grammar\ProductionRule;
 use SqlFaker\MySql\Grammar\Terminal;
 use SqlFaker\MySql\Grammar\TerminationAnalyzer;
+use SqlFaker\MySql\GenerationPlans;
 use SqlFaker\MySql\SqlGenerator;
 use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\Grammar\TokenJoiner;
@@ -103,6 +104,81 @@ final class SqlGeneratorTest extends TestCase
         $plan = GenerationPlan::fromRule('stmt')->requiringNonEmpty();
 
         self::assertSame('EXPECTED', $generator->generate($plan->withMaxDepth(1)));
+    }
+
+    public function testGeneratePreservesAnEmptyInsertRowAllowedByTheGrammar(): void
+    {
+        $faker = Factory::create();
+        $grammar = new Grammar('insert_stmt', [
+            'insert_stmt' => new ProductionRule('insert_stmt', [
+                new Production([
+                    new Terminal('INSERT_SYM'),
+                    new Terminal('INTO'),
+                    new Terminal('IDENT'),
+                    new Terminal('VALUES'),
+                    new NonTerminal('row_value'),
+                ]),
+            ]),
+            'row_value' => new ProductionRule('row_value', [
+                new Production([
+                    new Terminal('('),
+                    new NonTerminal('opt_values'),
+                    new Terminal(')'),
+                ]),
+            ]),
+            'opt_values' => new ProductionRule('opt_values', [
+                new Production([]),
+                new Production([new Terminal('DEFAULT_SYM')]),
+            ]),
+        ]);
+        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+
+        $result = $generator->generate(GenerationPlan::fromRule('insert_stmt')->withMaxDepth(1));
+
+        self::assertSame(
+            ['INSERT_SYM', 'INTO', 'IDENT', 'VALUES', '(', ')'],
+            (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($result),
+        );
+    }
+
+    public function testGenerateCanExcludeEveryEmptyRowThroughThePlan(): void
+    {
+        $faker = Factory::create();
+        $grammar = new Grammar('insert_stmt', [
+            'insert_stmt' => new ProductionRule('insert_stmt', [
+                new Production([
+                    new Terminal('INSERT_SYM'),
+                    new Terminal('INTO'),
+                    new Terminal('IDENT'),
+                    new Terminal('VALUES'),
+                    new NonTerminal('row_value'),
+                    new Terminal(','),
+                    new NonTerminal('row_value'),
+                ]),
+            ]),
+            'row_value' => new ProductionRule('row_value', [
+                new Production([
+                    new Terminal('('),
+                    new NonTerminal('opt_values'),
+                    new Terminal(')'),
+                ]),
+            ]),
+            'opt_values' => new ProductionRule('opt_values', [
+                new Production([]),
+                new Production([new Terminal('DEFAULT_SYM')]),
+            ]),
+        ]);
+        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+
+        $result = $generator->generate(GenerationPlans::withoutEmptyRows('insert_stmt')->withMaxDepth(1));
+
+        self::assertSame(
+            [
+                'INSERT_SYM', 'INTO', 'IDENT', 'VALUES',
+                '(', 'DEFAULT_SYM', ')', ',', '(', 'DEFAULT_SYM', ')',
+            ],
+            (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($result),
+        );
     }
 
     public function testGenerateUsesSimpleStatementOrBeginAsDefaultStartRule(): void

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -13,6 +13,7 @@ use SqlFaker\MySql\Grammar\Production;
 use SqlFaker\MySql\Grammar\ProductionRule;
 use SqlFaker\MySql\Grammar\Terminal;
 use SqlFaker\MySql\Grammar\TerminationAnalyzer;
+use SqlFaker\MySql\GenerationPlans;
 use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\MySql\LexicalGrammar;
 use SqlFaker\MySql\SqlGenerator;
@@ -42,6 +43,7 @@ use SqlFaker\MySql\Grammar\TerminalInventory;
 #[CoversClass(LexicalGrammar::class)]
 #[UsesClass(LexicalCatalog::class)]
 #[UsesClass(GenerationPlan::class)]
+#[UsesClass(GenerationPlans::class)]
 #[UsesClass(ProductionPattern::class)]
 #[UsesClass(SqlVersion::class)]
 #[UsesClass(TerminalInventory::class)]
@@ -108,6 +110,30 @@ final class MySqlProviderTest extends TestCase
         $provider = new MySqlProvider($faker);
 
         $result = $provider->sql(maxDepth: 5);
+
+        self::assertNotSame('', $result);
+    }
+
+    #[DataProvider('providerSupportedMySqlVersion')]
+    public function testSqlWithoutEmptyRowsUsesTheRestrictedGenerationPlan(string $version): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new MySqlProvider($faker, $version);
+
+        $result = $provider->sqlWithoutEmptyRows(StatementType::Insert, maxDepth: 10);
+
+        self::assertMatchesRegularExpression('/\bINSERT\b/i', $result);
+        self::assertDoesNotMatchRegularExpression('/\bVALUES?\s*(?:ROW\s*)?\(\s*\)/i', $result);
+    }
+
+    public function testSqlWithoutEmptyRowsCanGenerateFromTheWholeGrammar(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new MySqlProvider($faker);
+
+        $result = $provider->sqlWithoutEmptyRows(maxDepth: 3);
 
         self::assertNotSame('', $result);
     }
@@ -969,5 +995,19 @@ final class MySqlProviderTest extends TestCase
         foreach (range(0, 15) as $seed) {
             yield "seed {$seed}" => [$seed];
         }
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function providerSupportedMySqlVersion(): iterable
+    {
+        yield 'MySQL 5.6' => ['mysql-5.6.51'];
+        yield 'MySQL 5.7' => ['mysql-5.7.44'];
+        yield 'MySQL 8.0' => ['mysql-8.0.44'];
+        yield 'MySQL 8.1' => ['mysql-8.1.0'];
+        yield 'MySQL 8.2' => ['mysql-8.2.0'];
+        yield 'MySQL 8.3' => ['mysql-8.3.0'];
+        yield 'MySQL 8.4' => ['mysql-8.4.7'];
+        yield 'MySQL 9.0' => ['mysql-9.0.1'];
+        yield 'MySQL 9.1' => ['mysql-9.1.0'];
     }
 }


### PR DESCRIPTION
Stacked on #243.

## Problem
MySQL intentionally permits an empty `opt_values` production. That production is required to represent valid INSERT forms such as `INSERT INTO t () VALUES ()`, including the case reported in #97. SQLFaker must therefore keep empty rows in its unrestricted generation domain.

The MySQL syntax fuzz target has a narrower requirement: it must avoid zero-column row constructors while treating `ER_TABLE_VALUE_CONSTRUCTOR_MUST_HAVE_COLUMNS` (3942) as a failure. Rewriting an already generated empty row to `DEFAULT` changes the generated SQL and its semantics, so the restriction belongs in the generation Plan.

## Fix
- add an immutable Plan constraint that applies a production pattern to every occurrence of a grammar rule
- let occurrence-specific constraints take precedence over the recurring constraint
- add the MySQL `withoutEmptyRows` Plan and an individual public Provider entry point that delegates to `SqlGenerator`
- make only the MySQL syntax fuzz target select that restricted Plan
- remove post-generation INSERT row normalization entirely

Unrestricted `sql()` and `insertStatement()` generation still include empty rows; SQLFaker does not synthesize or rewrite SQL in the Provider.

## Recurrence prevention
- regression proving unrestricted generation can emit `INSERT ... VALUES ()`
- regression proving the restricted Plan excludes empty `opt_values` at every occurrence in a multi-row INSERT
- precedence and immutability tests for recurring Plan constraints
- Provider coverage for all nine supported MySQL grammar versions

## Verification
- SQLFaker: 2,029 tests, 6,704 assertions
- PHP-CS-Fixer: clean
- PHPStan: no errors
- Mutation: 23/23 killed, 100% covered MSI