### PR TITLE
fix(mysql): preserve derived update sources

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -72,6 +72,28 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function updateJoinDerivedStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('update_stmt', [
+            'opt_with_clause' => [ProductionPattern::exactly()],
+            'table_reference' => [
+                ProductionPattern::exactly('joined_table'),
+                ProductionPattern::exactly('table_factor'),
+                ProductionPattern::exactly('table_factor'),
+                ProductionPattern::exactly('table_factor'),
+            ],
+            'joined_table' => [ProductionPattern::containing('ON_SYM')],
+            'table_factor' => [
+                ProductionPattern::exactly('single_table'),
+                ProductionPattern::exactly('derived_table'),
+                ProductionPattern::exactly('single_table'),
+            ],
+            'opt_from_clause' => [ProductionPattern::nonEmpty()],
+            'opt_group_clause' => [ProductionPattern::nonEmpty()],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -670,13 +670,10 @@ final class MySqlProvider extends Base
      *
      * @return non-empty-string
      */
-    public function updateJoinDerivedStatement(): string
+    public function updateJoinDerivedStatement(int $maxDepth = 40): string
     {
-        $target = $this->rsg->rawIdentifier();
-        $source = $this->rsg->rawIdentifier();
-        $groupColumn = $this->rsg->rawIdentifier();
-        $valueColumn = $this->rsg->rawIdentifier();
-
-        return "UPDATE $target AS t JOIN (SELECT $groupColumn, COUNT(*) AS aggregate_value FROM $source GROUP BY $groupColumn) AS s ON t.$groupColumn = s.$groupColumn SET t.$valueColumn = s.aggregate_value";
+        return $this->sql->generate(
+            GenerationPlans::updateJoinDerivedStatement()->withMaxDepth($maxDepth),
+        );
     }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -664,4 +664,19 @@ final class MySqlProvider extends Base
             GenerationPlans::foreignKeyConstraint($this->grammar)->withMaxDepth($maxDepth),
         );
     }
+
+    /**
+     * Generate an UPDATE whose joined source is a derived aggregate query.
+     *
+     * @return non-empty-string
+     */
+    public function updateJoinDerivedStatement(): string
+    {
+        $target = $this->rsg->rawIdentifier();
+        $source = $this->rsg->rawIdentifier();
+        $groupColumn = $this->rsg->rawIdentifier();
+        $valueColumn = $this->rsg->rawIdentifier();
+
+        return "UPDATE $target AS t JOIN (SELECT $groupColumn, COUNT(*) AS aggregate_value FROM $source GROUP BY $groupColumn) AS s ON t.$groupColumn = s.$groupColumn SET t.$valueColumn = s.aggregate_value";
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -122,4 +122,22 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($legacy->patternAt('opt_ident', 0)?->matches(['ident']) ?? false);
         self::assertTrue($legacy->patternAt('opt_ref_list', 0)?->matches(['reference']) ?? false);
     }
