### PR TITLE
fix(mysql): resolve upsert row aliases

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -111,6 +111,18 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function insertRowAliasUpsertStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('insert_stmt', [
+            'insert_stmt' => [ProductionPattern::containing('insert_from_constructor')],
+            'insert_from_constructor' => [ProductionPattern::containing('insert_values')],
+            'value_or_values' => [ProductionPattern::exactly('VALUES')],
+            'opt_values_reference' => [ProductionPattern::nonEmpty()],
+            'opt_insert_update_list' => [ProductionPattern::nonEmpty()],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -694,13 +694,10 @@ final class MySqlProvider extends Base
      *
      * @return non-empty-string
      */
-    public function insertRowAliasUpsertStatement(): string
+    public function insertRowAliasUpsertStatement(int $maxDepth = 40): string
     {
-        $table = $this->rsg->rawIdentifier();
-        $keyColumn = $this->rsg->rawIdentifier();
-        $valueColumn = $this->rsg->rawIdentifier();
-        $rowAlias = $this->rsg->rawIdentifier();
-
-        return "INSERT INTO $table ($keyColumn, $valueColumn) VALUES (1, 2) AS $rowAlias ON DUPLICATE KEY UPDATE $valueColumn = $rowAlias.$valueColumn";
+        return $this->sql->generate(
+            GenerationPlans::insertRowAliasUpsertStatement()->withMaxDepth($maxDepth),
+        );
     }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -688,4 +688,19 @@ final class MySqlProvider extends Base
             GenerationPlans::insertSelectCompoundStatement()->withMaxDepth($maxDepth),
         );
     }
+
+    /**
+     * Generate a MySQL row-alias upsert introduced in MySQL 8.0.19.
+     *
+     * @return non-empty-string
+     */
+    public function insertRowAliasUpsertStatement(): string
+    {
+        $table = $this->rsg->rawIdentifier();
+        $keyColumn = $this->rsg->rawIdentifier();
+        $valueColumn = $this->rsg->rawIdentifier();
+        $rowAlias = $this->rsg->rawIdentifier();
+
+        return "INSERT INTO $table ($keyColumn, $valueColumn) VALUES (1, 2) AS $rowAlias ON DUPLICATE KEY UPDATE $valueColumn = $rowAlias.$valueColumn";
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -159,8 +159,12 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::insertRowAliasUpsertStatement();
 
         self::assertSame('insert_stmt', $plan->startRule());
-        self::assertNotNull($plan->patternAt('insert_from_constructor', 0));
-        self::assertNotNull($plan->patternAt('opt_values_reference', 0));
-        self::assertNotNull($plan->patternAt('opt_insert_update_list', 0));
+        self::assertTrue($plan->patternAt('insert_stmt', 0)?->matches(['insert_from_constructor']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('insert_from_constructor', 0)?->matches(['insert_values']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('value_or_values', 0)?->matches(['VALUES']) ?? false);
+        self::assertTrue($plan->patternAt('opt_values_reference', 0)?->matches(['alias']) ?? false);
+        self::assertTrue($plan->patternAt('opt_insert_update_list', 0)?->matches(['update']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -153,4 +153,14 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('query_primary', 0)?->matches(['query_specification']) ?? false);
         self::assertTrue($plan->patternAt('union_option', 0)?->matches(['ALL']) ?? false);
     }
+
+    public function testRowAliasUpsertPlanRestrictsTheValuesGrammar(): void
+    {
+        $plan = GenerationPlans::insertRowAliasUpsertStatement();
+
+        self::assertSame('insert_stmt', $plan->startRule());
+        self::assertNotNull($plan->patternAt('insert_from_constructor', 0));
+        self::assertNotNull($plan->patternAt('opt_values_reference', 0));
+        self::assertNotNull($plan->patternAt('opt_insert_update_list', 0));
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -568,6 +568,21 @@ final class MySqlProviderTest extends TestCase
         );
     }
 
+    public function testInsertRowAliasUpsertStatement(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new MySqlProvider($faker);
+
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($provider->insertRowAliasUpsertStatement());
+
+        self::assertSame('INSERT_SYM', $tokens[0]);
+        self::assertContains('VALUES', $tokens);
+        self::assertContains('AS', $tokens);
+        self::assertContains('DUPLICATE_SYM', $tokens);
+        self::assertContains('UPDATE_SYM', $tokens);
+    }
+
     public function testBinaryLiteral(): void
     {
         $faker = Factory::create();

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -568,14 +568,18 @@ final class MySqlProviderTest extends TestCase
         );
     }
 
-    public function testInsertRowAliasUpsertStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testInsertRowAliasUpsertStatement(int $seed): void
     {
         $faker = Factory::create();
-        $faker->seed(12345);
+        $faker->seed($seed);
         $provider = new MySqlProvider($faker);
+        $sql = $provider->insertRowAliasUpsertStatement();
+        $faker->seed($seed);
 
-        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($provider->insertRowAliasUpsertStatement());
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))->tokenize($sql);
 
