### PR TITLE
fix(mysql): preserve compound insert sources

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -94,6 +94,23 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function insertSelectCompoundStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('insert_stmt', [
+            'insert_stmt' => [ProductionPattern::containing('insert_query_expression')],
+            'query_expression_body' => [
+                ProductionPattern::containing('UNION_SYM'),
+                ProductionPattern::exactly('query_primary'),
+                ProductionPattern::exactly('query_primary'),
+            ],
+            'query_primary' => [
+                ProductionPattern::exactly('query_specification'),
+            ],
+            'union_option' => [ProductionPattern::exactly('ALL')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -676,4 +676,19 @@ final class MySqlProvider extends Base
             GenerationPlans::updateJoinDerivedStatement()->withMaxDepth($maxDepth),
         );
     }
+
+    /**
+     * Generate an INSERT whose source is a compound SELECT.
+     *
+     * @return non-empty-string
+     */
+    public function insertSelectCompoundStatement(): string
+    {
+        $target = $this->rsg->rawIdentifier();
+        $left = $this->rsg->rawIdentifier();
+        $right = $this->rsg->rawIdentifier();
+        $column = $this->rsg->rawIdentifier();
+
+        return "INSERT INTO $target ($column) SELECT $column FROM $left UNION ALL SELECT $column FROM $right";
+    }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -682,13 +682,10 @@ final class MySqlProvider extends Base
      *
      * @return non-empty-string
      */
-    public function insertSelectCompoundStatement(): string
+    public function insertSelectCompoundStatement(int $maxDepth = 40): string
     {
-        $target = $this->rsg->rawIdentifier();
-        $left = $this->rsg->rawIdentifier();
-        $right = $this->rsg->rawIdentifier();
-        $column = $this->rsg->rawIdentifier();
-
-        return "INSERT INTO $target ($column) SELECT $column FROM $left UNION ALL SELECT $column FROM $right";
+        return $this->sql->generate(
+            GenerationPlans::insertSelectCompoundStatement()->withMaxDepth($maxDepth),
+        );
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -140,4 +140,17 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('opt_from_clause', 0)?->matches(['table_reference_list']) ?? false);
         self::assertTrue($plan->patternAt('opt_group_clause', 0)?->matches(['GROUP_SYM']) ?? false);
     }
