### PR TITLE
fix(mysql): exclude named constraints from columns

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -6,6 +6,7 @@ namespace SqlFaker\MySql;
 
 use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\ProductionPattern;
+use SqlFaker\MySql\Grammar\Grammar;
 
 final class GenerationPlans
 {
@@ -19,6 +20,27 @@ final class GenerationPlans
         return $plan
             ->withPatternForEveryOccurrence('opt_values', ProductionPattern::nonEmpty())
             ->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function foreignKeyConstraint(Grammar $grammar): GenerationPlan
+    {
+        $startRule = isset($grammar->ruleMap['table_constraint_def'])
+            ? 'table_constraint_def'
+            : 'key_def';
+        $constraintNameRule = isset($grammar->ruleMap['opt_constraint_name'])
+            ? 'opt_constraint_name'
+            : 'opt_constraint';
+        $constraintNameSymbol = $constraintNameRule === 'opt_constraint_name'
+            ? 'CONSTRAINT'
+            : 'constraint';
+
+        return GenerationPlan::constrained($startRule, [
+            $startRule => [ProductionPattern::containing('FOREIGN', 'KEY_SYM')],
+            $constraintNameRule => [ProductionPattern::containing($constraintNameSymbol)],
+            'opt_ident' => [ProductionPattern::nonEmpty()],
+            'opt_ref_list' => [ProductionPattern::nonEmpty()],
+        ])->requiringNonEmpty();
     }
 
     /** @return GenerationPlan<true> */

--- a/packages/sql-faker/src/MySql/SqlGenerator.php
+++ b/packages/sql-faker/src/MySql/SqlGenerator.php
@@ -274,15 +274,17 @@ final class SqlGenerator
     }
 
     /**
-     * @param list<Production> $alternatives
+     * @param non-empty-array<int, Production> $alternatives
      */
     private function selectProduction(array $alternatives): Production
     {
         if ($this->derivationSteps < $this->targetDepth) {
-            return $alternatives[$this->faker->numberBetween(0, count($alternatives) - 1)];
+            $keys = array_keys($alternatives);
+
+            return $alternatives[$keys[$this->faker->numberBetween(0, count($keys) - 1)]];
         }
 
-        $selected = $alternatives[0];
+        $selected = $alternatives[array_key_first($alternatives)];
         $bestLength = $this->terminationAnalyzer->estimateProductionLength($selected);
         foreach (array_slice($alternatives, 1) as $alternative) {
             $length = $this->terminationAnalyzer->estimateProductionLength($alternative);

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -650,4 +650,19 @@ final class MySqlProvider extends Base
 
         return $this->sql->generate($plan->requiringNonEmpty()->withMaxDepth($maxDepth));
     }
+
+    /**
+     * Generate a named MySQL foreign-key table constraint.
+     *
+     * @return non-empty-string
+     */
+    public function foreignKeyConstraint(): string
+    {
+        $name = $this->identifier();
+        $column = $this->identifier();
+        $table = $this->identifier();
+        $referencedColumn = $this->identifier();
+
+        return "CONSTRAINT $name FOREIGN KEY ($column) REFERENCES $table ($referencedColumn)";
+    }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -53,6 +53,7 @@ use SqlFaker\MySql\StatementType;
  */
 final class MySqlProvider extends Base
 {
+    private Grammar $grammar;
     private SqlGenerator $sql;
     private RandomStringGenerator $rsg;
 
@@ -67,8 +68,9 @@ final class MySqlProvider extends Base
         $generator->addProvider($this);
 
         $resolvedVersion = Grammar::resolveVersion($version);
+        $this->grammar = Grammar::load($resolvedVersion);
         $this->rsg = new RandomStringGenerator($generator);
-        $this->sql = new SqlGenerator(Grammar::load($resolvedVersion), $generator, $this, $resolvedVersion);
+        $this->sql = new SqlGenerator($this->grammar, $generator, $this, $resolvedVersion);
     }
 
     /**
@@ -656,13 +658,10 @@ final class MySqlProvider extends Base
      *
      * @return non-empty-string
      */
-    public function foreignKeyConstraint(): string
+    public function foreignKeyConstraint(int $maxDepth = PHP_INT_MAX): string
     {
-        $name = $this->identifier();
-        $column = $this->identifier();
-        $table = $this->identifier();
-        $referencedColumn = $this->identifier();
-
-        return "CONSTRAINT $name FOREIGN KEY ($column) REFERENCES $table ($referencedColumn)";
+        return $this->sql->generate(
+            GenerationPlans::foreignKeyConstraint($this->grammar)->withMaxDepth($maxDepth),
+        );
     }
 }