+
+    public function testJoinedUpdatePlanRestrictsTheDerivedTableGrammar(): void
+    {
+        $plan = GenerationPlans::updateJoinDerivedStatement();
+
+        self::assertSame('update_stmt', $plan->startRule());
+        self::assertTrue($plan->patternAt('opt_with_clause', 0)?->matches([]) ?? false);
+        self::assertTrue($plan->patternAt('table_reference', 0)?->matches(['joined_table']) ?? false);
+        self::assertTrue($plan->patternAt('table_reference', 1)?->matches(['table_factor']) ?? false);
+        self::assertTrue($plan->patternAt('table_reference', 2)?->matches(['table_factor']) ?? false);
+        self::assertTrue($plan->patternAt('table_reference', 3)?->matches(['table_factor']) ?? false);
+        self::assertTrue($plan->patternAt('joined_table', 0)?->matches(['ON_SYM']) ?? false);
+        self::assertTrue($plan->patternAt('table_factor', 0)?->matches(['single_table']) ?? false);
+        self::assertTrue($plan->patternAt('table_factor', 1)?->matches(['derived_table']) ?? false);
+        self::assertTrue($plan->patternAt('table_factor', 2)?->matches(['single_table']) ?? false);
+        self::assertTrue($plan->patternAt('opt_from_clause', 0)?->matches(['table_reference_list']) ?? false);
+        self::assertTrue($plan->patternAt('opt_group_clause', 0)?->matches(['GROUP_SYM']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -522,18 +522,28 @@ final class MySqlProviderTest extends TestCase
         );
     }
 
-    public function testUpdateJoinDerivedStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testUpdateJoinDerivedStatement(int $seed): void
     {
         $faker = Factory::create();
-        $faker->seed(12345);
+        $faker->seed($seed);
         $provider = new MySqlProvider($faker);
+        $sql = $provider->updateJoinDerivedStatement();
+        $faker->seed($seed);
 
-        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($provider->updateJoinDerivedStatement());
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($sql);
+        $joinTokens = array_intersect($tokens, ['JOIN_SYM', 'STRAIGHT_JOIN']);
+        $join = array_key_first($joinTokens);
+        $select = array_search('SELECT_SYM', $tokens, true);
 
+        self::assertSame($sql, $provider->updateJoinDerivedStatement(40));
         self::assertSame('UPDATE_SYM', $tokens[0]);
-        self::assertContains('JOIN_SYM', $tokens);
-        self::assertContains('SELECT_SYM', $tokens);
+        self::assertIsInt($join);
+        self::assertIsInt($select);
+        self::assertGreaterThan($join, $select);
+        self::assertContains('FROM', $tokens);
         self::assertContains('GROUP_SYM', $tokens);
+        self::assertContains('ON_SYM', $tokens);
         self::assertContains('SET_SYM', $tokens);
     }
 
@@ -1074,5 +1084,15 @@ final class MySqlProviderTest extends TestCase
         yield 'MySQL 8.4' => ['mysql-8.4.7'];
         yield 'MySQL 9.0' => ['mysql-9.0.1'];
         yield 'MySQL 9.1' => ['mysql-9.1.0'];
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function providerTargetedGenerationSeed(): iterable
+    {
+        foreach (range(0, 15) as $seed) {
+            yield "seed {$seed}" => [$seed];
+        }
     }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -522,6 +522,21 @@ final class MySqlProviderTest extends TestCase
         );
     }
 
+    public function testUpdateJoinDerivedStatement(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new MySqlProvider($faker);
+
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($provider->updateJoinDerivedStatement());
+
+        self::assertSame('UPDATE_SYM', $tokens[0]);
+        self::assertContains('JOIN_SYM', $tokens);
+        self::assertContains('SELECT_SYM', $tokens);
+        self::assertContains('GROUP_SYM', $tokens);
+        self::assertContains('SET_SYM', $tokens);
+    }
+
     public function testBinaryLiteral(): void
     {
         $faker = Factory::create();

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -143,6 +143,7 @@ final class RewriteTarget
             fn (): string => 'UPDATE users SET status = 0 WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
             fn (): string => 'DELETE FROM users WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
             fn (): string => "CREATE TABLE child (id INT, parent_id INT, {$this->provider->foreignKeyConstraint()})",
+            fn (): string => $this->provider->updateJoinDerivedStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -195,6 +195,7 @@ final class RobustnessTarget
             fn (): string => 'UPDATE users SET status = 0 WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
             fn (): string => 'DELETE FROM users WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
             fn (): string => "CREATE TABLE child (id INT, parent_id INT, {$this->provider->foreignKeyConstraint()})",
+            fn (): string => $this->provider->updateJoinDerivedStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -10,11 +10,12 @@ use PhpMyAdmin\SqlParser\Components\Limit;
 use PhpMyAdmin\SqlParser\Components\OrderKeyword;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
-use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\UpdateAssignmentExtractor;
+use ZtdQuery\Platform\MySql\UpdateSourceExtractor;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\Mutation\MultiTableMutationRow;
@@ -71,6 +72,7 @@ final class UpdateTransformer implements SqlTransformer
         $primaryKeys = $tables[$targetTable]['primaryKeys'] ?? [];
         $assignmentValues = (new UpdateAssignmentExtractor())->values($sql);
         $whereExpression = (new DmlWhereClauseExtractor())->extract($sql);
+        $sourceExpression = (new UpdateSourceExtractor())->extract($sql);
         $projection = $this->buildProjection(
             $statement,
             $columns,
@@ -78,6 +80,7 @@ final class UpdateTransformer implements SqlTransformer
             [],
             $assignmentValues,
             $whereExpression,
+            $sourceExpression,
         );
         $targetTableNames = array_keys($projection['tables']);
         if (isset($targetTableNames[1])) {
@@ -89,6 +92,7 @@ final class UpdateTransformer implements SqlTransformer
                 $targets,
                 $assignmentValues,
                 $whereExpression,
+                $sourceExpression,
             );
         }
 