+        self::assertSame($sql, $provider->insertRowAliasUpsertStatement(40));
         self::assertSame('INSERT_SYM', $tokens[0]);
         self::assertContains('VALUES', $tokens);
         self::assertContains('AS', $tokens);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -145,6 +145,7 @@ final class RewriteTarget
             fn (): string => "CREATE TABLE child (id INT, parent_id INT, {$this->provider->foreignKeyConstraint()})",
             fn (): string => $this->provider->updateJoinDerivedStatement(),
             fn (): string => $this->provider->insertSelectCompoundStatement(),
+            fn (): string => $this->provider->insertRowAliasUpsertStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -197,6 +197,7 @@ final class RobustnessTarget
             fn (): string => "CREATE TABLE child (id INT, parent_id INT, {$this->provider->foreignKeyConstraint()})",
             fn (): string => $this->provider->updateJoinDerivedStatement(),
             fn (): string => $this->provider->insertSelectCompoundStatement(),
+            fn (): string => $this->provider->insertRowAliasUpsertStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/MySqlMutationResolver.php
+++ b/packages/ztd-query-mysql/src/MySqlMutationResolver.php
@@ -221,21 +221,14 @@ final class MySqlMutationResolver
             throw new UnsupportedSqlException($sql, 'Cannot resolve INSERT target');
         }
 
-        $updateColumns = [];
-        /** @var array<string, \ZtdQuery\Shadow\Mutation\UpsertExpression> $updateValues */
-        $updateValues = [];
+        $extractor = new MySqlUpsertAssignmentExtractor();
+        $incomingAlias = $extractor->incomingAlias($sql);
         $expressionParser = new MySqlUpsertExpressionParser();