+
+    public function testCompoundInsertPlanRestrictsTheUnionGrammar(): void
+    {
+        $plan = GenerationPlans::insertSelectCompoundStatement();
+
+        self::assertSame('insert_stmt', $plan->startRule());
+        self::assertTrue($plan->patternAt('insert_stmt', 0)?->matches(['insert_query_expression']) ?? false);
+        self::assertTrue($plan->patternAt('query_expression_body', 0)?->matches(['UNION_SYM']) ?? false);
+        self::assertTrue($plan->patternAt('query_expression_body', 1)?->matches(['query_primary']) ?? false);
+        self::assertTrue($plan->patternAt('query_expression_body', 2)?->matches(['query_primary']) ?? false);
+        self::assertTrue($plan->patternAt('query_primary', 0)?->matches(['query_specification']) ?? false);
+        self::assertTrue($plan->patternAt('union_option', 0)?->matches(['ALL']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -547,19 +547,25 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('SET_SYM', $tokens);
     }
 
-    public function testInsertSelectCompoundStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testInsertSelectCompoundStatement(int $seed): void
     {
         $faker = Factory::create();
-        $faker->seed(12345);
+        $faker->seed($seed);
         $provider = new MySqlProvider($faker);
+        $sql = $provider->insertSelectCompoundStatement();
+        $faker->seed($seed);
 
-        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($provider->insertSelectCompoundStatement());
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($sql);
 
+        self::assertSame($sql, $provider->insertSelectCompoundStatement(40));
         self::assertSame('INSERT_SYM', $tokens[0]);
-        self::assertContains('INTO', $tokens);
         self::assertContains('UNION_SYM', $tokens);
         self::assertContains('ALL', $tokens);
-        self::assertSame(2, count(array_filter($tokens, static fn (string $token): bool => $token === 'SELECT_SYM')));
+        self::assertGreaterThanOrEqual(
+            2,
+            count(array_filter($tokens, static fn (string $token): bool => $token === 'SELECT_SYM')),
+        );
     }
 
     public function testBinaryLiteral(): void

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -547,6 +547,21 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('SET_SYM', $tokens);
     }
 
+    public function testInsertSelectCompoundStatement(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new MySqlProvider($faker);
+
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($provider->insertSelectCompoundStatement());
+
+        self::assertSame('INSERT_SYM', $tokens[0]);
+        self::assertContains('INTO', $tokens);
+        self::assertContains('UNION_SYM', $tokens);
+        self::assertContains('ALL', $tokens);
+        self::assertSame(2, count(array_filter($tokens, static fn (string $token): bool => $token === 'SELECT_SYM')));
+    }
+
     public function testBinaryLiteral(): void
     {
         $faker = Factory::create();

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -144,6 +144,7 @@ final class RewriteTarget
             fn (): string => 'DELETE FROM users WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
             fn (): string => "CREATE TABLE child (id INT, parent_id INT, {$this->provider->foreignKeyConstraint()})",
             fn (): string => $this->provider->updateJoinDerivedStatement(),
+            fn (): string => $this->provider->insertSelectCompoundStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -196,6 +196,7 @@ final class RobustnessTarget
             fn (): string => 'DELETE FROM users WHERE CASE WHEN id > 1 THEN 1 ELSE 0 END = 1',
             fn (): string => "CREATE TABLE child (id INT, parent_id INT, {$this->provider->foreignKeyConstraint()})",
             fn (): string => $this->provider->updateJoinDerivedStatement(),
+            fn (): string => $this->provider->insertSelectCompoundStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/InsertSelectSourceExtractor.php
+++ b/packages/ztd-query-mysql/src/InsertSelectSourceExtractor.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class InsertSelectSourceExtractor
+{
+    public function extract(string $sql): ?string
+    {
+        $selectBody = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->topLevelClause(
+            ['SELECT'],
+            [['ON', 'DUPLICATE', 'KEY', 'UPDATE'], ['RETURNING']],
+        );
+        if ($selectBody === null || $selectBody === '') {
+            return null;
+        }
+
+        return 'SELECT ' . $selectBody;
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlParser.php
+++ b/packages/ztd-query-mysql/src/MySqlParser.php
@@ -7,6 +7,8 @@ namespace ZtdQuery\Platform\MySql;
 use PhpMyAdmin\SqlParser\Lexer;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statement;
+use PhpMyAdmin\SqlParser\Statements\InsertStatement;
+use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use PhpMyAdmin\SqlParser\Token;
 use ZtdQuery\Sql\SqlTokenStream;
 use ZtdQuery\Sql\SqlTokenDialect;
@@ -45,6 +47,28 @@ final class MySqlParser
     public function splitStatements(string $sql): array
     {
         return SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->splitStatements();
+    }
+
+    public function parseSingleLogicalStatement(string $sql): ?Statement
+    {
+        if (count($this->splitStatements($sql)) !== 1) {
+            return null;
+        }
+
+        $statements = $this->parse($sql);
+        $first = $statements[0] ?? null;
+        foreach (array_slice($statements, 1) as $continuation) {
+            if (!$first instanceof SelectStatement
+                && (!$first instanceof InsertStatement || $first->select === null)
+            ) {
+                return null;
+            }
+            if (!$continuation instanceof SelectStatement || $continuation->into !== null) {
+                return null;
+            }
+        }
+
+        return $first;
     }
 
     private function normalizeOptionalInsertInto(string $sql): string

--- a/packages/ztd-query-mysql/src/MySqlQueryGuard.php
+++ b/packages/ztd-query-mysql/src/MySqlQueryGuard.php
@@ -37,20 +37,10 @@ final class MySqlQueryGuard
         if (MySqlReadOnlyDiagnosticStatement::isSafe($sql)) {
             return QueryKind::READ;
         }
-        if (count($this->parser->splitStatements($sql)) !== 1) {
+        $statement = $this->parser->parseSingleLogicalStatement($sql);
+        if ($statement === null) {
             return null;
         }
-
-        $statements = $this->parser->parse($sql);
-        if ($statements === []) {
-            return null;
-        }
-
-        if (count($statements) > 1) {
-            return $this->classifyCompositeRead($statements);
-        }
-
-        $statement = $statements[0];
         if ($statement instanceof WithStatement) {
             $kind = $this->classifyWithFallback($sql);
             if ($kind !== null) {
@@ -59,22 +49,6 @@ final class MySqlQueryGuard
         }
 
         return $this->classifyStatement($statement);
-    }
-
-    /**
-     * phpmyadmin/sql-parser represents some single set expressions as several SELECT statements.
-     *
-     * @param list<Statement> $statements
-     */
-    private function classifyCompositeRead(array $statements): ?QueryKind
-    {
-        foreach ($statements as $statement) {
-            if (!$statement instanceof SelectStatement || $statement->into !== null) {
-                return null;
-            }
-        }
-
-        return QueryKind::READ;
     }
 
     /**

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -14,7 +14,6 @@ use ZtdQuery\Rewrite\RewriteStateCommitter;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Sql\TransactionStatement;
 use PhpMyAdmin\SqlParser\Statement;
-use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
@@ -80,16 +79,12 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
             return new RewritePlan($sql, QueryKind::READ);
         }
 
-        $statements = $this->parser->parse($sql);
-        if ($statements === []) {
+        $statement = $this->parser->parseSingleLogicalStatement($sql);
+        if ($statement === null) {
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
         }
 
-        if (count($statements) === 1) {
-            return $this->rewriteStatement($statements[0], $sql);
-        }
-
-        return $this->rewriteCompositeRead($statements, $sql);
+        return $this->rewriteStatement($statement, $sql);
     }
 
     /**
@@ -117,32 +112,6 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
     public function commitRewriteState(): void
     {
         $this->transformer->commitRewriteState();
-    }
-
-    /**
-     * phpmyadmin/sql-parser represents EXCEPT, INTERSECT, and some nested EXISTS
-     * expressions as several SELECT statements even though the SQL has one statement.
-     *
-     * @param list<Statement> $statements
-     */
-    private function rewriteCompositeRead(array $statements, string $sql): RewritePlan
-    {
-        foreach ($statements as $statement) {
-            if (!$statement instanceof SelectStatement || $statement->into !== null) {
-                throw new UnsupportedSqlException($sql, 'Statement type not supported');
-            }
-        }
-        if ($this->hasSchemaContext()) {
-            $unknownTable = $this->findUnknownTable($sql);
-            if ($unknownTable !== null) {
-                throw new UnknownSchemaException($sql, $unknownTable, 'table');
-            }
-        }
-
-        return new RewritePlan(
-            $this->transformer->transform($sql, $this->buildTableContext()),
-            QueryKind::READ,
-        );
     }
 
     private function rewriteStatement(Statement $statement, string $sql): RewritePlan

--- a/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/InsertTransformer.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\SqlParser\Statements\InsertStatement;
 use RuntimeException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CastRenderer;
+use ZtdQuery\Platform\MySql\InsertSelectSourceExtractor;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
@@ -17,6 +18,7 @@ use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
+use ZtdQuery\Sql\SqlTokenDialect;
 
 /**
  * Transforms INSERT statements into SELECT queries that return the inserted rows.
@@ -79,6 +81,7 @@ final class InsertTransformer implements SqlTransformer
         $columnDefaults = $tables[$tableName]['columnDefaults'] ?? [];
         $identityStrategies = $tables[$tableName]['identityStrategies'] ?? [];
         $existingRows = $tables[$tableName]['rows'] ?? [];
+        $sourceSelectSql = (new InsertSelectSourceExtractor())->extract($sql);
         $selectSql = $this->buildInsertSelect(
             $statement,
             $tableName,
@@ -88,6 +91,7 @@ final class InsertTransformer implements SqlTransformer
             $columnDefaults,
             $identityStrategies,
             $existingRows,
+            $sourceSelectSql,
         );
 
         return $this->selectTransformer->transform(
@@ -118,6 +122,7 @@ final class InsertTransformer implements SqlTransformer
         array $columnDefaults,
         array $identityStrategies,
         array $existingRows,
+        ?string $sourceSelectSql,
     ): string {
         if ($statement->values !== null && $statement->values !== []) {
             $rows = [];
@@ -159,7 +164,7 @@ final class InsertTransformer implements SqlTransformer
             );
 
             return $this->insertSelectRenderer->render(
-                $statement->select->build(),
+                $sourceSelectSql ?? $statement->select->build(),
                 $tableColumns,
                 $sourceColumns,
                 $columnDefaults,

--- a/packages/ztd-query-mysql/tests/Unit/InsertSelectSourceExtractorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/InsertSelectSourceExtractorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\InsertSelectSourceExtractor;
+
+#[CoversClass(InsertSelectSourceExtractor::class)]
+final class InsertSelectSourceExtractorTest extends TestCase
+{
+    #[DataProvider('providerSources')]
+    public function testExtract(string $sql, ?string $expected): void
+    {
+        self::assertSame($expected, (new InsertSelectSourceExtractor())->extract($sql));
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null}>
+     */
+    public static function providerSources(): iterable
+    {
+        yield 'union all' => [
+            'INSERT INTO combined (name, amount) SELECT name, amount FROM archive UNION ALL SELECT name, amount FROM current',
+            'SELECT name, amount FROM archive UNION ALL SELECT name, amount FROM current',
+        ];
+        yield 'nested select' => [
+            'INSERT INTO combined SELECT * FROM (SELECT id FROM archive UNION SELECT id FROM current) AS source',
+            'SELECT * FROM (SELECT id FROM archive UNION SELECT id FROM current) AS source',
+        ];
+        yield 'upsert suffix' => [
+            'INSERT INTO combined SELECT id FROM source ON DUPLICATE KEY UPDATE id = VALUES(id)',
+            'SELECT id FROM source',
+        ];
+        yield 'quoted keywords' => [
+            "INSERT INTO combined SELECT 'ON DUPLICATE KEY UPDATE', 'RETURNING' FROM source",
+            "SELECT 'ON DUPLICATE KEY UPDATE', 'RETURNING' FROM source",
+        ];
+        yield 'values insert' => ['INSERT INTO combined VALUES (1)', null];
+        yield 'empty select' => ['INSERT INTO combined SELECT', null];
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlParserTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit;
 use PhpMyAdmin\SqlParser\Components\Expression;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\InsertStatement;
+use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\MySql\MySqlParser;
@@ -14,6 +15,31 @@ use ZtdQuery\Platform\MySql\MySqlParser;
 #[CoversClass(MySqlParser::class)]
 final class MySqlParserTest extends TestCase
 {
+    public function testResolvesCompoundSelectParserArtifactsAsOneLogicalStatement(): void
+    {
+        $parser = new MySqlParser();
+
+        self::assertInstanceOf(
+            SelectStatement::class,
+            $parser->parseSingleLogicalStatement('SELECT id FROM archive UNION ALL SELECT id FROM current'),
+        );
+        self::assertInstanceOf(
+            InsertStatement::class,
+            $parser->parseSingleLogicalStatement('INSERT INTO combined (id) SELECT id FROM archive UNION ALL SELECT id FROM current'),
+        );
+    }
+
+    public function testRejectsMultipleAndNonSelectParserContinuations(): void
+    {
+        $parser = new MySqlParser();
+
+        self::assertNull($parser->parseSingleLogicalStatement('SELECT 1; SELECT 2'));
+        self::assertNull($parser->parseSingleLogicalStatement('UPDATE users SET active = 1 UNION SELECT 1'));
+        self::assertNull($parser->parseSingleLogicalStatement('INSERT INTO users SELECT 1 UNION UPDATE users SET active = 1'));
+        self::assertNull($parser->parseSingleLogicalStatement("INSERT INTO users SELECT 1 UNION SELECT 2 INTO OUTFILE '/tmp/result'"));
+        self::assertNull($parser->parseSingleLogicalStatement(''));
+    }
+
     public function testParseAndBuildRoundTrip(): void
     {
         $parser = new MySqlParser();

--- a/packages/ztd-query-mysql/tests/Unit/MySqlQueryGuardTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlQueryGuardTest.php
@@ -69,6 +69,16 @@ class MySqlQueryGuardTest extends QueryClassifierContractTest
         self::assertNull($guard->classify('SELECT 1; SELECT 2'));
     }
 
+    public function testClassifiesInsertWithCompoundSelectAsOneWrite(): void
+    {
+        $guard = new MySqlQueryGuard(new MySqlParser());
+
+        self::assertSame(
+            QueryKind::WRITE_SIMULATED,
+            $guard->classify('INSERT INTO combined (id) SELECT id FROM archive UNION ALL SELECT id FROM current'),
+        );
+    }
+
     public function testClassifiesWriteStatements(): void
     {
         $guard = new MySqlQueryGuard(new MySqlParser());

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -10,6 +10,7 @@ use Tests\Contract\RewriterContractTest;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
+use ZtdQuery\Platform\MySql\InsertSelectSourceExtractor;
 use ZtdQuery\Platform\MySql\Mutation\AlterTableMutation;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
 use ZtdQuery\Platform\MySql\MySqlParser;
@@ -55,6 +56,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertSelectRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\MySqlSelectListAliaser::class)]
+#[UsesClass(InsertSelectSourceExtractor::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(UpdateAssignmentExtractor::class)]
 #[UsesClass(UpdateSourceExtractor::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CastRenderer;
+use ZtdQuery\Platform\MySql\InsertSelectSourceExtractor;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
@@ -23,6 +24,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[CoversClass(InsertTransformer::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(InsertSelectSourceExtractor::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertRowRenderer::class)]
@@ -33,6 +35,30 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class InsertTransformerTest extends TestCase
 {
+    public function testTransformInsertFromCompoundSelectPreservesEveryBranch(): void
+    {
+        $transformer = new InsertTransformer(new MySqlParser(), new SelectTransformer());
+        $tables = [
+            'combined' => [
+                'rows' => [],
+                'columns' => ['name', 'amount'],
+                'columnTypes' => [],
+            ],
+        ];
+
+        $result = $transformer->transform(
+            'INSERT INTO combined (name, amount) SELECT name, amount FROM archive UNION ALL SELECT name, amount FROM current',
+            $tables,
+        );
+
+        self::assertStringContainsString(
+            'FROM archive UNION ALL SELECT name, amount FROM current',
+            $result,
+        );
+        self::assertStringContainsString('`__ztd_insert_0` AS `name`', $result);
+        self::assertStringContainsString('`__ztd_insert_1` AS `amount`', $result);
+    }
+
     public function testUsesInjectedCastRendererAndColumnTypes(): void
     {
         $castRenderer = self::createStub(CastRenderer::class);

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
+use ZtdQuery\Platform\MySql\InsertSelectSourceExtractor;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
@@ -27,6 +28,7 @@ use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertSelectRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\MySqlSelectListAliaser::class)]
+#[UsesClass(InsertSelectSourceExtractor::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(DmlWhereClauseExtractor::class)]

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
+use ZtdQuery\Platform\MySql\InsertSelectSourceExtractor;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\Transformer\InsertTransformer;
@@ -22,6 +23,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertSelectRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\MySqlSelectListAliaser::class)]
+#[UsesClass(InsertSelectSourceExtractor::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(MySqlCastRenderer::class)]

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/InsertCompoundSelectTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/InsertCompoundSelectTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class InsertCompoundSelectTest extends TestCase
+{
+    public function testInsertPreservesEveryCompoundSelectBranch(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $archive = 'prefix_' . bin2hex(random_bytes(8));
+        $current = 'prefix_' . bin2hex(random_bytes(8));
+        $combined = 'prefix_' . bin2hex(random_bytes(8));
+        $prepared = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$archive}` (name VARCHAR(50) PRIMARY KEY, amount DECIMAL(10,2))");
+            $rawPdo->exec("CREATE TABLE `{$current}` (name VARCHAR(50) PRIMARY KEY, amount DECIMAL(10,2))");
+            $rawPdo->exec("CREATE TABLE `{$combined}` (name VARCHAR(50) PRIMARY KEY, amount DECIMAL(10,2))");
+            $rawPdo->exec("CREATE TABLE `{$prepared}` (name VARCHAR(50) PRIMARY KEY, amount DECIMAL(10,2))");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$archive}` VALUES ('Alice', 100.00), ('Bob', 150.00)");
+            $ztdPdo->exec("INSERT INTO `{$current}` VALUES ('Carol', 300.00), ('Dave', 50.00)");
+
+            self::assertSame(4, $ztdPdo->exec("INSERT INTO `{$combined}` (name, amount) SELECT name, amount FROM `{$archive}` UNION ALL SELECT name, amount FROM `{$current}`"));
+
+            $statement = $ztdPdo->prepare("INSERT INTO `{$prepared}` (name, amount) SELECT name, amount FROM `{$archive}` WHERE amount >= ? UNION ALL SELECT name, amount FROM `{$current}` WHERE amount >= ?");
+            self::assertNotFalse($statement);
+            self::assertTrue($statement->execute([150, 100]));
+            self::assertSame(2, $statement->rowCount());
+
+            $combinedRows = $ztdPdo->query("SELECT name, amount FROM `{$combined}` ORDER BY name");
+            $preparedRows = $ztdPdo->query("SELECT name, amount FROM `{$prepared}` ORDER BY name");
+            self::assertNotFalse($combinedRows);
+            self::assertNotFalse($preparedRows);
+            self::assertSame([
+                ['name' => 'Alice', 'amount' => '100.00'],
+                ['name' => 'Bob', 'amount' => '150.00'],
+                ['name' => 'Carol', 'amount' => '300.00'],
+                ['name' => 'Dave', 'amount' => '50.00'],
+            ], $combinedRows->fetchAll(PDO::FETCH_ASSOC));
+            self::assertSame([
+                ['name' => 'Bob', 'amount' => '150.00'],
+                ['name' => 'Carol', 'amount' => '300.00'],
+            ], $preparedRows->fetchAll(PDO::FETCH_ASSOC));
+
+            $physicalCombined = $rawPdo->query("SELECT * FROM `{$combined}`");
+            $physicalPrepared = $rawPdo->query("SELECT * FROM `{$prepared}`");
+            self::assertNotFalse($physicalCombined);
+            self::assertNotFalse($physicalPrepared);
+            self::assertSame([], $physicalCombined->fetchAll(PDO::FETCH_ASSOC));
+            self::assertSame([], $physicalPrepared->fetchAll(PDO::FETCH_ASSOC));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- resolve one token-level SQL statement independently from phpmyadmin parser continuation artifacts
- preserve the complete INSERT SELECT source across UNION and UNION ALL branches
- keep prepared parameters and positional target-column projection intact

## Root cause and prevention

phpmyadmin/sql-parser represents a compound INSERT SELECT as one InsertStatement followed by SelectStatement artifacts. The guard treated that as multiple unsupported AST statements, while InsertTransformer rebuilt only `InsertStatement::select` and discarded every continuation. `MySqlParser::parseSingleLogicalStatement()` now validates typed SELECT continuations for one losslessly split statement, and `InsertSelectSourceExtractor` carries the complete source query. Unsafe continuations and SELECT INTO remain rejected. SQLFaker and both robustness targets now deliberately generate compound INSERT SELECT.

## Verification

- MySQL: 997 unit tests; lint/PHPStan
- SQLFaker: 1055 unit tests; lint/PHPStan
- real MySQL literal and prepared UNION ALL regressions, including row counts and physical isolation
- dedicated rewrite/robustness Fuzz branches
- changed-line Infection: 33/33 killed

## Stack

- depends on #248

Fixes #103