### PR TITLE
fix(mysql): preserve DML case predicates

### DIFF
--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -140,6 +140,8 @@ final class RewriteTarget
             fn () => $this->provider->truncateStatement(maxDepth: 3),
             fn (): string => "UPDATE users SET status = {$this->provider->quotedHexLiteral()} WHERE id = 1",
             fn (): string => "UPDATE orders SET created_at = created_at + INTERVAL {$this->provider->integerLiteral(1, 30)} DAY WHERE id = 1",
+            fn (): string => 'UPDATE users SET status = 0 WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
+            fn (): string => 'DELETE FROM users WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -192,6 +192,8 @@ final class RobustnessTarget
             fn (): string => 'SELECT * FROM app.users',
             fn (): string => "UPDATE users SET status = {$this->provider->quotedHexLiteral()} WHERE id = 1",
             fn (): string => "UPDATE orders SET created_at = created_at + INTERVAL {$this->provider->integerLiteral(1, 30)} DAY WHERE id = 1",
+            fn (): string => 'UPDATE users SET status = 0 WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
+            fn (): string => 'DELETE FROM users WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/DmlWhereClauseExtractor.php
+++ b/packages/ztd-query-mysql/src/DmlWhereClauseExtractor.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class DmlWhereClauseExtractor
+{
+    public function extract(string $sql): ?string
+    {
+        return SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->topLevelClause(
+            ['WHERE'],
+            [['ORDER', 'BY'], ['LIMIT'], ['RETURNING']],
+        );
+    }
+}

--- a/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
@@ -11,9 +11,10 @@ use PhpMyAdmin\SqlParser\Components\Limit;
 use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
+use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
-use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Shadow\Mutation\MultiTableMutationRow;
 use ZtdQuery\Shadow\Mutation\MultiTableMutationTarget;
@@ -180,8 +181,12 @@ final class DeleteTransformer implements SqlTransformer
         }
 
         $whereClause = "";
-        if ($stmt->where !== null && $stmt->where !== []) {
-            $whereClause = " WHERE " . Condition::build($stmt->where);
+        $whereExpression = (new DmlWhereClauseExtractor())->extract($originalSql);
+        if ($whereExpression === null && $stmt->where !== null && $stmt->where !== []) {
+            $whereExpression = Condition::build($stmt->where);
+        }
+        if ($whereExpression !== null && $whereExpression !== '') {
+            $whereClause = " WHERE " . $whereExpression;
         }
 
         $orderClause = "";

--- a/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Platform\MySql\Transformer;
 
-use PhpMyAdmin\SqlParser\Components\Condition;
 use PhpMyAdmin\SqlParser\Components\Expression;
 use PhpMyAdmin\SqlParser\Components\JoinKeyword;
 use PhpMyAdmin\SqlParser\Components\Limit;
@@ -182,9 +181,6 @@ final class DeleteTransformer implements SqlTransformer
 
         $whereClause = "";
         $whereExpression = (new DmlWhereClauseExtractor())->extract($originalSql);
-        if ($whereExpression === null && $stmt->where !== null && $stmt->where !== []) {
-            $whereExpression = Condition::build($stmt->where);
-        }
         if ($whereExpression !== null && $whereExpression !== '') {
             $whereClause = " WHERE " . $whereExpression;
         }

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -13,6 +13,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\UpdateAssignmentExtractor;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
@@ -69,7 +70,15 @@ final class UpdateTransformer implements SqlTransformer
 
         $primaryKeys = $tables[$targetTable]['primaryKeys'] ?? [];
         $assignmentValues = (new UpdateAssignmentExtractor())->values($sql);
-        $projection = $this->buildProjection($statement, $columns, $primaryKeys, [], $assignmentValues);
+        $whereExpression = (new DmlWhereClauseExtractor())->extract($sql);
+        $projection = $this->buildProjection(
+            $statement,
+            $columns,
+            $primaryKeys,
+            [],
+            $assignmentValues,
+            $whereExpression,
+        );
         $targetTableNames = array_keys($projection['tables']);
         if (isset($targetTableNames[1])) {
             $targets = $this->targetsFromContexts($projection['tables'], $tables);
@@ -79,6 +88,7 @@ final class UpdateTransformer implements SqlTransformer
                 $primaryKeys,
                 $targets,
                 $assignmentValues,
+                $whereExpression,
             );
         }
 