-        if ($statement->onDuplicateSet !== null && $statement->onDuplicateSet !== []) {
-            foreach ($statement->onDuplicateSet as $set) {
-                $colName = trim($set->column, '`"\'');
-                if (str_contains($colName, '.')) {
-                    $parts = explode('.', $colName);
-                    $colName = trim(end($parts), '`"\'');
-                }
-                $updateColumns[] = $colName;
-                $updateValues[$colName] = $expressionParser->parse($set->value, $tableName);
-            }
+        $updateValues = [];
+        foreach ($extractor->extract($sql) as $column => $expression) {
+            $updateValues[$column] = $expressionParser->parse($expression, $tableName, $incomingAlias);
         }
+        $updateColumns = array_keys($updateValues);
         $isOnDuplicateKeyUpdate = $updateColumns !== [];
 
         $isIgnore = $statement->options !== null && self::optionSet($statement->options, 'IGNORE');

--- a/packages/ztd-query-mysql/src/MySqlUpsertAssignmentExtractor.php
+++ b/packages/ztd-query-mysql/src/MySqlUpsertAssignmentExtractor.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class MySqlUpsertAssignmentExtractor
+{
+    /** @return array<string, string> */
+    public function extract(string $sql): array
+    {
+        $stream = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql);
+        $clause = $stream->topLevelClause(['ON', 'DUPLICATE', 'KEY', 'UPDATE']);
+        if ($clause === null) {
+            return [];
+        }
+
+        $assignments = [];
+        foreach (SqlTokenStream::tokenize($clause, SqlTokenDialect::MySql)->splitTopLevel() as $assignment) {
+            $parts = $this->assignment($assignment);
+            if ($parts !== null) {
+                $assignments[$parts['column']] = $parts['value'];
+            }
+        }
+
+        return $assignments;
+    }
+
+    public function incomingAlias(string $sql): ?string
+    {
+        $stream = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql);
+        $clause = $stream->topLevelClauseAfter(
+            ['VALUES'],
+            ['AS'],
+        );
+        if ($clause === null) {
+            return null;
+        }
+
+        return SqlTokenStream::tokenize($clause, SqlTokenDialect::MySql)->identifierAt()['name'] ?? null;
+    }
+
+    /** @return array{column: string, value: string}|null */
+    private function assignment(string $assignment): ?array
+    {
+        $tokens = SqlTokenStream::tokenize($assignment, SqlTokenDialect::MySql)->significantTokens();
+        foreach ($tokens as $index => $token) {
+            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '=' || !$token->isTopLevel()) {
+                continue;
+            }
+            $column = $this->lastIdentifier(array_slice($tokens, 0, $index));
+            $value = trim(substr($assignment, $token->endOffset()));
+            if ($column === null || $value === '') {
+                return null;
+            }
+
+            return ['column' => $column, 'value' => $value];
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function lastIdentifier(array $tokens): ?string
+    {
+        $token = array_pop($tokens);
+        return $token !== null
+            ? SqlTokenStream::tokenize($token->text, SqlTokenDialect::MySql)->identifierAt()['name'] ?? null
+            : null;
+    }
+
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlSchemaParser;
+use ZtdQuery\Platform\MySql\MySqlUpsertAssignmentExtractor;
 use ZtdQuery\Platform\MySql\UpdateSourceExtractor;
 use ZtdQuery\Platform\MySql\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
@@ -41,6 +42,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser::class)]
+#[UsesClass(MySqlUpsertAssignmentExtractor::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
@@ -162,6 +164,38 @@ final class MySqlMutationResolverTest extends TestCase
 
         self::assertInstanceOf(UpsertMutation::class, $mutation);
         self::assertSame('users', $mutation->tableName());
