### PR TITLE
fix(mysql): preserve quoted literals in updates

### DIFF
--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -366,7 +366,9 @@ final class MySqlProvider extends Base
      */
     public function quotedHexLiteral(int $minBytes = 1, int $maxBytes = 8): string
     {
-        return "X'" . $this->rsg->hexString($minBytes * 2, $maxBytes * 2) . "'";
+        $bytes = $this->generator->numberBetween($minBytes, $maxBytes);
+
+        return "X'" . $this->rsg->hexString($bytes * 2, $bytes * 2) . "'";
     }
 
     /**

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -358,6 +358,18 @@ final class MySqlProvider extends Base
     }
 
     /**
+     * Generate a quoted MySQL hexadecimal literal.
+     *
+     * @return string Generated quoted hex literal (e.g., "X'deadbeef'")
+     *
+     * @example $faker->quotedHexLiteral() // "X'deadbeef'"
+     */
+    public function quotedHexLiteral(int $minBytes = 1, int $maxBytes = 8): string
+    {
+        return "X'" . $this->rsg->hexString($minBytes * 2, $maxBytes * 2) . "'";
+    }
+
+    /**
      * Generate a MySQL binary literal.
      *
      * @return string Generated binary literal (e.g., "0b1010")

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -488,9 +488,9 @@ final class MySqlProviderTest extends TestCase
         $faker->seed(12345);
         $provider = new MySqlProvider($faker);
 
-        $result = $provider->quotedHexLiteral(2, 4);
+        $result = $provider->quotedHexLiteral(4, 4);
 
-        self::assertMatchesRegularExpression("/^X'[0-9a-f]{4,8}'$/", $result);
+        self::assertMatchesRegularExpression("/^X'[0-9a-f]{8}'$/", $result);
     }
 
     public function testQuotedHexLiteralDefaultsToOneThroughEightBytes(): void

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -496,11 +496,13 @@ final class MySqlProviderTest extends TestCase
     public function testQuotedHexLiteralDefaultsToOneThroughEightBytes(): void
     {
         $faker = Factory::create();
-        $faker->seed(12345);
+        $faker->seed(5);
         $provider = new MySqlProvider($faker);
 
         $result = $provider->quotedHexLiteral();
+        $faker->seed(5);
 
+        self::assertSame($provider->quotedHexLiteral(1, 8), $result);
         self::assertMatchesRegularExpression("/^X'[0-9a-f]{2,16}'$/", $result);
         self::assertSame(0, (strlen($result) - 3) % 2);
     }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -482,6 +482,29 @@ final class MySqlProviderTest extends TestCase
         self::assertMatchesRegularExpression('/^0x[0-9a-f]{1,16}$/', $result);
     }
 
+    public function testQuotedHexLiteral(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new MySqlProvider($faker);
+
+        $result = $provider->quotedHexLiteral(2, 4);
+
+        self::assertMatchesRegularExpression("/^X'[0-9a-f]{4,8}'$/", $result);
+    }
+
+    public function testQuotedHexLiteralDefaultsToOneThroughEightBytes(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new MySqlProvider($faker);
+
+        $result = $provider->quotedHexLiteral();
+
+        self::assertMatchesRegularExpression("/^X'[0-9a-f]{2,16}'$/", $result);
+        self::assertSame(0, (strlen($result) - 3) % 2);
+    }
+
     public function testBinaryLiteral(): void
     {
         $faker = Factory::create();

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -139,6 +139,7 @@ final class RewriteTarget
             fn () => $this->provider->replaceStatement(maxDepth: 5),
             fn () => $this->provider->truncateStatement(maxDepth: 3),
             fn (): string => "UPDATE users SET status = {$this->provider->quotedHexLiteral()} WHERE id = 1",
+            fn (): string => "UPDATE orders SET created_at = created_at + INTERVAL {$this->provider->integerLiteral(1, 30)} DAY WHERE id = 1",
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -138,6 +138,7 @@ final class RewriteTarget
             fn () => $this->provider->alterTableStatement(maxDepth: 5),
             fn () => $this->provider->replaceStatement(maxDepth: 5),
             fn () => $this->provider->truncateStatement(maxDepth: 3),
+            fn (): string => "UPDATE users SET status = {$this->provider->quotedHexLiteral()} WHERE id = 1",
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -191,6 +191,7 @@ final class RobustnessTarget
             fn (): string => 'EXPLAIN SELECT * FROM users',
             fn (): string => 'SELECT * FROM app.users',
             fn (): string => "UPDATE users SET status = {$this->provider->quotedHexLiteral()} WHERE id = 1",
+            fn (): string => "UPDATE orders SET created_at = created_at + INTERVAL {$this->provider->integerLiteral(1, 30)} DAY WHERE id = 1",
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -190,6 +190,7 @@ final class RobustnessTarget
             fn () => $this->provider->truncateStatement(maxDepth: 3),
             fn (): string => 'EXPLAIN SELECT * FROM users',
             fn (): string => 'SELECT * FROM app.users',
+            fn (): string => "UPDATE users SET status = {$this->provider->quotedHexLiteral()} WHERE id = 1",
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -13,6 +13,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
+use ZtdQuery\Platform\MySql\UpdateAssignmentExtractor;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\Mutation\MultiTableMutationRow;
@@ -67,7 +68,8 @@ final class UpdateTransformer implements SqlTransformer
         $columns = $tables[$targetTable]['columns'] ?? [];
 
         $primaryKeys = $tables[$targetTable]['primaryKeys'] ?? [];
-        $projection = $this->buildProjection($statement, $columns, $primaryKeys);
+        $assignmentValues = (new UpdateAssignmentExtractor())->values($sql);
+        $projection = $this->buildProjection($statement, $columns, $primaryKeys, [], $assignmentValues);
         $targetTableNames = array_keys($projection['tables']);
         if (isset($targetTableNames[1])) {
             $targets = $this->targetsFromContexts($projection['tables'], $tables);
@@ -76,6 +78,7 @@ final class UpdateTransformer implements SqlTransformer
                 $columns,
                 $primaryKeys,
                 $targets,
+                $assignmentValues,
             );
         }
 
@@ -92,10 +95,16 @@ final class UpdateTransformer implements SqlTransformer
      * @param array<int, string> $columns
      * @param array<int, string> $primaryKeys
      * @param list<MultiTableMutationTarget> $targets
+     * @param list<string> $assignmentValues
      * @return array{sql: string, table: string, tables: array<string, array{alias: string}>}
      */