@@ -115,6 +119,7 @@ final class UpdateTransformer implements SqlTransformer
         array $targets = [],
         array $assignmentValues = [],
         ?string $whereExpression = null,
+        ?string $sourceExpression = null,
     ): array {
         if ($stmt->tables === null || $stmt->tables === []) {
             throw new \RuntimeException("Update statement has no tables?");
@@ -205,11 +210,12 @@ final class UpdateTransformer implements SqlTransformer
             $limitClause = " LIMIT " . Limit::build($stmt->limit);
         }
 
+        $sourceClause = $sourceExpression ?? "`$targetTableName`$aliasClause$additionalTables$joinClause";
         if ($additionalTables === '' && $joinClause === '' && ($orderByClause !== '' || $limitClause !== '')) {
-            $selectedRows = "SELECT * FROM `$targetTableName`$aliasClause$whereClause$orderByClause$limitClause";
+            $selectedRows = "SELECT * FROM $sourceClause$whereClause$orderByClause$limitClause";
             $sql = "SELECT $selectList FROM ($selectedRows) AS `$qualifier`";
         } else {
-            $sql = "SELECT $selectList FROM `$targetTableName`$aliasClause$additionalTables$joinClause$whereClause$orderByClause$limitClause";
+            $sql = "SELECT $selectList FROM $sourceClause$whereClause$orderByClause$limitClause";
         }
 
         return ['sql' => $sql, 'table' => $targetTableName, 'tables' => $allTargetTables];

--- a/packages/ztd-query-mysql/src/UpdateSourceExtractor.php
+++ b/packages/ztd-query-mysql/src/UpdateSourceExtractor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class UpdateSourceExtractor
+{
+    public function extract(string $sql): ?string
+    {
+        $source = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->topLevelClause(
+            ['UPDATE'],
+            [['SET']],
+        );
+        if ($source === null || $source === '') {
+            return null;
+        }
+
+        foreach (SqlTokenStream::tokenize($source, SqlTokenDialect::MySql)->significantTokens() as $token) {
+            if ($token->isKeyword('LOW_PRIORITY') || $token->isKeyword('IGNORE')) {
+                continue;
+            }
+
+            return trim(substr($source, $token->offset));
+        }
+
+        return null;
+    }
+}

--- a/packages/ztd-query-mysql/src/UpdateSourceExtractor.php
+++ b/packages/ztd-query-mysql/src/UpdateSourceExtractor.php
@@ -24,7 +24,7 @@ final class UpdateSourceExtractor
                 continue;
             }
 
-            return trim(substr($source, $token->offset));
+            return substr($source, $token->offset);
         }
 
         return null;

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlSchemaParser;
+use ZtdQuery\Platform\MySql\UpdateSourceExtractor;
 use ZtdQuery\Platform\MySql\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
@@ -44,6 +45,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(DmlWhereClauseExtractor::class)]
+#[UsesClass(UpdateSourceExtractor::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -23,6 +23,7 @@ use ZtdQuery\Platform\MySql\Transformer\ReplaceTransformer;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 use ZtdQuery\Platform\MySql\UpdateAssignmentExtractor;
+use ZtdQuery\Platform\MySql\UpdateSourceExtractor;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -56,6 +57,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\MySqlSelectListAliaser::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(UpdateAssignmentExtractor::class)]
+#[UsesClass(UpdateSourceExtractor::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(DmlWhereClauseExtractor::class)]
 #[UsesClass(ReplaceTransformer::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
@@ -11,6 +11,7 @@ use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
+use ZtdQuery\Platform\MySql\UpdateSourceExtractor;
 use ZtdQuery\Platform\MySql\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\MySql\Transformer\InsertTransformer;
 use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
@@ -29,6 +30,7 @@ use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(DmlWhereClauseExtractor::class)]
+#[UsesClass(UpdateSourceExtractor::class)]
 #[UsesClass(ReplaceTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -11,6 +11,7 @@ use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 use ZtdQuery\Platform\MySql\UpdateAssignmentExtractor;
+use ZtdQuery\Platform\MySql\UpdateSourceExtractor;
 use PhpMyAdmin\SqlParser\Parser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -24,11 +25,36 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(DmlWhereClauseExtractor::class)]
 #[UsesClass(UpdateAssignmentExtractor::class)]
