### PR TITLE
fix(schema): preserve temporary table context

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -142,6 +142,14 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function temporaryTableStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('create_table_stmt', [
+            'opt_temporary' => [ProductionPattern::nonEmpty()],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -708,12 +708,10 @@ final class MySqlProvider extends Base
         );
     }
     /** @return non-empty-string */
-    public function temporaryTableStatement(): string
+    public function temporaryTableStatement(int $maxDepth = 40): string
     {
-        $table = $this->rsg->rawIdentifier();
-        $keyColumn = $this->rsg->rawIdentifier();
-        $valueColumn = $this->rsg->rawIdentifier();
-
-        return "CREATE TEMPORARY TABLE $table ($keyColumn INT PRIMARY KEY, $valueColumn VARCHAR(255))";
+        return $this->sql->generate(
+            GenerationPlans::temporaryTableStatement()->withMaxDepth($maxDepth),
+        );
     }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -707,4 +707,13 @@ final class MySqlProvider extends Base
             GenerationPlans::insertFunctionUpsertStatement()->withMaxDepth($maxDepth),
         );
     }
+    /** @return non-empty-string */
+    public function temporaryTableStatement(): string
+    {
+        $table = $this->rsg->rawIdentifier();
+        $keyColumn = $this->rsg->rawIdentifier();
+        $valueColumn = $this->rsg->rawIdentifier();
+
+        return "CREATE TEMPORARY TABLE $table ($keyColumn INT PRIMARY KEY, $valueColumn VARCHAR(255))";
+    }
 }

--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -42,6 +42,14 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function temporaryTableStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('CreateStmt', [
+            'OptTemp' => [ProductionPattern::containing('TEMP')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -416,13 +416,11 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function temporaryTableStatement(): string
+    public function temporaryTableStatement(int $maxDepth = 40): string
     {
-        $table = $this->rsg->rawIdentifier();
-        $keyColumn = $this->rsg->rawIdentifier();
-        $valueColumn = $this->rsg->rawIdentifier();
-
-        return "CREATE TEMP TABLE $table ($keyColumn INTEGER PRIMARY KEY, $valueColumn TEXT)";
+        return $this->sql->generate(
+            GenerationPlans::temporaryTableStatement()->withMaxDepth($maxDepth),
+        );
     }
 
     /**

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -415,6 +415,16 @@ final class PostgreSqlProvider extends Base
         );
     }
 
+    /** @return non-empty-string */
+    public function temporaryTableStatement(): string
+    {
+        $table = $this->rsg->rawIdentifier();
+        $keyColumn = $this->rsg->rawIdentifier();
+        $valueColumn = $this->rsg->rawIdentifier();
+
+        return "CREATE TEMP TABLE $table ($keyColumn INTEGER PRIMARY KEY, $valueColumn TEXT)";
+    }
+
     /**
      * @template TRequiresNonEmpty of bool
      * @param GenerationPlan<TRequiresNonEmpty> $plan

--- a/packages/sql-faker/src/Sqlite/GenerationPlans.php
+++ b/packages/sql-faker/src/Sqlite/GenerationPlans.php
@@ -32,6 +32,15 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function temporaryTableStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('cmd', [
+            'cmd' => [ProductionPattern::containing('create_table', 'create_table_args')],
+            'temp' => [ProductionPattern::containing('TEMP')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('conslist', [

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -268,4 +268,14 @@ final class SqliteProvider extends Base
     {
         return $this->sql->generate(GenerationPlan::fromRule($startRule)->withMaxDepth($maxDepth));
     }
+
+    /** @return non-empty-string */
+    public function temporaryTableStatement(): string
+    {
+        $table = $this->rsg->rawIdentifier();
+        $keyColumn = $this->rsg->rawIdentifier();
+        $valueColumn = $this->rsg->rawIdentifier();
+
+        return "CREATE TEMP TABLE $table ($keyColumn INTEGER PRIMARY KEY, $valueColumn TEXT)";
+    }
 }

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -270,12 +270,10 @@ final class SqliteProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function temporaryTableStatement(): string
+    public function temporaryTableStatement(int $maxDepth = 40): string
     {
-        $table = $this->rsg->rawIdentifier();
-        $keyColumn = $this->rsg->rawIdentifier();
-        $valueColumn = $this->rsg->rawIdentifier();
-
-        return "CREATE TEMP TABLE $table ($keyColumn INTEGER PRIMARY KEY, $valueColumn TEXT)";
+        return $this->sql->generate(
+            GenerationPlans::temporaryTableStatement()->withMaxDepth($maxDepth),
+        );
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -186,4 +186,12 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('simple_expr', 0)?->matches(['function_call_conflict']) ?? false);
         self::assertTrue($plan->patternAt('function_call_conflict', 0)?->matches(['IF']) ?? false);
     }
+
+    public function testTemporaryTablePlanRequiresTheTemporaryProduction(): void
+    {
+        $plan = GenerationPlans::temporaryTableStatement();
+
+        self::assertSame('create_table_stmt', $plan->startRule());
+        self::assertTrue($plan->patternAt('opt_temporary', 0)?->matches(['TEMPORARY']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -95,14 +95,22 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('DUPLICATE_SYM', $tokens);
     }
 
-    public function testTemporaryTableStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testTemporaryTableStatement(int $seed): void
     {
-        $provider = new MySqlProvider(Factory::create());
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new MySqlProvider($faker);
+        $sql = $provider->temporaryTableStatement();
+        $faker->seed($seed);
 
-        self::assertMatchesRegularExpression(
-            '/^CREATE TEMPORARY TABLE \w+ \(\w+ INT PRIMARY KEY, \w+ VARCHAR\(255\)\)$/',
-            $provider->temporaryTableStatement(),
-        );
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))
+            ->tokenize($sql);
+
+        self::assertSame($sql, $provider->temporaryTableStatement(40));
+        self::assertSame('CREATE', $tokens[0]);
+        self::assertContains('TEMPORARY', $tokens);
+        self::assertContains('TABLE_SYM', $tokens);
     }
 
     public function testSql(): void

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -95,6 +95,16 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('DUPLICATE_SYM', $tokens);
     }
 