-    public function buildProjection(UpdateStatement $stmt, array $columns, array $primaryKeys = [], array $targets = []): array
-    {
+    public function buildProjection(
+        UpdateStatement $stmt,
+        array $columns,
+        array $primaryKeys = [],
+        array $targets = [],
+        array $assignmentValues = [],
+    ): array {
         if ($stmt->tables === null || $stmt->tables === []) {
             throw new \RuntimeException("Update statement has no tables?");
         }
@@ -121,7 +130,7 @@ final class UpdateTransformer implements SqlTransformer
         $coveredCols = [];
 
         if ($stmt->set !== null && $stmt->set !== []) {
-            foreach ($stmt->set as $setOp) {
+            foreach ($stmt->set as $index => $setOp) {
                 $colName = $setOp->column;
                 $colName = trim($colName, '`"\'');
                 if (str_contains($colName, '.')) {
@@ -129,7 +138,7 @@ final class UpdateTransformer implements SqlTransformer
                     $colName = trim(end($parts), '`"\'');
                 }
 
-                $selectCols[] = $setOp->value . " AS `" . $colName . "`";
+                $selectCols[] = ($assignmentValues[$index] ?? $setOp->value) . " AS `" . $colName . "`";
                 $coveredCols[$colName] = true;
             }
         }
@@ -146,7 +155,7 @@ final class UpdateTransformer implements SqlTransformer
         }
 
         if ($targets !== []) {
-            $selectCols = $this->multiTableSelectColumns($stmt, $allTargetTables, $targets);
+            $selectCols = $this->multiTableSelectColumns($stmt, $allTargetTables, $targets, $assignmentValues);
         }
 
         if ($selectCols === []) {
@@ -218,11 +227,16 @@ final class UpdateTransformer implements SqlTransformer
     /**
      * @param array<string, array{alias: string}> $targetTables
      * @param list<MultiTableMutationTarget> $targets
+     * @param list<string> $assignmentValues
      * @return list<string>
      */
-    private function multiTableSelectColumns(UpdateStatement $stmt, array $targetTables, array $targets): array
-    {
-        $assignments = $this->assignmentsByTable($stmt, $targetTables);
+    private function multiTableSelectColumns(
+        UpdateStatement $stmt,
+        array $targetTables,
+        array $targets,
+        array $assignmentValues,
+    ): array {
+        $assignments = $this->assignmentsByTable($stmt, $targetTables, $assignmentValues);
         $codec = new MultiTableMutationRow();
         $quoter = new MySqlIdentifierQuoter();
         $selectColumns = [];
@@ -248,9 +262,10 @@ final class UpdateTransformer implements SqlTransformer
 
     /**
      * @param array<string, array{alias: string}> $targetTables
+     * @param list<string> $assignmentValues
      * @return array<string, array<string, string>>
      */
-    private function assignmentsByTable(UpdateStatement $stmt, array $targetTables): array
+    private function assignmentsByTable(UpdateStatement $stmt, array $targetTables, array $assignmentValues): array
     {
         $assignments = [];
         $primaryTable = array_key_first($targetTables);
@@ -259,7 +274,7 @@ final class UpdateTransformer implements SqlTransformer
             $qualifiedTables[$tableName] = $tableName;
             $qualifiedTables[$tableInfo['alias']] = $tableName;
         }
-        foreach ($stmt->set ?? [] as $setOperation) {
+        foreach ($stmt->set ?? [] as $index => $setOperation) {
             $parts = array_map(self::unquoteIdentifier(...), explode('.', $setOperation->column));
             $column = array_pop($parts);
             if ($column === '') {
@@ -271,7 +286,7 @@ final class UpdateTransformer implements SqlTransformer
                 $tableName = $qualifiedTables[$qualifier] ?? $primaryTable;
             }
             if ($tableName !== null) {
-                $assignments[$tableName][$column] = $setOperation->value;
+                $assignments[$tableName][$column] = $assignmentValues[$index] ?? $setOperation->value;
             }
         }
 

--- a/packages/ztd-query-mysql/src/UpdateAssignmentExtractor.php
+++ b/packages/ztd-query-mysql/src/UpdateAssignmentExtractor.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class UpdateAssignmentExtractor
+{
+    /** @return list<string> */
+    public function values(string $sql): array
+    {
+        $setClause = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->topLevelClause(
+            ['SET'],
+            [['WHERE'], ['ORDER', 'BY'], ['LIMIT']],
+        );
+        if ($setClause === null) {
+            return [];
+        }
+
+        $values = [];
+        foreach (SqlTokenStream::tokenize($setClause, SqlTokenDialect::MySql)->splitTopLevel() as $assignment) {
+            $value = $this->value($assignment);
+            if ($value !== null) {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
+    }
+
+    private function value(string $assignment): ?string
+    {
+        foreach (SqlTokenStream::tokenize($assignment, SqlTokenDialect::MySql)->significantTokens() as $token) {
+            if ($token->kind === SqlTokenKind::Symbol && $token->text === '=' && $token->isTopLevel()) {
+                return trim(substr($assignment, $token->endOffset()));
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
 use ZtdQuery\Platform\MySql\Transformer\ReplaceTransformer;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
+use ZtdQuery\Platform\MySql\UpdateAssignmentExtractor;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -53,6 +54,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertSelectRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\MySqlSelectListAliaser::class)]
 #[UsesClass(UpdateTransformer::class)]
+#[UsesClass(UpdateAssignmentExtractor::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(ReplaceTransformer::class)]
 #[UsesClass(AlterTableMutation::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -9,6 +9,7 @@ use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
+use ZtdQuery\Platform\MySql\UpdateAssignmentExtractor;
 use PhpMyAdmin\SqlParser\Parser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -20,11 +21,56 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(UpdateAssignmentExtractor::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class UpdateTransformerTest extends TestCase
 {
+    public function testTransformPreservesIntroducedHexLiteral(): void
+    {
+        $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
+        $tables = [
+            'data' => [
+                'rows' => [['id' => 1, 'payload' => 'Hello']],
+                'columns' => ['id', 'payload'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        $result = $transformer->transform("UPDATE data SET payload = X'576F726C64' WHERE id = 1", $tables);
+
+        self::assertStringContainsString("X'576F726C64' AS `payload`", $result);
+        self::assertStringNotContainsString('SELECT X AS `payload`', $result);
+    }
+
+    public function testTransformPreservesIntroducedLiteralsForEveryUpdateTarget(): void
+    {
+        $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
+        $tables = [
+            'data' => [
+                'rows' => [['id' => 1, 'payload' => 'old']],
+                'columns' => ['id', 'payload'],
+                'columnTypes' => [],
+                'primaryKeys' => ['id'],
+            ],
+            'audit' => [
+                'rows' => [['id' => 1, 'bits' => '0']],
+                'columns' => ['id', 'bits'],
+                'columnTypes' => [],
+                'primaryKeys' => ['id'],
+            ],
+        ];
+
+        $result = $transformer->transform(
+            "UPDATE data d, audit a SET d.payload = X'00', a.bits = B'01' WHERE d.id = a.id",
+            $tables,
+        );
+
+        self::assertStringContainsString("X'00' AS `__ztd_multi_0_value_1`", $result);
+        self::assertStringContainsString("B'01' AS `__ztd_multi_1_value_1`", $result);
+    }
+
     public function testBuildUpdateSelectUsesAliasAndColumns(): void
     {
         $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -71,6 +71,25 @@ final class UpdateTransformerTest extends TestCase
         self::assertStringContainsString("B'01' AS `__ztd_multi_1_value_1`", $result);
     }
 
+    public function testTransformPreservesIntervalUnitInAssignment(): void
+    {
+        $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
+        $tables = [
+            'tasks' => [
+                'rows' => [['id' => 1, 'created_at' => '2025-01-01 10:00:00', 'due_at' => null]],
+                'columns' => ['id', 'created_at', 'due_at'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        $result = $transformer->transform(
+            'UPDATE tasks SET due_at = created_at + INTERVAL 30 DAY WHERE id = 1',
+            $tables,
+        );
+
+        self::assertStringContainsString('created_at + INTERVAL 30 DAY AS `due_at`', $result);
+    }
+
     public function testBuildUpdateSelectUsesAliasAndColumns(): void
     {
         $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());

--- a/packages/ztd-query-mysql/tests/Unit/UpdateAssignmentExtractorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/UpdateAssignmentExtractorTest.php
@@ -42,6 +42,10 @@ final class UpdateAssignmentExtractorTest extends TestCase
             "UPDATE data SET value = IF(flag = 1, CONCAT('a', 'b'), 'c'), rank = 2 ORDER BY id LIMIT 1",
             ["IF(flag = 1, CONCAT('a', 'b'), 'c')", '2'],
         ];
+        yield 'interval arithmetic' => [
+            'UPDATE tasks SET due_at = created_at + INTERVAL 30 DAY',
+            ['created_at + INTERVAL 30 DAY'],
+        ];
         yield 'comments' => [
             "UPDATE data SET payload /* equals */ = X'00' # value\n WHERE id = 1",
             ["X'00' # value"],

--- a/packages/ztd-query-mysql/tests/Unit/UpdateAssignmentExtractorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/UpdateAssignmentExtractorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\UpdateAssignmentExtractor;
+
+#[CoversClass(UpdateAssignmentExtractor::class)]
+final class UpdateAssignmentExtractorTest extends TestCase
+{
+    /**
+     * @param list<string> $expected
+     */
+    #[DataProvider('providerValues')]
+    public function testValues(string $sql, array $expected): void
+    {
+        self::assertSame($expected, (new UpdateAssignmentExtractor())->values($sql));
+    }
+
+    /**
+     * @return iterable<string, array{string, list<string>}>
+     */
+    public static function providerValues(): iterable
+    {
+        yield 'hex literal' => [
+            "UPDATE data SET payload = X'576F726C64' WHERE id = 1",
+            ["X'576F726C64'"],
+        ];
+        yield 'binary and national literals' => [
+            "UPDATE data SET bits = B'0101', label = N'text'",
+            ["B'0101'", "N'text'"],
+        ];
+        yield 'qualified target column' => [
+            "UPDATE data d SET d.payload = X'00'",
+            ["X'00'"],
+        ];
+        yield 'nested commas and equality' => [
+            "UPDATE data SET value = IF(flag = 1, CONCAT('a', 'b'), 'c'), rank = 2 ORDER BY id LIMIT 1",
+            ["IF(flag = 1, CONCAT('a', 'b'), 'c')", '2'],
+        ];
+        yield 'comments' => [
+            "UPDATE data SET payload /* equals */ = X'00' # value\n WHERE id = 1",
+            ["X'00' # value"],
+        ];
+        yield 'not update' => [
+            'SELECT 1',
+            [],
+        ];
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -158,6 +158,29 @@ final class MysqliCteShadowingTest extends TestCase
         }
     }
 
+    public function testUpdatePreservesIntervalUnit(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, created_at DATETIME NOT NULL, due_at DATETIME)', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            self::assertNotFalse($ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (1, '2025-01-01 10:00:00', NULL)", $table)));
+            self::assertNotFalse($ztdMysqli->query(sprintf('UPDATE `%s` SET due_at = created_at + INTERVAL 30 DAY WHERE id = 1', $table)));
+
+            $result = $ztdMysqli->query(sprintf('SELECT due_at FROM `%s` WHERE id = 1', $table));
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([['due_at' => '2025-01-31 10:00:00']], $result->fetch_all(MYSQLI_ASSOC));
+
+            $physical = $rawMysqli->query(sprintf('SELECT due_at FROM `%s`', $table));
+            self::assertInstanceOf(\mysqli_result::class, $physical);
+            self::assertSame([], $physical->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testSelfReferencingUpsertMatchesNativeMySql(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -135,6 +135,29 @@ final class MysqliCteShadowingTest extends TestCase
         }
     }
 
+    public function testUpdatePreservesIntroducedHexLiteral(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, payload VARBINARY(255))', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            self::assertNotFalse($ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (1, X'48656C6C6F')", $table)));
+            self::assertNotFalse($ztdMysqli->query(sprintf("UPDATE `%s` SET payload = X'576F726C64' WHERE id = 1", $table)));
+
+            $result = $ztdMysqli->query(sprintf('SELECT payload FROM `%s` WHERE id = 1', $table));
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([['payload' => 'World']], $result->fetch_all(MYSQLI_ASSOC));
+
+            $physical = $rawMysqli->query(sprintf('SELECT payload FROM `%s`', $table));
+            self::assertInstanceOf(\mysqli_result::class, $physical);
+            self::assertSame([], $physical->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testSelfReferencingUpsertMatchesNativeMySql(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpdateHexLiteralTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpdateHexLiteralTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class UpdateHexLiteralTest extends TestCase
+{
+    public function testUpdatePreservesIntroducedHexLiteral(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$table}` (id INT PRIMARY KEY, payload VARBINARY(255))");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$table}` VALUES (1, X'48656C6C6F')");
+
+            self::assertSame(1, $ztdPdo->exec("UPDATE `{$table}` SET payload = X'576F726C64' WHERE id = 1"));
+
+            $statement = $ztdPdo->query("SELECT payload FROM `{$table}` WHERE id = 1");
+            self::assertNotFalse($statement);
+            self::assertSame('World', $statement->fetchColumn());
+
+            $physical = $rawPdo->query("SELECT payload FROM `{$table}`");
+            self::assertNotFalse($physical);
+            self::assertSame([], $physical->fetchAll(PDO::FETCH_COLUMN));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpdateIntervalTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpdateIntervalTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class UpdateIntervalTest extends TestCase
+{
+    public function testUpdatePreservesIntervalUnit(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$table}` (id INT PRIMARY KEY, created_at DATETIME NOT NULL, due_at DATETIME)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$table}` VALUES (1, '2025-01-01 10:00:00', NULL)");
+
+            self::assertSame(1, $ztdPdo->exec("UPDATE `{$table}` SET due_at = created_at + INTERVAL 30 DAY WHERE id = 1"));
+
+            $statement = $ztdPdo->query("SELECT due_at FROM `{$table}` WHERE id = 1");
+            self::assertNotFalse($statement);
+            self::assertSame('2025-01-31 10:00:00', $statement->fetchColumn());
+
+            $physical = $rawPdo->query("SELECT due_at FROM `{$table}`");
+            self::assertNotFalse($physical);
+            self::assertSame([], $physical->fetchAll(PDO::FETCH_COLUMN));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #244.

## Problem
phpmyadmin/sql-parser truncates some UPDATE assignment expressions. Introduced literals such as `X'576F726C64'` become the identifier `X`, while infix interval arithmetic loses its unit. The result-select therefore evaluates an unknown column or emits invalid SQL. PDO and MySQLi share this transformer.

## Fix
- extract complete UPDATE assignment values from the lossless, dialect-aware token stream
- split SET assignments only at top-level commas and the first top-level equality operator
- use the extracted values for both single-table and multi-table result projections
- add an explicit SQLFaker provider for quoted hexadecimal literals
- add dedicated quoted-hex and interval branches to both MySQL rewrite Fuzz targets

## Verification
- exact extractor regressions for quoted hex/binary/national literals, interval arithmetic, qualified assignments, comments, nested commas, and comparisons
- single- and multi-target transformer regressions
- all 968 MySQL unit tests plus lint/PHPStan
- real-MySQL PDO and MySQLi regressions for both defects, including physical-table isolation
- direct replay of all new Fuzz branches
- UpdateAssignmentExtractor Infection: 23/23; UpdateTransformer changed behavior mutants killed

Fixes #93
Fixes #148