@@ -104,6 +114,7 @@ final class UpdateTransformer implements SqlTransformer
         array $primaryKeys = [],
         array $targets = [],
         array $assignmentValues = [],
+        ?string $whereExpression = null,
     ): array {
         if ($stmt->tables === null || $stmt->tables === []) {
             throw new \RuntimeException("Update statement has no tables?");
@@ -173,8 +184,11 @@ final class UpdateTransformer implements SqlTransformer
         $joinClause = $this->buildJoinClause($stmt);
 
         $whereClause = "";
-        if ($stmt->where !== null && $stmt->where !== []) {
-            $whereClause = " WHERE " . Condition::build($stmt->where);
+        if ($whereExpression === null && $stmt->where !== null && $stmt->where !== []) {
+            $whereExpression = Condition::build($stmt->where);
+        }
+        if ($whereExpression !== null && $whereExpression !== '') {
+            $whereClause = " WHERE " . $whereExpression;
         }
 
         $orderByClause = "";

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -184,10 +184,10 @@ final class UpdateTransformer implements SqlTransformer
         $joinClause = $this->buildJoinClause($stmt);
 
         $whereClause = "";
-        if ($whereExpression === null && $stmt->where !== null && $stmt->where !== []) {
-            $whereExpression = Condition::build($stmt->where);
+        if ($whereExpression === null) {
+            $whereExpression = Condition::build($stmt->where ?? []);
         }
-        if ($whereExpression !== null && $whereExpression !== '') {
+        if ($whereExpression !== '') {
             $whereClause = " WHERE " . $whereExpression;
         }
 

--- a/packages/ztd-query-mysql/tests/Unit/DmlWhereClauseExtractorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/DmlWhereClauseExtractorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
+
+#[CoversClass(DmlWhereClauseExtractor::class)]
+final class DmlWhereClauseExtractorTest extends TestCase
+{
+    #[DataProvider('providerExtract')]
+    public function testExtract(string $sql, ?string $expected): void
+    {
+        self::assertSame($expected, (new DmlWhereClauseExtractor())->extract($sql));
+    }
+
+    /** @return iterable<string, array{string, string|null}> */
+    public static function providerExtract(): iterable
+    {
+        yield 'searched case' => [
+            'UPDATE t SET score = 0 WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1',
+            'CASE WHEN score > 80 THEN 1 ELSE 0 END = 1',
+        ];
+        yield 'nested subquery' => [
+            'DELETE FROM t WHERE id IN (SELECT id FROM source WHERE active = 1) ORDER BY id LIMIT 2',
+            'id IN (SELECT id FROM source WHERE active = 1)',
+        ];
+        yield 'quoted and commented keywords' => [
+            "UPDATE t SET note = 'WHERE' /* WHERE */ WHERE id = 1 # ORDER BY\n LIMIT 1",
+            'id = 1 # ORDER BY',
+        ];
+        yield 'without where' => [
+            'DELETE FROM t ORDER BY id LIMIT 1',
+            null,
+        ];
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnknownSchemaException;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
@@ -42,6 +43,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
+#[UsesClass(DmlWhereClauseExtractor::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use Tests\Contract\RewriterContractTest;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\Mutation\AlterTableMutation;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
 use ZtdQuery\Platform\MySql\MySqlParser;
@@ -56,6 +57,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(UpdateAssignmentExtractor::class)]
 #[UsesClass(DeleteTransformer::class)]
+#[UsesClass(DmlWhereClauseExtractor::class)]
 #[UsesClass(ReplaceTransformer::class)]
 #[UsesClass(AlterTableMutation::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCastRenderer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Transformer;
 
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\Transformer\DeleteTransformer;
@@ -20,11 +21,31 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(DmlWhereClauseExtractor::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class DeleteTransformerTest extends TestCase
 {
+    public function testTransformPreservesCaseWhereExpression(): void
+    {
+        $transformer = new DeleteTransformer(new MySqlParser(), new SelectTransformer());
+        $tables = [
+            't' => [
+                'rows' => [['id' => 1, 'score' => 85], ['id' => 2, 'score' => 60]],
+                'columns' => ['id', 'score'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        $result = $transformer->transform(
+            'DELETE FROM t WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1',
+            $tables,
+        );
+
+        self::assertStringContainsString('WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1', $result);
+    }
+
     public function testBuildDeleteWithJoinAlias(): void
     {
         $transformer = new DeleteTransformer(new MySqlParser(), new SelectTransformer());

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Transformer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
@@ -27,6 +28,7 @@ use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\MySqlSelectListAliaser::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
+#[UsesClass(DmlWhereClauseExtractor::class)]
 #[UsesClass(ReplaceTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Transformer;
 
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
@@ -21,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(DmlWhereClauseExtractor::class)]
 #[UsesClass(UpdateAssignmentExtractor::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
@@ -88,6 +90,25 @@ final class UpdateTransformerTest extends TestCase
         );
 
         self::assertStringContainsString('created_at + INTERVAL 30 DAY AS `due_at`', $result);
+    }
+
+    public function testTransformPreservesCaseWhereExpression(): void
+    {
+        $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
+        $tables = [
+            't' => [
+                'rows' => [['id' => 1, 'score' => 85], ['id' => 2, 'score' => 60]],
+                'columns' => ['id', 'score'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        $result = $transformer->transform(
+            'UPDATE t SET score = 0 WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1',
+            $tables,
+        );
+
+        self::assertStringContainsString('WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1', $result);
     }
 
     public function testBuildUpdateSelectUsesAliasAndColumns(): void

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -181,6 +181,50 @@ final class MysqliCteShadowingTest extends TestCase
         }
     }
 
+    public function testUpdateAndDeleteRestrictRowsWithCaseExpression(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $updates = 'prefix_' . bin2hex(random_bytes(8));
+        $deletes = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, score INT)', $updates));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, score INT)', $deletes));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            $rows = 'VALUES (1, 85), (2, 60), (3, 95), (4, 45)';
+            self::assertNotFalse($ztdMysqli->query(sprintf('INSERT INTO `%s` %s', $updates, $rows)));
+            self::assertNotFalse($ztdMysqli->query(sprintf('INSERT INTO `%s` %s', $deletes, $rows)));
+            self::assertNotFalse($ztdMysqli->query(sprintf('UPDATE `%s` SET score = 0 WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1', $updates)));
+            self::assertSame(2, $ztdMysqli->lastAffectedRows());
+            self::assertNotFalse($ztdMysqli->query(sprintf('DELETE FROM `%s` WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1', $deletes)));
+            self::assertSame(2, $ztdMysqli->lastAffectedRows());
+
+            $updated = $ztdMysqli->query(sprintf('SELECT id, score FROM `%s` ORDER BY id', $updates));
+            $remaining = $ztdMysqli->query(sprintf('SELECT id, score FROM `%s` ORDER BY id', $deletes));
+            self::assertInstanceOf(\mysqli_result::class, $updated);
+            self::assertInstanceOf(\mysqli_result::class, $remaining);
+            self::assertSame([
+                ['id' => 1, 'score' => 0],
+                ['id' => 2, 'score' => 60],
+                ['id' => 3, 'score' => 0],
+                ['id' => 4, 'score' => 45],
+            ], $updated->fetch_all(MYSQLI_ASSOC));
+            self::assertSame([
+                ['id' => 2, 'score' => 60],
+                ['id' => 4, 'score' => 45],
+            ], $remaining->fetch_all(MYSQLI_ASSOC));
+
+            $physicalUpdates = $rawMysqli->query(sprintf('SELECT * FROM `%s`', $updates));
+            $physicalDeletes = $rawMysqli->query(sprintf('SELECT * FROM `%s`', $deletes));
+            self::assertInstanceOf(\mysqli_result::class, $physicalUpdates);
+            self::assertInstanceOf(\mysqli_result::class, $physicalDeletes);
+            self::assertSame([], $physicalUpdates->fetch_all(MYSQLI_ASSOC));
+            self::assertSame([], $physicalDeletes->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testSelfReferencingUpsertMatchesNativeMySql(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/CaseWhereTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/CaseWhereTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class CaseWhereTest extends TestCase
+{
+    public function testUpdateAndDeleteRestrictRowsWithCaseExpression(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $updates = 'prefix_' . bin2hex(random_bytes(8));
+        $deletes = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$updates}` (id INT PRIMARY KEY, score INT)");
+            $rawPdo->exec("CREATE TABLE `{$deletes}` (id INT PRIMARY KEY, score INT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $rows = 'VALUES (1, 85), (2, 60), (3, 95), (4, 45)';
+            $ztdPdo->exec("INSERT INTO `{$updates}` {$rows}");
+            $ztdPdo->exec("INSERT INTO `{$deletes}` {$rows}");
+
+            self::assertSame(2, $ztdPdo->exec("UPDATE `{$updates}` SET score = 0 WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1"));
+            self::assertSame(2, $ztdPdo->exec("DELETE FROM `{$deletes}` WHERE CASE WHEN score > 80 THEN 1 ELSE 0 END = 1"));
+
+            $updated = $ztdPdo->query("SELECT id, score FROM `{$updates}` ORDER BY id");
+            $remaining = $ztdPdo->query("SELECT id, score FROM `{$deletes}` ORDER BY id");
+            self::assertNotFalse($updated);
+            self::assertNotFalse($remaining);
+            self::assertSame([
+                ['id' => 1, 'score' => 0],
+                ['id' => 2, 'score' => 60],
+                ['id' => 3, 'score' => 0],
+                ['id' => 4, 'score' => 45],
+            ], $updated->fetchAll(PDO::FETCH_ASSOC));
+            self::assertSame([
+                ['id' => 2, 'score' => 60],
+                ['id' => 4, 'score' => 45],
+            ], $remaining->fetchAll(PDO::FETCH_ASSOC));
+
+            $physicalUpdates = $rawPdo->query("SELECT * FROM `{$updates}`");
+            $physicalDeletes = $rawPdo->query("SELECT * FROM `{$deletes}`");
+            self::assertNotFalse($physicalUpdates);
+            self::assertNotFalse($physicalDeletes);
+            self::assertSame([], $physicalUpdates->fetchAll(PDO::FETCH_ASSOC));
+            self::assertSame([], $physicalDeletes->fetchAll(PDO::FETCH_ASSOC));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #245.

## Problem
phpmyadmin/sql-parser returns an empty WHERE component for searched CASE predicates in UPDATE and DELETE. Both transformers therefore dropped the predicate and simulated the mutation against every shadow row.

## Fix
- extract the main DML WHERE clause from the lossless MySQL token stream
- respect parenthesis/bracket depth so nested subquery WHERE clauses do not terminate or replace the outer predicate
- preserve comments and quoted keywords while stopping before top-level ORDER BY, LIMIT, or RETURNING
- share the extractor between UPDATE and DELETE
- add dedicated CASE-WHERE branches to both MySQL rewrite Fuzz targets

## Verification
- extractor regressions for CASE, nested subqueries, quoted/commented keywords, and missing WHERE
- exact UPDATE and DELETE projection regressions
- all 978 MySQL unit tests plus lint/PHPStan
- real-MySQL PDO and MySQLi regressions proving exactly two of four rows are updated/deleted and physical tables stay empty
- direct replay of all four new Fuzz branches
- DmlWhereClauseExtractor Infection: 6/6

Fixes #96