--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SqlFaker\PostgreSql;
+
+use SqlFaker\Grammar\GenerationPlan;
+use SqlFaker\Grammar\ProductionPattern;
+
+final class GenerationPlans
+{
+    /** @return GenerationPlan<true> */
+    public static function foreignKeyConstraint(): GenerationPlan
+    {
+        return GenerationPlan::constrained('TableConstraint', [
+            'TableConstraint' => [ProductionPattern::containing('CONSTRAINT')],
+            'ConstraintElem' => [ProductionPattern::containing('FOREIGN', 'KEY')],
+            'opt_column_list' => [ProductionPattern::nonEmpty()],
+        ])->requiringNonEmpty();
+    }
+}

--- a/packages/sql-faker/src/PostgreSql/SqlGenerator.php
+++ b/packages/sql-faker/src/PostgreSql/SqlGenerator.php
@@ -289,15 +289,17 @@ final class SqlGenerator
     }
 
     /**
-     * @param list<Production> $alternatives
+     * @param non-empty-array<int, Production> $alternatives
      */
     private function selectProduction(array $alternatives): Production
     {
         if ($this->derivationSteps < $this->targetDepth) {
-            return $alternatives[$this->faker->numberBetween(0, count($alternatives) - 1)];
+            $keys = array_keys($alternatives);
+
+            return $alternatives[$keys[$this->faker->numberBetween(0, count($keys) - 1)]];
         }
 
-        $selected = $alternatives[0];
+        $selected = $alternatives[array_key_first($alternatives)];
         $bestLength = $this->terminationAnalyzer->estimateProductionLength($selected);
         foreach (array_slice($alternatives, 1) as $alternative) {
             $length = $this->terminationAnalyzer->estimateProductionLength($alternative);

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -9,6 +9,7 @@ use Faker\Provider\Base;
 use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\PostgreSql\Grammar\PgGrammar;
+use SqlFaker\PostgreSql\GenerationPlans;
 use SqlFaker\PostgreSql\SqlGenerator;
 use SqlFaker\PostgreSql\StatementType;
 
@@ -293,6 +294,16 @@ final class PostgreSqlProvider extends Base
     public function withClause(int $maxDepth = PHP_INT_MAX): string
     {
         return $this->generate(GenerationPlan::fromRule('with_clause')->requiringNonEmpty(), $maxDepth);
+    }
+
+    /**
+     * Generate a named PostgreSQL foreign-key table constraint.
+     *
+     * @return non-empty-string
+     */
+    public function foreignKeyConstraint(int $maxDepth = PHP_INT_MAX): string
+    {
+        return $this->sql->generate(GenerationPlans::foreignKeyConstraint()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/src/Sqlite/GenerationPlans.php
+++ b/packages/sql-faker/src/Sqlite/GenerationPlans.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SqlFaker\Sqlite;
+
+use SqlFaker\Grammar\GenerationPlan;
+use SqlFaker\Grammar\ProductionPattern;
+
+final class GenerationPlans
+{
+    /** @return GenerationPlan<true> */
+    public static function foreignKeyConstraint(): GenerationPlan
+    {
+        return GenerationPlan::constrained('conslist', [
+            'conslist' => [
+                ProductionPattern::exactly('conslist', 'tconscomma', 'tcons'),
+                ProductionPattern::exactly('tcons'),
+            ],
+            'tcons' => [
+                ProductionPattern::containing('CONSTRAINT'),
+                ProductionPattern::containing('FOREIGN', 'KEY'),
+            ],
+            'tconscomma' => [ProductionPattern::exactly()],
+            'eidlist_opt' => [ProductionPattern::nonEmpty()],
+        ])->requiringNonEmpty();
+    }
+}

--- a/packages/sql-faker/src/Sqlite/SqlGenerator.php
+++ b/packages/sql-faker/src/Sqlite/SqlGenerator.php
@@ -204,7 +204,8 @@ final class SqlGenerator
                     }
                 }
             } else {
-                $selectedIndex = $this->faker->numberBetween(0, count($alternatives) - 1);
+                $keys = array_keys($alternatives);
+                $selectedIndex = $keys[$this->faker->numberBetween(0, count($keys) - 1)];
             }
 
             $production = $alternatives[$selectedIndex];

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -9,6 +9,7 @@ use Faker\Provider\Base;
 use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\Sqlite\Grammar\SqliteGrammar;
+use SqlFaker\Sqlite\GenerationPlans;
 use SqlFaker\Sqlite\SqlGenerator;
 use SqlFaker\Sqlite\StatementType;
 
@@ -201,6 +202,16 @@ final class SqliteProvider extends Base
     public function withClause(int $maxDepth = PHP_INT_MAX): string
     {
         return $this->generate('with', $maxDepth);
+    }
+
+    /**
+     * Generate a named SQLite foreign-key table constraint.
+     *
+     * @return non-empty-string
+     */
+    public function foreignKeyConstraint(int $maxDepth = PHP_INT_MAX): string
+    {
+        return $this->sql->generate(GenerationPlans::foreignKeyConstraint()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -10,10 +10,14 @@ use PHPUnit\Framework\TestCase;
 use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\ProductionPattern;
 use SqlFaker\MySql\GenerationPlans;
+use SqlFaker\MySql\Grammar\Grammar;
+use SqlFaker\MySql\Grammar\ProductionRule;
 
 #[CoversClass(GenerationPlans::class)]
 #[UsesClass(GenerationPlan::class)]
 #[UsesClass(ProductionPattern::class)]
+#[UsesClass(Grammar::class)]
+#[UsesClass(ProductionRule::class)]
 final class GenerationPlansTest extends TestCase
 {
     public function testWithoutEmptyRowsPlanConstrainsEveryOptionalValuesOccurrence(): void
@@ -92,5 +96,22 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('table_factor', 1)?->matches(['single_table']) ?? false);
         self::assertTrue($plan->patternAt('opt_use_partition', 0)?->matches([]) ?? false);
         self::assertTrue($plan->patternAt('opt_use_partition', 1)?->matches([]) ?? false);
+    }
+
+    public function testForeignKeyPlanAdaptsToTheGrammarVersion(): void
+    {
+        $modernGrammar = new Grammar('table_constraint_def', [
+            'table_constraint_def' => new ProductionRule('table_constraint_def', []),
+            'opt_constraint_name' => new ProductionRule('opt_constraint_name', []),
+        ]);
+        $legacyGrammar = new Grammar('key_def', []);
+
+        $modern = GenerationPlans::foreignKeyConstraint($modernGrammar);
+        $legacy = GenerationPlans::foreignKeyConstraint($legacyGrammar);
+
+        self::assertSame('table_constraint_def', $modern->startRule());
+        self::assertNotNull($modern->patternAt('opt_constraint_name', 0));
+        self::assertSame('key_def', $legacy->startRule());
+        self::assertNotNull($legacy->patternAt('opt_constraint', 0));
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -110,8 +110,16 @@ final class GenerationPlansTest extends TestCase
         $legacy = GenerationPlans::foreignKeyConstraint($legacyGrammar);
 
         self::assertSame('table_constraint_def', $modern->startRule());
-        self::assertNotNull($modern->patternAt('opt_constraint_name', 0));
+        self::assertTrue(
+            $modern->patternAt('table_constraint_def', 0)?->matches(['FOREIGN', 'KEY_SYM']) ?? false,
+        );
+        self::assertTrue($modern->patternAt('opt_constraint_name', 0)?->matches(['CONSTRAINT']) ?? false);
+        self::assertTrue($modern->patternAt('opt_ident', 0)?->matches(['ident']) ?? false);
+        self::assertTrue($modern->patternAt('opt_ref_list', 0)?->matches(['reference']) ?? false);
         self::assertSame('key_def', $legacy->startRule());
-        self::assertNotNull($legacy->patternAt('opt_constraint', 0));
+        self::assertTrue($legacy->patternAt('key_def', 0)?->matches(['FOREIGN', 'KEY_SYM']) ?? false);
+        self::assertTrue($legacy->patternAt('opt_constraint', 0)?->matches(['constraint']) ?? false);
+        self::assertTrue($legacy->patternAt('opt_ident', 0)?->matches(['ident']) ?? false);
+        self::assertTrue($legacy->patternAt('opt_ref_list', 0)?->matches(['reference']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/SqlGeneratorTest.php
@@ -24,6 +24,7 @@ use SqlFaker\Grammar\TokenJoiner;
 use SqlFaker\MySql\LexicalGrammar;
 use SqlFaker\MySqlProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(SqlGenerator::class)]
 #[CoversClass(TokenJoiner::class)]
@@ -35,6 +36,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(NonTerminal::class)]
 #[CoversClass(MySqlProvider::class)]
 #[CoversClass(TerminationAnalyzer::class)]
+#[UsesClass(GenerationPlan::class)]
 #[Medium]
 final class SqlGeneratorTest extends TestCase
 {

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -28,7 +28,6 @@ use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\ProductionPattern;
 use SqlFaker\Grammar\SqlVersion;
 use SqlFaker\MySql\Grammar\TerminalInventory;
-use SqlFaker\MySql\GenerationPlans;
 
 #[CoversClass(MySqlProvider::class)]
 #[CoversClass(TokenJoiner::class)]
@@ -48,7 +47,6 @@ use SqlFaker\MySql\GenerationPlans;
 #[UsesClass(ProductionPattern::class)]
 #[UsesClass(SqlVersion::class)]
 #[UsesClass(TerminalInventory::class)]
-#[UsesClass(GenerationPlans::class)]
 #[Medium]
 final class MySqlProviderTest extends TestCase
 {

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -507,6 +507,28 @@ final class MySqlProviderTest extends TestCase
         self::assertSame(0, (strlen($result) - 3) % 2);
     }
 
+    public function testForeignKeyConstraint(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new MySqlProvider($faker);
+
+        $result = $provider->foreignKeyConstraint();
+
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($result);
+        self::assertCount(12, $tokens);
+        self::assertSame('CONSTRAINT', $tokens[0]);
+        self::assertSame('FOREIGN', $tokens[2]);
+        self::assertSame('KEY_SYM', $tokens[3]);
+        self::assertSame(['(', ')', 'REFERENCES', '(', ')'], [
+            $tokens[4],
+            $tokens[6],
+            $tokens[7],
+            $tokens[9],
+            $tokens[11],
+        ]);
+    }
+
     public function testBinaryLiteral(): void
     {
         $faker = Factory::create();

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -28,6 +28,7 @@ use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\ProductionPattern;
 use SqlFaker\Grammar\SqlVersion;
 use SqlFaker\MySql\Grammar\TerminalInventory;
+use SqlFaker\MySql\GenerationPlans;
 
 #[CoversClass(MySqlProvider::class)]
 #[CoversClass(TokenJoiner::class)]
@@ -47,6 +48,7 @@ use SqlFaker\MySql\Grammar\TerminalInventory;
 #[UsesClass(ProductionPattern::class)]
 #[UsesClass(SqlVersion::class)]
 #[UsesClass(TerminalInventory::class)]
+#[UsesClass(GenerationPlans::class)]
 #[Medium]
 final class MySqlProviderTest extends TestCase
 {
@@ -507,26 +509,19 @@ final class MySqlProviderTest extends TestCase
         self::assertSame(0, (strlen($result) - 3) % 2);
     }
 
-    public function testForeignKeyConstraint(): void
+    #[DataProvider('providerMySqlVersion')]
+    public function testForeignKeyConstraint(string $version): void
     {
         $faker = Factory::create();
         $faker->seed(12345);
-        $provider = new MySqlProvider($faker);
+        $provider = new MySqlProvider($faker, $version);
 
-        $result = $provider->foreignKeyConstraint();
+        $result = $provider->foreignKeyConstraint(1);
 
-        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($result);
-        self::assertCount(12, $tokens);
-        self::assertSame('CONSTRAINT', $tokens[0]);
-        self::assertSame('FOREIGN', $tokens[2]);
-        self::assertSame('KEY_SYM', $tokens[3]);
-        self::assertSame(['(', ')', 'REFERENCES', '(', ')'], [
-            $tokens[4],
-            $tokens[6],
-            $tokens[7],
-            $tokens[9],
-            $tokens[11],
-        ]);
+        self::assertSame(
+            ['CONSTRAINT', 'IDENT', 'FOREIGN', 'KEY_SYM', '(', 'IDENT', ')', 'REFERENCES', 'IDENT', '(', 'IDENT', ')'],
+            (new LexicalGrammar($faker, $version, true))->tokenize($result),
+        );
     }
 
     public function testBinaryLiteral(): void
@@ -1023,6 +1018,16 @@ final class MySqlProviderTest extends TestCase
         yield 'AlterTable' => [StatementType::AlterTable];
         yield 'DropTable' => [StatementType::DropTable];
         yield 'SimpleStatement' => [StatementType::SimpleStatement];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function providerMySqlVersion(): iterable
+    {
+        foreach (SqlVersion::names('mysql') as $version) {
+            yield $version => [$version];
+        }
     }
 
     /**

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SqlFaker\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use SqlFaker\Grammar\GenerationPlan;
+use SqlFaker\Grammar\ProductionPattern;
+use SqlFaker\PostgreSql\GenerationPlans;
+
+#[CoversClass(GenerationPlans::class)]
+#[UsesClass(GenerationPlan::class)]
+#[UsesClass(ProductionPattern::class)]
+final class GenerationPlansTest extends TestCase
+{
+    public function testForeignKeyPlanRestrictsTheTableConstraintGrammar(): void
+    {
+        $plan = GenerationPlans::foreignKeyConstraint();
+
+        self::assertSame('TableConstraint', $plan->startRule());
+        self::assertNotNull($plan->patternAt('TableConstraint', 0));
+        self::assertNotNull($plan->patternAt('ConstraintElem', 0));
+    }
+}

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -21,7 +21,8 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::foreignKeyConstraint();
 
         self::assertSame('TableConstraint', $plan->startRule());
-        self::assertNotNull($plan->patternAt('TableConstraint', 0));
-        self::assertNotNull($plan->patternAt('ConstraintElem', 0));
+        self::assertTrue($plan->patternAt('TableConstraint', 0)?->matches(['CONSTRAINT']) ?? false);
+        self::assertTrue($plan->patternAt('ConstraintElem', 0)?->matches(['FOREIGN', 'KEY']) ?? false);
+        self::assertTrue($plan->patternAt('opt_column_list', 0)?->matches(['column']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
@@ -23,6 +23,7 @@ use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\Grammar\TokenJoiner;
 use SqlFaker\PostgreSqlProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(SqlGenerator::class)]
 #[CoversClass(TokenJoiner::class)]
@@ -34,6 +35,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(NonTerminal::class)]
 #[CoversClass(PostgreSqlProvider::class)]
 #[CoversClass(TerminationAnalyzer::class)]
+#[UsesClass(GenerationPlan::class)]
 #[Medium]
 final class SqlGeneratorTest extends TestCase
 {

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -14,7 +14,10 @@ use SqlFaker\Grammar\Production;
 use SqlFaker\Grammar\ProductionRule;
 use SqlFaker\Grammar\Terminal;
 use SqlFaker\Grammar\TerminationAnalyzer;
+use SqlFaker\Grammar\GenerationPlan;
+use SqlFaker\Grammar\ProductionPattern;
 use SqlFaker\PostgreSql\Grammar\PgGrammar;
+use SqlFaker\PostgreSql\GenerationPlans;
 use SqlFaker\PostgreSql\LexicalGrammar;
 use SqlFaker\PostgreSql\SqlGenerator;
 use SqlFaker\PostgreSql\StatementType;
@@ -41,8 +44,11 @@ use SqlFaker\Grammar\TerminalInventory;
 #[CoversClass(StatementType::class)]
 #[CoversClass(LexicalGrammar::class)]
 #[UsesClass(LexicalCatalog::class)]
+#[UsesClass(GenerationPlan::class)]
+#[UsesClass(ProductionPattern::class)]
 #[UsesClass(SqlVersion::class)]
 #[UsesClass(TerminalInventory::class)]
+#[UsesClass(GenerationPlans::class)]
 #[Medium]
 final class PostgreSqlProviderTest extends TestCase
 {
@@ -366,6 +372,20 @@ final class PostgreSqlProviderTest extends TestCase
         $result = $provider->withClause(maxDepth: 3);
 
         self::assertStringContainsString('WITH', $result);
+    }
+
+    public function testForeignKeyConstraint(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new PostgreSqlProvider($faker, 'pg-17.2');
+
+        $result = $provider->foreignKeyConstraint(1);
+
+        self::assertSame(
+            ['CONSTRAINT', 'IDENT', 'FOREIGN', 'KEY', '(', 'IDENT', ')', 'REFERENCES', 'IDENT', '(', 'IDENT', ')'],
+            (new LexicalGrammar($faker, 'pg-17.2'))->tokenize($result),
+        );
     }
 
     public function testIdentifier(): void

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -21,7 +21,13 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::foreignKeyConstraint();
 
         self::assertSame('conslist', $plan->startRule());
-        self::assertNotNull($plan->patternAt('conslist', 0));
-        self::assertNotNull($plan->patternAt('tcons', 1));
+        self::assertTrue(
+            $plan->patternAt('conslist', 0)?->matches(['conslist', 'tconscomma', 'tcons']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('conslist', 1)?->matches(['tcons']) ?? false);
+        self::assertTrue($plan->patternAt('tcons', 0)?->matches(['CONSTRAINT']) ?? false);
+        self::assertTrue($plan->patternAt('tcons', 1)?->matches(['FOREIGN', 'KEY']) ?? false);
+        self::assertTrue($plan->patternAt('tconscomma', 0)?->matches([]) ?? false);
+        self::assertTrue($plan->patternAt('eidlist_opt', 0)?->matches(['column']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\SqlFaker\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use SqlFaker\Grammar\GenerationPlan;
+use SqlFaker\Grammar\ProductionPattern;
+use SqlFaker\Sqlite\GenerationPlans;
+
+#[CoversClass(GenerationPlans::class)]
+#[UsesClass(GenerationPlan::class)]
+#[UsesClass(ProductionPattern::class)]
+final class GenerationPlansTest extends TestCase
+{
+    public function testForeignKeyPlanRestrictsTheTableConstraintGrammar(): void
+    {
+        $plan = GenerationPlans::foreignKeyConstraint();
+
+        self::assertSame('conslist', $plan->startRule());
+        self::assertNotNull($plan->patternAt('conslist', 0));
+        self::assertNotNull($plan->patternAt('tcons', 1));
+    }
+}

--- a/packages/sql-faker/tests/Unit/Sqlite/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/SqlGeneratorTest.php
@@ -26,6 +26,7 @@ use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\Grammar\TokenJoiner;
 use SqlFaker\SqliteProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(SqlGenerator::class)]
 #[CoversClass(TokenJoiner::class)]
@@ -38,6 +39,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(SqliteProvider::class)]
 #[CoversClass(SqliteGrammar::class)]
 #[CoversClass(TerminationAnalyzer::class)]
+#[UsesClass(GenerationPlan::class)]
 #[Large]
 final class SqlGeneratorTest extends TestCase
 {

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -14,7 +14,6 @@ use SqlFaker\Grammar\Production;
 use SqlFaker\Grammar\ProductionRule;
 use SqlFaker\Grammar\Terminal;
 use SqlFaker\Grammar\TerminationAnalyzer;
-use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\ProductionPattern;
 use SqlFaker\Sqlite\LexicalGrammar;
 use SqlFaker\Sqlite\Grammar\SqliteGrammar;
@@ -45,7 +44,6 @@ use SqlFaker\Grammar\TerminalInventory;
 #[CoversClass(LexicalGrammar::class)]
 #[UsesClass(GenerationPlan::class)]
 #[UsesClass(LexicalCatalog::class)]
-#[UsesClass(GenerationPlan::class)]
 #[UsesClass(ProductionPattern::class)]
 #[UsesClass(SqlVersion::class)]
 #[UsesClass(TerminalInventory::class)]
@@ -319,17 +317,27 @@ final class SqliteProviderTest extends TestCase
 
         $result = $provider->foreignKeyConstraint(1);
 
-        self::assertSame(
-            ['CONSTRAINT', 'ID', 'FOREIGN', 'KEY', 'LP', 'ID', 'RP', 'REFERENCES', 'ID', 'LP', 'ID', 'RP'],
+        $tokens = array_map(
+            static fn (string $token): string => in_array($token, ['ID', 'STRING'], true) ? 'NAME' : $token,
             (new LexicalGrammar($faker, 'sqlite-3.47.2'))->tokenize($result),
+        );
+
+        self::assertSame(
+            ['CONSTRAINT', 'NAME', 'FOREIGN', 'KEY', 'LP', 'NAME', 'RP', 'REFERENCES', 'NAME', 'LP', 'NAME', 'RP'],
+            $tokens,
         );
 
         $faker->seed(2);
         $result = $provider->foreignKeyConstraint(20);
 
+        $tokens = array_map(
+            static fn (string $token): string => in_array($token, ['ID', 'STRING'], true) ? 'NAME' : $token,
+            (new LexicalGrammar($faker, 'sqlite-3.47.2'))->tokenize($result),
+        );
+
         self::assertSame(
-            ['CONSTRAINT', 'ID', 'FOREIGN', 'KEY'],
-            array_slice((new LexicalGrammar($faker, 'sqlite-3.47.2'))->tokenize($result), 0, 4),
+            ['CONSTRAINT', 'NAME', 'FOREIGN', 'KEY'],
+            array_slice($tokens, 0, 4),
         );
     }
 

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -14,8 +14,11 @@ use SqlFaker\Grammar\Production;
 use SqlFaker\Grammar\ProductionRule;
 use SqlFaker\Grammar\Terminal;
 use SqlFaker\Grammar\TerminationAnalyzer;
+use SqlFaker\Grammar\GenerationPlan;
+use SqlFaker\Grammar\ProductionPattern;
 use SqlFaker\Sqlite\LexicalGrammar;
 use SqlFaker\Sqlite\Grammar\SqliteGrammar;
+use SqlFaker\Sqlite\GenerationPlans;
 use SqlFaker\Sqlite\SqlGenerator;
 use SqlFaker\Sqlite\StatementType;
 use SqlFaker\Grammar\RandomStringGenerator;
@@ -42,8 +45,11 @@ use SqlFaker\Grammar\TerminalInventory;
 #[CoversClass(LexicalGrammar::class)]
 #[UsesClass(GenerationPlan::class)]
 #[UsesClass(LexicalCatalog::class)]
+#[UsesClass(GenerationPlan::class)]
+#[UsesClass(ProductionPattern::class)]
 #[UsesClass(SqlVersion::class)]
 #[UsesClass(TerminalInventory::class)]
+#[UsesClass(GenerationPlans::class)]
 final class SqliteProviderTest extends TestCase
 {
     #[\Override]
@@ -303,6 +309,28 @@ final class SqliteProviderTest extends TestCase
         $result = $provider->withClause(maxDepth: 6);
 
         self::assertMatchesRegularExpression('/^$|WITH/', $result);
+    }
+
+    public function testForeignKeyConstraint(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new SqliteProvider($faker, 'sqlite-3.47.2');
+
+        $result = $provider->foreignKeyConstraint(1);
+
+        self::assertSame(
+            ['CONSTRAINT', 'ID', 'FOREIGN', 'KEY', 'LP', 'ID', 'RP', 'REFERENCES', 'ID', 'LP', 'ID', 'RP'],
+            (new LexicalGrammar($faker, 'sqlite-3.47.2'))->tokenize($result),
+        );
+
+        $faker->seed(2);
+        $result = $provider->foreignKeyConstraint(20);
+
+        self::assertSame(
+            ['CONSTRAINT', 'ID', 'FOREIGN', 'KEY'],
+            array_slice((new LexicalGrammar($faker, 'sqlite-3.47.2'))->tokenize($result), 0, 4),
+        );
     }
 
     public function testIdentifier(): void

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -142,6 +142,7 @@ final class RewriteTarget
             fn (): string => "UPDATE orders SET created_at = created_at + INTERVAL {$this->provider->integerLiteral(1, 30)} DAY WHERE id = 1",
             fn (): string => 'UPDATE users SET status = 0 WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
             fn (): string => 'DELETE FROM users WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
+            fn (): string => "CREATE TABLE child (id INT, parent_id INT, {$this->provider->foreignKeyConstraint()})",
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -194,6 +194,7 @@ final class RobustnessTarget
             fn (): string => "UPDATE orders SET created_at = created_at + INTERVAL {$this->provider->integerLiteral(1, 30)} DAY WHERE id = 1",
             fn (): string => 'UPDATE users SET status = 0 WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
             fn (): string => 'DELETE FROM users WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
+            fn (): string => "CREATE TABLE child (id INT, parent_id INT, {$this->provider->foreignKeyConstraint()})",
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/MySqlSchemaParser.php
+++ b/packages/ztd-query-mysql/src/MySqlSchemaParser.php
@@ -56,8 +56,12 @@ final class MySqlSchemaParser implements SchemaParser
         foreach ($stmt->fields as $field) {
             $name = $field->name ?? null;
 
-            if (is_string($name) && $name !== '' && $field->type !== null) {
-                $columnName = str_replace('`', '', $name);
+            if ($field->type !== null) {
+                $columnName = $name ?? '';
+                if ($columnName === '') {
+                    continue;
+                }
+
                 $columns[] = $columnName;
 
                 if ($field->type->name !== null) {

--- a/packages/ztd-query-mysql/src/MySqlSchemaParser.php
+++ b/packages/ztd-query-mysql/src/MySqlSchemaParser.php
@@ -56,11 +56,11 @@ final class MySqlSchemaParser implements SchemaParser
         foreach ($stmt->fields as $field) {
             $name = $field->name ?? null;
 
-            if (is_string($name) && $name !== '') {
+            if (is_string($name) && $name !== '' && $field->type !== null) {
                 $columnName = str_replace('`', '', $name);
                 $columns[] = $columnName;
 
-                if ($field->type !== null && $field->type->name !== null) {
+                if ($field->type->name !== null) {
                     $typeName = strtoupper($field->type->name);
                     if ($field->type->parameters !== [] && $field->type->parameters !== null) {
                         $typeName .= '(' . implode(',', $field->type->parameters) . ')';

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
@@ -84,6 +84,48 @@ final class MySqlSchemaParserTest extends SchemaParserContractTest
         self::assertSame(['order_id', 'product_id'], $definition->primaryKeys);
     }
 
+    public function testParseDoesNotTreatNamedForeignKeyAsColumn(): void
+    {
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $sql = <<<'SQL'
+            CREATE TABLE child (
+                id INT PRIMARY KEY AUTO_INCREMENT,
+                parent_id INT NOT NULL,
+                label VARCHAR(50) NOT NULL,
+                CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent(id)
+            )
+            SQL;
+
+        $definition = $schemaParser->parse($sql);
+
+        self::assertNotNull($definition);
+        self::assertSame(['id', 'parent_id', 'label'], $definition->columns);
+        self::assertArrayNotHasKey('fk_parent', $definition->columnTypes);
+        self::assertArrayNotHasKey('fk_parent', $definition->typedColumns);
+    }
+
+    public function testParseDoesNotTreatNamedTableConstraintsAsColumns(): void
+    {
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $sql = <<<'SQL'
+            CREATE TABLE child (
+                id INT,
+                parent_id INT,
+                CONSTRAINT pk_child PRIMARY KEY (id),
+                CONSTRAINT uq_parent UNIQUE (parent_id),
+                CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent(id),
+                CONSTRAINT ck_id CHECK (id > 0)
+            )
+            SQL;
+
+        $definition = $schemaParser->parse($sql);
+
+        self::assertNotNull($definition);
+        self::assertSame(['id', 'parent_id'], $definition->columns);
+    }
+
     public function testParseUniqueConstraint(): void
     {
         $parser = new MySqlParser();

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -225,6 +225,31 @@ final class MysqliCteShadowingTest extends TestCase
         }
     }
 
+    public function testInsertWithoutColumnListIgnoresNamedForeignKeyConstraint(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $parent = 'prefix_' . bin2hex(random_bytes(8));
+        $child = 'prefix_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, name VARCHAR(50)) ENGINE=InnoDB', $parent));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, parent_id INT NOT NULL, label VARCHAR(50) NOT NULL, CONSTRAINT `fk_parent` FOREIGN KEY (parent_id) REFERENCES `%s`(id)) ENGINE=InnoDB', $child, $parent));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            self::assertNotFalse($ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (1, 'Parent')", $parent)));
+            self::assertNotFalse($ztdMysqli->query(sprintf("INSERT INTO `%s` VALUES (10, 1, 'Child')", $child)));
+
+            $result = $ztdMysqli->query(sprintf('SELECT * FROM `%s`', $child));
+            self::assertInstanceOf(\mysqli_result::class, $result);
+            self::assertSame([['id' => 10, 'parent_id' => 1, 'label' => 'Child']], $result->fetch_all(MYSQLI_ASSOC));
+
+            $physical = $rawMysqli->query(sprintf('SELECT * FROM `%s`', $child));
+            self::assertInstanceOf(\mysqli_result::class, $physical);
+            self::assertSame([], $physical->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
     public function testSelfReferencingUpsertMatchesNativeMySql(): void
     {
         [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/ForeignKeySchemaTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/ForeignKeySchemaTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class ForeignKeySchemaTest extends TestCase
+{
+    public function testInsertWithoutColumnListIgnoresNamedForeignKeyConstraint(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $parent = 'prefix_' . bin2hex(random_bytes(8));
+        $child = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$parent}` (id INT PRIMARY KEY, name VARCHAR(50)) ENGINE=InnoDB");
+            $rawPdo->exec("CREATE TABLE `{$child}` (id INT PRIMARY KEY, parent_id INT NOT NULL, label VARCHAR(50) NOT NULL, CONSTRAINT `fk_parent` FOREIGN KEY (parent_id) REFERENCES `{$parent}`(id)) ENGINE=InnoDB");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$parent}` VALUES (1, 'Parent')");
+
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO `{$child}` VALUES (10, 1, 'Child')"));
+
+            $statement = $ztdPdo->query("SELECT * FROM `{$child}`");
+            self::assertNotFalse($statement);
+            self::assertSame([['id' => 10, 'parent_id' => 1, 'label' => 'Child']], $statement->fetchAll(PDO::FETCH_ASSOC));
+
+            $physical = $rawPdo->query("SELECT * FROM `{$child}`");
+            self::assertNotFalse($physical);
+            self::assertSame([], $physical->fetchAll(PDO::FETCH_ASSOC));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- classify MySQL CREATE TABLE fields by the parser AST data-type discriminator so named table constraints are never exposed as columns
- generate named foreign-key constraints from the official MySQL, PostgreSQL, and SQLite grammars
- expose `foreignKeyConstraint()` as an individual public method on all three Providers
- add parser and real MySQL PDO/MySQLi regression coverage for INSERT without a column list

## Root cause and prevention

`MySqlSchemaParser` previously accepted every named CREATE TABLE field as a column. phpmyadmin/sql-parser represents named table constraints as fields too, but unlike real columns they have no `DataType`. The parser now uses that typed AST distinction rather than matching constraint names or SQL text.

Providers remain public facades only: each `foreignKeyConstraint()` delegates generation to its dialect `SqlGenerator`. The generators constrain official grammar productions through the shared `DerivationPlan` / `ProductionPattern` mechanism, instead of interpolating SQL in a Provider. No `MySqlGenerationTarget` parameter or other generic target-enum API is exposed; each supported unit remains an explicit Provider method.

SQLFaker and both MySQL fuzz targets now cover this previously absent construct. SQLite tests normalize both grammar-valid name token forms (`ID` and `STRING`) while still asserting the complete foreign-key structure.

## Verification

- MySQL: 985 unit tests / 2,414 assertions; lint and PHPStan
- SQLFaker: 1,070 unit tests / 1,884 assertions; lint and PHPStan
- MySQL rewrite fuzz: 500 runs; robustness fuzz: 500 runs
- focused SQLFaker Infection: 51/51 relevant mutants killed
- PDO/MySQLi real-MySQL regression tests

## Stack

- depends on #246

Fixes #127