+    }
+
+    public function testResolveRowAliasUpsertAppliesIncomingColumns(): void
+    {
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $shadowStore = new ShadowStore();
+        $shadowStore->set('users', [['id' => 1, 'name' => 'old', 'score' => 10]]);
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(
+            ['id', 'name', 'score'],
+            ['id' => 'INT', 'name' => 'VARCHAR(255)', 'score' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+        ));
+        $selectTransformer = new SelectTransformer();
+        $resolver = new MySqlMutationResolver(
+            $shadowStore,
+            $registry,
+            $schemaParser,
+            new UpdateTransformer($parser, $selectTransformer),
+            new DeleteTransformer($parser, $selectTransformer),
+        );
+        $sql = "INSERT INTO users VALUES (1, 'new', 20) AS incoming ON DUPLICATE KEY UPDATE name = incoming.name, score = incoming.score";
+        $statements = $parser->parse($sql);
+
+        $mutation = $resolver->resolve($sql, $statements[0], QueryKind::WRITE_SIMULATED);
+        self::assertInstanceOf(UpsertMutation::class, $mutation);
+        $mutation->apply($shadowStore, [['id' => 1, 'name' => 'new', 'score' => 20]]);
+
+        self::assertSame([['id' => 1, 'name' => 'new', 'score' => 20]], $shadowStore->get('users'));
     }
 
     public function testResolveInsertOnDuplicateKeyWithoutRegisteredSchema(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -17,6 +17,7 @@ use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlQueryGuard;
 use ZtdQuery\Platform\MySql\MySqlRewriter;
 use ZtdQuery\Platform\MySql\MySqlSchemaParser;
+use ZtdQuery\Platform\MySql\MySqlUpsertAssignmentExtractor;
 use ZtdQuery\Platform\MySql\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\MySql\Transformer\InsertTransformer;
 use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
@@ -47,6 +48,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
+#[UsesClass(MySqlUpsertAssignmentExtractor::class)]
 #[UsesClass(MySqlQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlReadOnlyDiagnosticStatement::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTransactionStatementParser::class)]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlUpsertAssignmentExtractorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlUpsertAssignmentExtractorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlUpsertAssignmentExtractor;
+
+#[CoversClass(MySqlUpsertAssignmentExtractor::class)]
+final class MySqlUpsertAssignmentExtractorTest extends TestCase
+{
+    /** @param array<string, string> $expected */
+    #[DataProvider('providerAssignments')]
+    public function testExtract(string $sql, array $expected): void
+    {
+        self::assertSame($expected, (new MySqlUpsertAssignmentExtractor())->extract($sql));
+    }
+
+    /**
+     * @return iterable<string, array{string, array<string, string>}>
+     */
+    public static function providerAssignments(): iterable
+    {
+        yield 'row alias' => [
+            "INSERT INTO t VALUES (1, 'updated', 99) AS new ON DUPLICATE KEY UPDATE name = new.name, score = new.score",
+            ['name' => 'new.name', 'score' => 'new.score'],
+        ];
+        yield 'quoted row alias and columns' => [
+            "INSERT INTO t VALUES (1, 'updated') AS `incoming` ON DUPLICATE KEY UPDATE `t`.`name` = `incoming`.`name`",
+            ['name' => '`incoming`.`name`'],
+        ];
+        yield 'case-insensitive row alias' => [
+            "INSERT INTO t VALUES (1, 'updated') AS Incoming ON DUPLICATE KEY UPDATE name = incoming.name",
+            ['name' => 'incoming.name'],
+        ];
+        yield 'values function and nested commas' => [
+            "INSERT INTO t VALUES (1, 2) ON DUPLICATE KEY UPDATE value = IF(VALUES(value) > value, VALUES(value), value)",
+            ['value' => 'IF(VALUES(value) > value, VALUES(value), value)'],
+        ];
+        yield 'multiple alias references after other identifiers' => [
+            'INSERT INTO t VALUES (1, 2) AS incoming ON DUPLICATE KEY UPDATE value = value + incoming.value + incoming.value',
+            ['value' => 'value + incoming.value + incoming.value'],
+        ];
+        yield 'alias word without qualification' => [
+            'INSERT INTO t VALUES (1, 2) AS incoming ON DUPLICATE KEY UPDATE value = incoming + incoming.value',
+            ['value' => 'incoming + incoming.value'],
+        ];
+        yield 'select alias is not a row alias' => [
+            'INSERT INTO t SELECT other.value AS projected FROM other ON DUPLICATE KEY UPDATE value = projected.value',
+            ['value' => 'projected.value'],
+        ];
+        yield 'quoted keywords' => [
+            "INSERT INTO t VALUES (1, 'ON DUPLICATE KEY UPDATE') ON DUPLICATE KEY UPDATE value = 'RETURNING'",
+            ['value' => "'RETURNING'"],
+        ];
+        yield 'not upsert' => ['INSERT INTO t VALUES (1)', []];
+        yield 'missing on keyword' => [
+            'INSERT INTO t VALUES (1) DUPLICATE KEY UPDATE value = 2',
+            [],
+        ];
+        yield 'malformed assignments' => [
+            'INSERT INTO t VALUES (1) ON DUPLICATE KEY UPDATE missing, value =',
+            [],
+        ];
+    }
+
+    public function testExtractsIncomingRowAliasWithoutRewritingExpressions(): void
+    {
+        $extractor = new MySqlUpsertAssignmentExtractor();
+
+        self::assertSame(
+            'incoming',
+            $extractor->incomingAlias(
+                'INSERT INTO t VALUES (1) AS `incoming` ON DUPLICATE KEY UPDATE value = incoming.value',
+            ),
+        );
+        self::assertNull($extractor->incomingAlias('INSERT INTO t VALUES (1) ON DUPLICATE KEY UPDATE value = 1'));
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlUpsertAssignmentExtractorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlUpsertAssignmentExtractorTest.php
@@ -77,6 +77,13 @@ final class MySqlUpsertAssignmentExtractorTest extends TestCase
                 'INSERT INTO t VALUES (1) AS `incoming` ON DUPLICATE KEY UPDATE value = incoming.value',
             ),
         );
+        self::assertSame(
+            'incoming',
+            $extractor->incomingAlias(
+                'WITH payload AS (SELECT 1) INSERT INTO t VALUES (1) AS incoming '
+                . 'ON DUPLICATE KEY UPDATE value = incoming.value',
+            ),
+        );
         self::assertNull($extractor->incomingAlias('INSERT INTO t VALUES (1) ON DUPLICATE KEY UPDATE value = 1'));
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpsertRowAliasTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/UpsertRowAliasTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+#[CoversNothing]
+#[Large]
+final class UpsertRowAliasTest extends TestCase
+{
+    public function testRowAliasResolvesIncomingValuesForLiteralAndPreparedUpserts(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+        $table = 'prefix_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec("CREATE TABLE `{$table}` (id INT PRIMARY KEY, name VARCHAR(50), score INT)");
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec("INSERT INTO `{$table}` VALUES (1, 'original', 10)");
+
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO `{$table}` VALUES (1, 'literal', 20) AS incoming ON DUPLICATE KEY UPDATE name = incoming.name, score = incoming.score"));
+
+            $statement = $ztdPdo->prepare("INSERT INTO `{$table}` VALUES (?, ?, ?) AS incoming ON DUPLICATE KEY UPDATE name = incoming.name, score = incoming.score");
+            self::assertNotFalse($statement);
+            self::assertTrue($statement->execute([1, 'prepared', 30]));
+            self::assertSame(1, $statement->rowCount());
+
+            $row = $ztdPdo->query("SELECT id, name, score FROM `{$table}`");
+            self::assertNotFalse($row);
+            self::assertSame(['id' => 1, 'name' => 'prepared', 'score' => 30], $row->fetch(PDO::FETCH_ASSOC));
+
+            $physical = $rawPdo->query("SELECT * FROM `{$table}`");
+            self::assertNotFalse($physical);
+            self::assertSame([], $physical->fetchAll(PDO::FETCH_ASSOC));
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- extract MySQL ON DUPLICATE KEY UPDATE assignments from the lossless token stream
- recognize VALUES-row aliases and resolve alias-qualified columns as incoming values
- cover literal and prepared row-alias upserts through the shared PDO/MySQLi mutation path

## Root cause and prevention

phpmyadmin/sql-parser drops the MySQL 8.0.19+ `VALUES (...) AS alias` suffix and its ON DUPLICATE assignments. The mutation resolver therefore created a plain insert or used incomplete expressions. `MySqlUpsertAssignmentExtractor` now owns the complete clause and normalizes only structurally qualified row-alias references into the typed incoming-row expression namespace. It handles quoted/case-varied aliases, multiple references, nested commas, and rejects malformed anchors. SQLFaker and both MySQL robustness targets now explicitly generate the modern syntax.

## Verification

- MySQL: 1004 unit tests; lint/PHPStan
- SQLFaker: 1056 unit tests; lint/PHPStan
- real MySQL literal and prepared row-alias regressions, with physical isolation
- dedicated rewrite/robustness Fuzz branches
- extractor Infection: 59/59 killed; changed resolver line 1/1 killed

## Stack

- depends on #249

Fixes #152