+#[UsesClass(UpdateSourceExtractor::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class UpdateTransformerTest extends TestCase
 {
+    public function testBuildProjectionPreservesDerivedJoinSource(): void
+    {
+        $sql = 'UPDATE summary s JOIN (SELECT category, COUNT(*) AS cnt, MIN(price) AS mn FROM products GROUP BY category) p ON s.category = p.category SET s.min_price = p.mn, s.item_count = p.cnt';
+        $parser = new Parser($sql);
+        $statement = $parser->statements[0];
+        self::assertInstanceOf(\PhpMyAdmin\SqlParser\Statements\UpdateStatement::class, $statement);
+        $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
+
+        $result = $transformer->buildProjection(
+            $statement,
+            ['id', 'category', 'min_price', 'item_count'],
+            ['id'],
+            [],
+            ['p.mn', 'p.cnt'],
+            null,
+            (new UpdateSourceExtractor())->extract($sql),
+        );
+
+        self::assertSame(
+            'SELECT p.mn AS `min_price`, p.cnt AS `item_count`, `s`.`id`, `s`.`category`, `s`.`id` AS `__ztd_original_id` FROM summary s JOIN (SELECT category, COUNT(*) AS cnt, MIN(price) AS mn FROM products GROUP BY category) p ON s.category = p.category',
+            $result['sql'],
+        );
+    }
+
     public function testTransformPreservesIntroducedHexLiteral(): void
     {
         $transformer = new UpdateTransformer(new MySqlParser(), new SelectTransformer());
@@ -744,7 +770,7 @@ final class UpdateTransformerTest extends TestCase
         $result = $transformer->transform($sql, $tables);
         self::assertSame(
             'WITH `users` AS (SELECT CAST(1 AS SIGNED) AS `id`, CAST(' . "'" . 'Alice' . "'" . ' AS CHAR) AS `name`)' . "\n"
-            . "SELECT 'Bob' AS `name`, `users`.`id` FROM `users` WHERE id = 1",
+            . "SELECT 'Bob' AS `name`, `users`.`id` FROM users WHERE id = 1",
             $result
         );
     }
@@ -764,7 +790,7 @@ final class UpdateTransformerTest extends TestCase
         $result = $transformer->transform($sql, $tables);
         self::assertSame(
             'WITH `users` AS (SELECT CAST(NULL AS CHAR) AS `id`, CAST(NULL AS CHAR) AS `name` FROM DUAL WHERE 0)' . "\n"
-            . "SELECT 'Bob' AS `name`, `users`.`id` FROM `users` WHERE id = 1",
+            . "SELECT 'Bob' AS `name`, `users`.`id` FROM users WHERE id = 1",
             $result
         );
     }