+    public function testTemporaryTableStatement(): void
+    {
+        $provider = new MySqlProvider(Factory::create());
+
+        self::assertMatchesRegularExpression(
+            '/^CREATE TEMPORARY TABLE \w+ \(\w+ INT PRIMARY KEY, \w+ VARCHAR\(255\)\)$/',
+            $provider->temporaryTableStatement(),
+        );
+    }
+
     public function testSql(): void
     {
         $faker = Factory::create();

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -55,4 +55,12 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('AexprConst', 0)?->matches(['Iconst']) ?? false);
         self::assertTrue($plan->patternAt('func_expr', 0)?->matches(['func_application']) ?? false);
     }
+
+    public function testTemporaryTablePlanRequiresTheTemporaryProduction(): void
+    {
+        $plan = GenerationPlans::temporaryTableStatement();
+
+        self::assertSame('CreateStmt', $plan->startRule());
+        self::assertTrue($plan->patternAt('OptTemp', 0)?->matches(['TEMP']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -78,14 +78,22 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
-    public function testTemporaryTableStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testTemporaryTableStatement(int $seed): void
     {
-        $provider = new PostgreSqlProvider(Factory::create());
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->temporaryTableStatement();
+        $faker->seed($seed);
 
-        self::assertMatchesRegularExpression(
-            '/^CREATE TEMP(?:ORARY)? TABLE \w+ \(\w+ INTEGER PRIMARY KEY, \w+ TEXT\)$/',
-            $provider->temporaryTableStatement(),
-        );
+        $tokens = (new LexicalGrammar($faker, 'pg-17.2', true))
+            ->tokenize($sql);
+
+        self::assertSame($sql, $provider->temporaryTableStatement(40));
+        self::assertSame('CREATE', $tokens[0]);
+        self::assertContains('TEMP', $tokens);
+        self::assertContains('TABLE', $tokens);
     }
 
     #[\Override]

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -78,6 +78,16 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
+    public function testTemporaryTableStatement(): void
+    {
+        $provider = new PostgreSqlProvider(Factory::create());
+
+        self::assertMatchesRegularExpression(
+            '/^CREATE TEMP(?:ORARY)? TABLE \w+ \(\w+ INTEGER PRIMARY KEY, \w+ TEXT\)$/',
+            $provider->temporaryTableStatement(),
+        );
+    }
+
     #[\Override]
     protected function setUp(): void
     {

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -61,4 +61,13 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('expr', 0)?->matches(['term']) ?? false);
         self::assertTrue($plan->patternAt('expr', 1)?->matches(['idj', 'LP', 'RP']) ?? false);
     }
+
+    public function testTemporaryTablePlanRequiresTheTemporaryProduction(): void
+    {
+        $plan = GenerationPlans::temporaryTableStatement();
+
+        self::assertSame('cmd', $plan->startRule());
+        self::assertTrue($plan->patternAt('cmd', 0)?->matches(['create_table', 'create_table_args']) ?? false);
+        self::assertTrue($plan->patternAt('temp', 0)?->matches(['TEMP']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -77,14 +77,22 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
-    public function testTemporaryTableStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testTemporaryTableStatement(int $seed): void
     {
-        $provider = new SqliteProvider(Factory::create());
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new SqliteProvider($faker);
+        $sql = $provider->temporaryTableStatement();
+        $faker->seed($seed);
 
-        self::assertMatchesRegularExpression(
-            '/^CREATE TEMP(?:ORARY)? TABLE \w+ \(\w+ INTEGER PRIMARY KEY, \w+ TEXT\)$/',
-            $provider->temporaryTableStatement(),
-        );
+        $tokens = (new LexicalGrammar($faker, 'sqlite-3.47.2', true))
+            ->tokenize($sql);
+
+        self::assertSame($sql, $provider->temporaryTableStatement(40));
+        self::assertSame('CREATE', $tokens[0]);
+        self::assertContains('TEMP', $tokens);
+        self::assertContains('TABLE', $tokens);
     }
 
     #[\Override]

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -77,6 +77,16 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
+    public function testTemporaryTableStatement(): void
+    {
+        $provider = new SqliteProvider(Factory::create());
+
+        self::assertMatchesRegularExpression(
+            '/^CREATE TEMP(?:ORARY)? TABLE \w+ \(\w+ INTEGER PRIMARY KEY, \w+ TEXT\)$/',
+            $provider->temporaryTableStatement(),
+        );
+    }
+
     #[\Override]
     protected function setUp(): void
     {

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -147,6 +147,7 @@ final class RewriteTarget
             fn (): string => $this->provider->insertSelectCompoundStatement(),
             fn (): string => $this->provider->insertRowAliasUpsertStatement(),
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
+            fn (): string => $this->provider->temporaryTableStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/TemporaryTableTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/TemporaryTableTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_mysql
+ * @group integration
+ * @group mysql
+ */
+#[CoversNothing]
+#[Large]
+final class TemporaryTableTest extends TestCase
+{
+    public function testDmlContinuesAcrossTemporaryTableLifecycle(): void
+    {
+        [$databaseName, $rawPdo] = MySqlContainer::createTestDatabase();
+
+        try {
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec('CREATE TABLE source (id INT PRIMARY KEY, value VARCHAR(255))');
+            $ztdPdo->exec("INSERT INTO source VALUES (1, 'a')");
+            $ztdPdo->exec('CREATE TEMPORARY TABLE staging (id INT PRIMARY KEY, value VARCHAR(255))');
+            $ztdPdo->exec('INSERT INTO staging SELECT * FROM source');
+            $ztdPdo->exec("UPDATE staging SET value = 'b' WHERE id = 1");
+            $ztdPdo->exec('DELETE FROM staging WHERE id = 1');
+            $ztdPdo->exec("INSERT INTO staging VALUES (2, 'c')");
+            $ztdPdo->exec('INSERT INTO source SELECT * FROM staging');
+
+            $statement = $ztdPdo->query('SELECT * FROM source ORDER BY id');
+            self::assertNotFalse($statement);
+            self::assertSame(
+                [['id' => 1, 'value' => 'a'], ['id' => 2, 'value' => 'c']],
+                $statement->fetchAll(\PDO::FETCH_ASSOC),
+            );
+        } finally {
+            $rawPdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/TemporaryTableTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/TemporaryTableTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class TemporaryTableTest extends TestCase
+{
+    public function testDmlContinuesAcrossTemporaryTableLifecycle(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            $ztdPdo->exec('CREATE TABLE source (id INT PRIMARY KEY, value TEXT)');
+            $ztdPdo->exec("INSERT INTO source VALUES (1, 'a')");
+            $ztdPdo->exec('CREATE TEMP TABLE staging (id INT PRIMARY KEY, value TEXT)');
+            $ztdPdo->exec('INSERT INTO staging SELECT * FROM source');
+            $ztdPdo->exec("UPDATE staging SET value = 'b' WHERE id = 1");
+            $ztdPdo->exec('DELETE FROM staging WHERE id = 1');
+            $ztdPdo->exec("INSERT INTO staging VALUES (2, 'c')");
+            $ztdPdo->exec('INSERT INTO source SELECT * FROM staging');
+
+            $statement = $ztdPdo->query('SELECT * FROM source ORDER BY id');
+            self::assertNotFalse($statement);
+            self::assertSame(
+                [['id' => 1, 'value' => 'a'], ['id' => 2, 'value' => 'c']],
+                $statement->fetchAll(\PDO::FETCH_ASSOC),
+            );
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/TemporaryTableTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/TemporaryTableTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/** @requires extension pdo_sqlite */
+#[CoversNothing]
+#[Large]
+final class TemporaryTableTest extends TestCase
+{
+    public function testDmlContinuesAcrossTemporaryTableLifecycle(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+        $ztdPdo->exec('CREATE TABLE source (id INTEGER PRIMARY KEY, value TEXT)');
+        $ztdPdo->exec("INSERT INTO source VALUES (1, 'a')");
+        $ztdPdo->exec('CREATE TEMP TABLE staging (id INTEGER PRIMARY KEY, value TEXT)');
+        $ztdPdo->exec('INSERT INTO staging SELECT * FROM source');
+        $ztdPdo->exec("UPDATE staging SET value = 'b' WHERE id = 1");
+        $ztdPdo->exec('DELETE FROM staging WHERE id = 1');
+        $ztdPdo->exec("INSERT INTO staging VALUES (2, 'c')");
+        $ztdPdo->exec('INSERT INTO source SELECT * FROM staging');
+
+        $statement = $ztdPdo->query('SELECT * FROM source ORDER BY id');
+
+        self::assertNotFalse($statement);
+        self::assertSame(
+            [['id' => 1, 'value' => 'a'], ['id' => 2, 'value' => 'c']],
+            $statement->fetchAll(\PDO::FETCH_ASSOC),
+        );
+    }
+
+    public function testTemporaryTableCreatedBeforeWrappingIsReflected(): void
+    {
+        $rawPdo = new \PDO('sqlite::memory:');
+        $rawPdo->exec('CREATE TEMPORARY TABLE staging (id INTEGER PRIMARY KEY, value TEXT)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        $ztdPdo->exec("INSERT INTO staging VALUES (1, 'a')");
+        $ztdPdo->exec("UPDATE staging SET value = 'b' WHERE id = 1");
+        $statement = $ztdPdo->query('SELECT * FROM staging');
+
+        self::assertNotFalse($statement);
+        self::assertSame([['id' => 1, 'value' => 'b']], $statement->fetchAll(\PDO::FETCH_ASSOC));
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -135,6 +135,7 @@ final class RewriteTarget
             fn (): string => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => $this->provider->truncateStatement(maxDepth: 8),
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
+            fn (): string => $this->provider->temporaryTableStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
@@ -132,6 +132,7 @@ final class RewriteTarget
             fn () => $this->provider->alterTableStatement(maxDepth: 5),
             fn () => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
+            fn (): string => $this->provider->temporaryTableStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -60,7 +60,7 @@ final class SqliteParser
                 'DELETE' => 'DELETE',
                 'CREATE' => match ($second) {
                     'TABLE' => 'CREATE_TABLE',
-                    'TEMPORARY' => $third === 'TABLE' ? 'CREATE_TABLE' : null,
+                    'TEMP', 'TEMPORARY' => $third === 'TABLE' ? 'CREATE_TABLE' : null,
                     default => null,
                 },
                 'DROP' => $second === 'TABLE' ? 'DROP_TABLE' : null,
@@ -591,7 +591,7 @@ final class SqliteParser
     private function extractCreateTableName(string $sql): ?string
     {
         $sql = $this->stripComments($sql);
-        if (preg_match('/^CREATE\s+(?:TEMPORARY\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s(]+)/i', trim($sql), $matches) === 1) {
+        if (preg_match('/^CREATE\s+(?:(?:TEMP|TEMPORARY)\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?("(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]])*\]|[^\s(]+)/i', $sql, $matches) === 1) {
             return $this->unquoteIdentifier($matches[1]);
         }
 

--- a/packages/ztd-query-sqlite/src/SqliteSchemaReflector.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaReflector.php
@@ -25,7 +25,12 @@ final class SqliteSchemaReflector implements SchemaReflector
     public function getCreateStatement(string $tableName): ?string
     {
         $stmt = $this->connection->query(
-            "SELECT sql FROM sqlite_master WHERE type='table' AND name='" . str_replace("'", "''", $tableName) . "'"
+            "SELECT sql FROM ("
+            . "SELECT sql, 0 AS precedence FROM sqlite_temp_master WHERE type='table' AND name='"
+            . str_replace("'", "''", $tableName)
+            . "' UNION ALL SELECT sql, 1 AS precedence FROM sqlite_master WHERE type='table' AND name='"
+            . str_replace("'", "''", $tableName)
+            . "') ORDER BY precedence LIMIT 1"
         );
         if ($stmt === false) {
             return null;
@@ -45,7 +50,12 @@ final class SqliteSchemaReflector implements SchemaReflector
     public function reflectAll(): array
     {
         $stmt = $this->connection->query(
-            "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+            "SELECT name, sql FROM ("
+            . "SELECT name, sql, 0 AS precedence FROM sqlite_temp_master "
+            . "WHERE type='table' AND name NOT LIKE 'sqlite_%' UNION ALL "
+            . "SELECT name, sql, 1 AS precedence FROM sqlite_master "
+            . "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            . ') ORDER BY precedence, name'
         );
         if ($stmt === false) {
             return [];
@@ -59,6 +69,9 @@ final class SqliteSchemaReflector implements SchemaReflector
             $createSql = $row['sql'] ?? null;
 
             if (!is_string($tableName) || $tableName === '' || !is_string($createSql) || $createSql === '') {
+                continue;
+            }
+            if (isset($result[$tableName])) {
                 continue;
             }
 

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteParserTest.php
@@ -94,6 +94,9 @@ final class SqliteParserTest extends TestCase
     {
         $parser = new SqliteParser();
         self::assertSame('CREATE_TABLE', $parser->classifyStatement('CREATE TEMPORARY TABLE tmp (id INTEGER)'));
+        self::assertSame('CREATE_TABLE', $parser->classifyStatement('CREATE TEMP TABLE tmp (id INTEGER)'));
+        self::assertSame('tmp', $parser->extractTargetTable('CREATE TEMP TABLE tmp (id INTEGER)'));
+        self::assertSame('tmp', $parser->extractTargetTable('  CREATE TEMP TABLE tmp (id INTEGER)'));
     }
 
     public function testClassifyDropTable(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaReflectorTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaReflectorTest.php
@@ -87,6 +87,28 @@ final class SqliteSchemaReflectorTest extends TestCase
         self::assertArrayHasKey('orders', $result);
     }
 
+    public function testReflectAllPrefersTemporaryTableWhenNamesCollide(): void
+    {
+        $statement = static::createStub(StatementInterface::class);
+        $statement->method('fetchAll')->willReturn([
+            ['name' => 'staging', 'sql' => 'CREATE TABLE staging (temporary_value TEXT)'],
+            ['name' => 'staging', 'sql' => 'CREATE TABLE staging (persistent_value TEXT)'],
+            ['name' => 'after', 'sql' => 'CREATE TABLE after (id INTEGER)'],
+        ]);
+        $connection = static::createMock(ConnectionInterface::class);
+        $connection->expects(self::once())->method('query')->with(
+            "SELECT name, sql FROM (SELECT name, sql, 0 AS precedence FROM sqlite_temp_master "
+            . "WHERE type='table' AND name NOT LIKE 'sqlite_%' UNION ALL "
+            . "SELECT name, sql, 1 AS precedence FROM sqlite_master "
+            . "WHERE type='table' AND name NOT LIKE 'sqlite_%') ORDER BY precedence, name",
+        )->willReturn($statement);
+
+        $result = (new SqliteSchemaReflector($connection))->reflectAll();
+
+        self::assertSame('CREATE TABLE staging (temporary_value TEXT)', $result['staging']);
+        self::assertSame('CREATE TABLE after (id INTEGER)', $result['after']);
+    }
+
     public function testReflectAllSkipsInvalidRows(): void
     {
         $statement = static::createStub(StatementInterface::class);
@@ -237,8 +259,12 @@ final class SqliteSchemaReflectorTest extends TestCase
             ['sql' => "CREATE TABLE \"it's\" (id INTEGER)"],
         ]);
 
-        $connection = static::createStub(ConnectionInterface::class);
-        $connection->method('query')->willReturn($statement);
+        $connection = static::createMock(ConnectionInterface::class);
+        $connection->expects(self::once())->method('query')->with(
+            "SELECT sql FROM (SELECT sql, 0 AS precedence FROM sqlite_temp_master WHERE type='table' AND name='it''s' "
+            . "UNION ALL SELECT sql, 1 AS precedence FROM sqlite_master WHERE type='table' AND name='it''s') "
+            . 'ORDER BY precedence LIMIT 1',
+        )->willReturn($statement);
 
         $reflector = new SqliteSchemaReflector($connection);
         $result = $reflector->getCreateStatement("it's");


### PR DESCRIPTION
## Root problem

Temporary tables were not represented consistently across the parser, reflected schema, and stateful DML pipeline. SQLite did not classify the `CREATE TEMP TABLE` spelling and only reflected `sqlite_master`, so session-local schemas could be absent when later INSERT/UPDATE/DELETE statements were rewritten.

## Change

- recognize both SQLite `TEMP` and `TEMPORARY` table forms
- reflect `sqlite_temp_master` before the persistent catalog and preserve temporary-name precedence
- verify the complete temporary-table DML lifecycle on MySQL, PostgreSQL, and SQLite

## Recurrence prevention

- add a dedicated temporary-table generator to every SQLFaker dialect
- route those generators through all three rewrite fuzz targets
- add real-database tests for CREATE, INSERT SELECT, UPDATE, DELETE, and downstream INSERT SELECT
- cover wrapping a connection that already owns a SQLite temporary table

## Verification

- SQLite diff mutation: 44/44 killed (100%)
- SQLFaker diff mutation: 100% covered MSI
- PDO integration: 4 tests, 8 assertions
- issue reproduction audit: PASS
- lint and PHPStan passed

Fixes #122