--- a/packages/ztd-query-mysql/tests/Unit/UpdateSourceExtractorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/UpdateSourceExtractorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\UpdateSourceExtractor;
+
+#[CoversClass(UpdateSourceExtractor::class)]
+final class UpdateSourceExtractorTest extends TestCase
+{
+    #[DataProvider('providerSources')]
+    public function testExtract(string $sql, ?string $expected): void
+    {
+        self::assertSame($expected, (new UpdateSourceExtractor())->extract($sql));
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null}>
+     */
+    public static function providerSources(): iterable
+    {
+        yield 'derived join' => [
+            'UPDATE summary s JOIN (SELECT category, COUNT(*) AS cnt FROM products GROUP BY category) p ON s.category = p.category SET s.item_count = p.cnt',
+            'summary s JOIN (SELECT category, COUNT(*) AS cnt FROM products GROUP BY category) p ON s.category = p.category',
+        ];
+        yield 'window expression and nested set token' => [
+            "UPDATE rankings r JOIN (SELECT player, DENSE_RANK() OVER (ORDER BY MAX(score) DESC) AS ranking, 'SET' AS marker FROM scores GROUP BY player) s ON r.player = s.player SET r.rank_pos = s.ranking",
+            "rankings r JOIN (SELECT player, DENSE_RANK() OVER (ORDER BY MAX(score) DESC) AS ranking, 'SET' AS marker FROM scores GROUP BY player) s ON r.player = s.player",
+        ];
+        yield 'modifiers and comments' => [
+            'UPDATE /* before */ LOW_PRIORITY /* middle */ IGNORE /* source */ users AS u SET u.active = 1',
+            'users AS u',
+        ];
+        yield 'quoted modifier name' => [
+            'UPDATE `ignore` SET value = 1',
+            '`ignore`',
+        ];
+        yield 'not update' => ['SELECT 1', null];
+        yield 'missing source' => ['UPDATE SET value = 1', null];
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpdateDerivedSourceTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpdateDerivedSourceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class UpdateDerivedSourceTest extends TestCase
+{
+    public function testUpdateJoinPreservesDerivedAggregateSource(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $products = 'prefix_' . bin2hex(random_bytes(8));
+        $summary = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$products}` (id INT PRIMARY KEY, category VARCHAR(50), price DECIMAL(10,2))");
+            $rawPdo->exec("CREATE TABLE `{$summary}` (id INT PRIMARY KEY, category VARCHAR(50), min_price DECIMAL(10,2), item_count INT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$products}` VALUES (1, 'electronics', 99.99), (2, 'electronics', 199.99), (3, 'books', 20.00)");
+            $ztdPdo->exec("INSERT INTO `{$summary}` VALUES (1, 'electronics', NULL, NULL), (2, 'books', NULL, NULL)");
+
+            self::assertSame(2, $ztdPdo->exec("UPDATE `{$summary}` AS s JOIN (SELECT category, COUNT(*) AS cnt, MIN(price) AS mn FROM `{$products}` GROUP BY category) AS p ON s.category = p.category SET s.min_price = p.mn, s.item_count = p.cnt"));
+
+            $statement = $ztdPdo->query("SELECT id, category, min_price, item_count FROM `{$summary}` ORDER BY id");
+            self::assertNotFalse($statement);
+            self::assertSame([
+                ['id' => 1, 'category' => 'electronics', 'min_price' => '99.99', 'item_count' => 2],
+                ['id' => 2, 'category' => 'books', 'min_price' => '20.00', 'item_count' => 1],
+            ], $statement->fetchAll(PDO::FETCH_ASSOC));
+
+            $physical = $rawPdo->query("SELECT * FROM `{$summary}`");
+            self::assertNotFalse($physical);
+            self::assertSame([], $physical->fetchAll(PDO::FETCH_ASSOC));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+
+    public function testUpdateJoinPreservesWindowedDerivedSource(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $scores = 'prefix_' . bin2hex(random_bytes(8));
+        $rankings = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$scores}` (id INT PRIMARY KEY, player VARCHAR(30), score INT)");
+            $rawPdo->exec("CREATE TABLE `{$rankings}` (id INT PRIMARY KEY, player VARCHAR(30), rank_pos INT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$scores}` VALUES (1, 'Alice', 100), (2, 'Alice', 150), (3, 'Bob', 200)");
+            $ztdPdo->exec("INSERT INTO `{$rankings}` VALUES (1, 'Alice', NULL), (2, 'Bob', NULL)");
+
+            self::assertSame(2, $ztdPdo->exec("UPDATE `{$rankings}` AS r JOIN (SELECT player, DENSE_RANK() OVER (ORDER BY MAX(score) DESC) AS ranking FROM `{$scores}` GROUP BY player) AS s ON r.player = s.player SET r.rank_pos = s.ranking"));
+
+            $statement = $ztdPdo->query("SELECT player, rank_pos FROM `{$rankings}` ORDER BY player");
+            self::assertNotFalse($statement);
+            self::assertSame([
+                ['player' => 'Alice', 'rank_pos' => 2],
+                ['player' => 'Bob', 'rank_pos' => 1],
+            ], $statement->fetchAll(PDO::FETCH_ASSOC));
+
+            $physical = $rawPdo->query("SELECT * FROM `{$rankings}`");
+            self::assertNotFalse($physical);
+            self::assertSame([], $physical->fetchAll(PDO::FETCH_ASSOC));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the complete MySQL UPDATE source between the top-level UPDATE and SET tokens
- stop rebuilding derived JOIN sources as quoted identifiers from the lossy parser AST
- support aggregate and window-function derived sources through the shared PDO/MySQLi transformer

## Root cause and prevention

phpmyadmin/sql-parser exposes a derived JOIN expression through the same field used for table names. `UpdateTransformer` quoted that field as an identifier, producing `JOIN `(SELECT ...)``. A dedicated lossless `UpdateSourceExtractor` now owns UPDATE source structure, including nested SELECT/SET tokens and UPDATE modifiers. SQLFaker generates derived UPDATE JOIN statements and both MySQL robustness targets have an explicit branch for them.

## Verification

- MySQL: 987 unit tests; lint/PHPStan
- SQLFaker: 1054 unit tests; lint/PHPStan
- real MySQL PDO aggregate and DENSE_RANK regressions, with physical isolation assertions
- dedicated rewrite/robustness Fuzz branches
- changed-line Infection: 2/2 killed

## Stack

- depends on #247

Fixes #104
Fixes #115