### PR TITLE
fix(schema): resolve views against shadow state

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -150,6 +150,19 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function viewStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('create', [
+            'create' => [ProductionPattern::exactly('CREATE', 'view_or_trigger_or_sp_or_event')],
+            'view_or_trigger_or_sp_or_event' => [
+                ProductionPattern::exactly('no_definer', 'init_lex_create_info', 'no_definer_tail'),
+            ],
+            'no_definer_tail' => [ProductionPattern::exactly('view_tail')],
+            'query_primary' => [ProductionPattern::exactly('query_specification')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -714,4 +714,14 @@ final class MySqlProvider extends Base
             GenerationPlans::temporaryTableStatement()->withMaxDepth($maxDepth),
         );
     }
+    /** @return non-empty-string */
+    public function viewStatement(): string
+    {
+        $view = $this->rsg->rawIdentifier();
+        $table = $this->rsg->rawIdentifier();
+        $keyColumn = $this->rsg->rawIdentifier();
+        $valueColumn = $this->rsg->rawIdentifier();
+
+        return "CREATE VIEW $view AS SELECT $keyColumn, $valueColumn FROM $table WHERE $keyColumn IS NOT NULL";
+    }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -715,13 +715,8 @@ final class MySqlProvider extends Base
         );
     }
     /** @return non-empty-string */
-    public function viewStatement(): string
+    public function viewStatement(int $maxDepth = 40): string
     {
-        $view = $this->rsg->rawIdentifier();
-        $table = $this->rsg->rawIdentifier();
-        $keyColumn = $this->rsg->rawIdentifier();
-        $valueColumn = $this->rsg->rawIdentifier();
-
-        return "CREATE VIEW $view AS SELECT $keyColumn, $valueColumn FROM $table WHERE $keyColumn IS NOT NULL";
+        return $this->sql->generate(GenerationPlans::viewStatement()->withMaxDepth($maxDepth));
     }
 }

--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -50,6 +50,12 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function viewStatement(): GenerationPlan
+    {
+        return GenerationPlan::fromRule('ViewStmt')->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -423,6 +423,17 @@ final class PostgreSqlProvider extends Base
         );
     }
 
+    /** @return non-empty-string */
+    public function viewStatement(): string
+    {
+        $view = $this->rsg->rawIdentifier();
+        $table = $this->rsg->rawIdentifier();
+        $keyColumn = $this->rsg->rawIdentifier();
+        $valueColumn = $this->rsg->rawIdentifier();
+
+        return "CREATE VIEW $view AS SELECT $keyColumn, $valueColumn FROM $table WHERE $keyColumn IS NOT NULL";
+    }
+
     /**
      * @template TRequiresNonEmpty of bool
      * @param GenerationPlan<TRequiresNonEmpty> $plan

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -424,14 +424,9 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function viewStatement(): string
+    public function viewStatement(int $maxDepth = 40): string
     {
-        $view = $this->rsg->rawIdentifier();
-        $table = $this->rsg->rawIdentifier();
-        $keyColumn = $this->rsg->rawIdentifier();
-        $valueColumn = $this->rsg->rawIdentifier();
-
-        return "CREATE VIEW $view AS SELECT $keyColumn, $valueColumn FROM $table WHERE $keyColumn IS NOT NULL";
+        return $this->sql->generate(GenerationPlans::viewStatement()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/src/Sqlite/GenerationPlans.php
+++ b/packages/sql-faker/src/Sqlite/GenerationPlans.php
@@ -41,6 +41,15 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function viewStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('cmd', [
+            'cmd' => [ProductionPattern::containing('createkw', 'VIEW', 'select')],
+            'oneselect' => [ProductionPattern::containing('SELECT')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('conslist', [

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -278,13 +278,8 @@ final class SqliteProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function viewStatement(): string
+    public function viewStatement(int $maxDepth = 40): string
     {
-        $view = $this->rsg->rawIdentifier();
-        $table = $this->rsg->rawIdentifier();
-        $keyColumn = $this->rsg->rawIdentifier();
-        $valueColumn = $this->rsg->rawIdentifier();
-
-        return "CREATE VIEW $view AS SELECT $keyColumn, $valueColumn FROM $table WHERE $keyColumn IS NOT NULL";
+        return $this->sql->generate(GenerationPlans::viewStatement()->withMaxDepth($maxDepth));
     }
 }

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -276,4 +276,15 @@ final class SqliteProvider extends Base
             GenerationPlans::temporaryTableStatement()->withMaxDepth($maxDepth),
         );
     }
+
+    /** @return non-empty-string */
+    public function viewStatement(): string
+    {
+        $view = $this->rsg->rawIdentifier();
+        $table = $this->rsg->rawIdentifier();
+        $keyColumn = $this->rsg->rawIdentifier();
+        $valueColumn = $this->rsg->rawIdentifier();
+
+        return "CREATE VIEW $view AS SELECT $keyColumn, $valueColumn FROM $table WHERE $keyColumn IS NOT NULL";
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -200,7 +200,17 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::viewStatement();
 
         self::assertSame('create', $plan->startRule());
-        self::assertNotNull($plan->patternAt('view_or_trigger_or_sp_or_event', 0));
-        self::assertNotNull($plan->patternAt('no_definer_tail', 0));
+        self::assertTrue(
+            $plan->patternAt('create', 0)?->matches(['CREATE', 'view_or_trigger_or_sp_or_event']) ?? false,
+        );
+        self::assertTrue(
+            $plan->patternAt('view_or_trigger_or_sp_or_event', 0)?->matches([
+                'no_definer',
+                'init_lex_create_info',
+                'no_definer_tail',
+            ]) ?? false,
+        );
+        self::assertTrue($plan->patternAt('no_definer_tail', 0)?->matches(['view_tail']) ?? false);
+        self::assertTrue($plan->patternAt('query_primary', 0)?->matches(['query_specification']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -194,4 +194,13 @@ final class GenerationPlansTest extends TestCase
         self::assertSame('create_table_stmt', $plan->startRule());
         self::assertTrue($plan->patternAt('opt_temporary', 0)?->matches(['TEMPORARY']) ?? false);
     }
+
+    public function testViewPlanRestrictsTheCreateGrammar(): void
+    {
+        $plan = GenerationPlans::viewStatement();
+
+        self::assertSame('create', $plan->startRule());
+        self::assertNotNull($plan->patternAt('view_or_trigger_or_sp_or_event', 0));
+        self::assertNotNull($plan->patternAt('no_definer_tail', 0));
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -113,14 +113,21 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('TABLE_SYM', $tokens);
     }
 
-    public function testViewStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testViewStatement(int $seed): void
     {
-        $sql = (new MySqlProvider(Factory::create()))->viewStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new MySqlProvider($faker);
+        $sql = $provider->viewStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))
+            ->tokenize($sql);
 
-        self::assertStringStartsWith('CREATE VIEW ', $sql);
-        self::assertStringContainsString(' AS SELECT ', $sql);
-        self::assertStringContainsString(' FROM ', $sql);
-        self::assertStringEndsWith(' IS NOT NULL', $sql);
+        self::assertSame($sql, $provider->viewStatement(40));
+        self::assertSame('CREATE', $tokens[0]);
+        self::assertContains('VIEW_SYM', $tokens);
+        self::assertContains('SELECT_SYM', $tokens);
     }
 
     public function testSql(): void

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -113,6 +113,16 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('TABLE_SYM', $tokens);
     }
 
+    public function testViewStatement(): void
+    {
+        $sql = (new MySqlProvider(Factory::create()))->viewStatement();
+
+        self::assertStringStartsWith('CREATE VIEW ', $sql);
+        self::assertStringContainsString(' AS SELECT ', $sql);
+        self::assertStringContainsString(' FROM ', $sql);
+        self::assertStringEndsWith(' IS NOT NULL', $sql);
+    }
+
     public function testSql(): void
     {
         $faker = Factory::create();

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -63,4 +63,9 @@ final class GenerationPlansTest extends TestCase
         self::assertSame('CreateStmt', $plan->startRule());
         self::assertTrue($plan->patternAt('OptTemp', 0)?->matches(['TEMP']) ?? false);
     }
+
+    public function testViewPlanStartsFromTheViewGrammar(): void
+    {
+        self::assertSame('ViewStmt', GenerationPlans::viewStatement()->startRule());
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -96,14 +96,21 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('TABLE', $tokens);
     }
 
-    public function testViewStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testViewStatement(int $seed): void
     {
-        $sql = (new PostgreSqlProvider(Factory::create()))->viewStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->viewStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'pg-17.2', true))
+            ->tokenize($sql);
 
-        self::assertStringStartsWith('CREATE VIEW ', $sql);
-        self::assertStringContainsString(' AS SELECT ', $sql);
-        self::assertStringContainsString(' FROM ', $sql);
-        self::assertStringEndsWith(' IS NOT NULL', $sql);
+        self::assertSame($sql, $provider->viewStatement(40));
+        self::assertSame('CREATE', $tokens[0]);
+        self::assertContains('VIEW', $tokens);
+        self::assertNotSame([], array_intersect(['SELECT', 'VALUES', 'TABLE'], $tokens));
     }
 
     #[\Override]

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -96,6 +96,16 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('TABLE', $tokens);
     }
 
+    public function testViewStatement(): void
+    {
+        $sql = (new PostgreSqlProvider(Factory::create()))->viewStatement();
+
+        self::assertStringStartsWith('CREATE VIEW ', $sql);
+        self::assertStringContainsString(' AS SELECT ', $sql);
+        self::assertStringContainsString(' FROM ', $sql);
+        self::assertStringEndsWith(' IS NOT NULL', $sql);
+    }
+
     #[\Override]
     protected function setUp(): void
     {

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -70,4 +70,13 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('cmd', 0)?->matches(['create_table', 'create_table_args']) ?? false);
         self::assertTrue($plan->patternAt('temp', 0)?->matches(['TEMP']) ?? false);
     }
+
+    public function testViewPlanRestrictsTheCreateGrammar(): void
+    {
+        $plan = GenerationPlans::viewStatement();
+
+        self::assertSame('cmd', $plan->startRule());
+        self::assertNotNull($plan->patternAt('cmd', 0));
+        self::assertNotNull($plan->patternAt('oneselect', 0));
+    }
 }

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -76,7 +76,7 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::viewStatement();
 
         self::assertSame('cmd', $plan->startRule());
-        self::assertNotNull($plan->patternAt('cmd', 0));
-        self::assertNotNull($plan->patternAt('oneselect', 0));
+        self::assertTrue($plan->patternAt('cmd', 0)?->matches(['createkw', 'VIEW', 'select']) ?? false);
+        self::assertTrue($plan->patternAt('oneselect', 0)?->matches(['SELECT']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -95,6 +95,16 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('TABLE', $tokens);
     }
 
+    public function testViewStatement(): void
+    {
+        $sql = (new SqliteProvider(Factory::create()))->viewStatement();
+
+        self::assertStringStartsWith('CREATE VIEW ', $sql);
+        self::assertStringContainsString(' AS SELECT ', $sql);
+        self::assertStringContainsString(' FROM ', $sql);
+        self::assertStringEndsWith(' IS NOT NULL', $sql);
+    }
+
     #[\Override]
     protected function setUp(): void
     {

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -95,14 +95,21 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('TABLE', $tokens);
     }
 
-    public function testViewStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testViewStatement(int $seed): void
     {
-        $sql = (new SqliteProvider(Factory::create()))->viewStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new SqliteProvider($faker);
+        $sql = $provider->viewStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'sqlite-3.47.2', true))
+            ->tokenize($sql);
 
-        self::assertStringStartsWith('CREATE VIEW ', $sql);
-        self::assertStringContainsString(' AS SELECT ', $sql);
-        self::assertStringContainsString(' FROM ', $sql);
-        self::assertStringEndsWith(' IS NOT NULL', $sql);
+        self::assertSame($sql, $provider->viewStatement(40));
+        self::assertSame('CREATE', $tokens[0]);
+        self::assertContains('VIEW', $tokens);
+        self::assertContains('SELECT', $tokens);
     }
 
     #[\Override]
@@ -713,4 +720,5 @@ final class SqliteProviderTest extends TestCase
         yield 'AlterTable' => [StatementType::AlterTable];
         yield 'DropTable' => [StatementType::DropTable];
     }
+
 }

--- a/packages/ztd-query-core/src/Platform/ViewReflector.php
+++ b/packages/ztd-query-core/src/Platform/ViewReflector.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform;
+
+use ZtdQuery\Schema\ViewDefinition;
+
+interface ViewReflector
+{
+    /** @return array<string, ViewDefinition> */
+    public function reflectViews(): array;
+}

--- a/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
+++ b/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
@@ -18,7 +18,7 @@ interface SqlTransformer
      * Transform a SQL statement using the provided table context.
      *
      * @param string $sql The original SQL statement.
-     * @param array<string, array{
+     * @param array<string, array{viewSql: string}|array{
      *     rows: array<int, array<string, mixed>>,
      *     columns: array<int, string>,
      *     columnTypes: array<string, ColumnType>,

--- a/packages/ztd-query-core/src/Schema/ViewDefinition.php
+++ b/packages/ztd-query-core/src/Schema/ViewDefinition.php
@@ -4,53 +4,12 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Schema;
 
-use ZtdQuery\Sql\SqlTokenDialect;
-use ZtdQuery\Sql\SqlTokenStream;
-
 final class ViewDefinition
 {
     /** @param list<string> $dependencies */
     public function __construct(
         public readonly string $query,
         public readonly array $dependencies,
-        private readonly SqlTokenDialect $dialect = SqlTokenDialect::Standard,
     ) {
-    }
-
-    public static function fromQuery(
-        string $query,
-        SqlTokenDialect $dialect = SqlTokenDialect::Standard,
-    ): self {
-        $query = rtrim(trim($query), ';');
-
-        return new self(
-            $query,
-            SqlTokenStream::tokenize($query, $dialect)->selectTableNames(),
-            $dialect,
-        );
-    }
-
-    public static function fromCreateStatement(
-        string $sql,
-        SqlTokenDialect $dialect = SqlTokenDialect::Standard,
-    ): ?self {
-        foreach (SqlTokenStream::tokenize($sql, $dialect)->significantTokens() as $token) {
-            if (!$token->isTopLevel() || !$token->isKeyword('AS')) {
-                continue;
-            }
-            $query = substr($sql, $token->endOffset());
-            if (trim($query) !== '') {
-                return self::fromQuery($query, $dialect);
-            }
-        }
-
-        return null;
-    }
-
-    /** @param list<string> $relationNames */
-    public function shadowQuery(array $relationNames): string
-    {
-        return SqlTokenStream::tokenize($this->query, $this->dialect)
-            ->unqualifySelectTableReferences($relationNames);
     }
 }

--- a/packages/ztd-query-core/src/Schema/ViewDefinition.php
+++ b/packages/ztd-query-core/src/Schema/ViewDefinition.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class ViewDefinition
+{
+    /** @param list<string> $dependencies */
+    public function __construct(
+        public readonly string $query,
+        public readonly array $dependencies,
+        private readonly SqlTokenDialect $dialect = SqlTokenDialect::Standard,
+    ) {
+    }
+
+    public static function fromQuery(
+        string $query,
+        SqlTokenDialect $dialect = SqlTokenDialect::Standard,
+    ): self {
+        $query = rtrim(trim($query), ';');
+
+        return new self(
+            $query,
+            SqlTokenStream::tokenize($query, $dialect)->selectTableNames(),
+            $dialect,
+        );
+    }
+
+    public static function fromCreateStatement(
+        string $sql,
+        SqlTokenDialect $dialect = SqlTokenDialect::Standard,
+    ): ?self {
+        foreach (SqlTokenStream::tokenize($sql, $dialect)->significantTokens() as $token) {
+            if (!$token->isTopLevel() || !$token->isKeyword('AS')) {
+                continue;
+            }
+            $query = substr($sql, $token->endOffset());
+            if (trim($query) !== '') {
+                return self::fromQuery($query, $dialect);
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<string> $relationNames */
+    public function shadowQuery(array $relationNames): string
+    {
+        return SqlTokenStream::tokenize($this->query, $this->dialect)
+            ->unqualifySelectTableReferences($relationNames);
+    }
+}

--- a/packages/ztd-query-core/src/Schema/ViewDefinitionSet.php
+++ b/packages/ztd-query-core/src/Schema/ViewDefinitionSet.php
@@ -25,10 +25,9 @@ final class ViewDefinitionSet
     }
 
     /**
-     * @param list<string> $tableNames
-     * @return array<string, string>
+     * @return array<string, ViewDefinition>
      */
-    public function shadowQueries(array $tableNames): array
+    public function orderedDefinitions(): array
     {
         $remaining = $this->definitions;
         $ordered = [];
@@ -54,12 +53,6 @@ final class ViewDefinitionSet
             }
         }
 
-        $relationNames = array_merge($tableNames, array_keys($ordered));
-        $queries = [];
-        foreach ($ordered as $viewName => $definition) {
-            $queries[$viewName] = $definition->shadowQuery($relationNames);
-        }
-
-        return $queries;
+        return $ordered;
     }
 }

--- a/packages/ztd-query-core/src/Schema/ViewDefinitionSet.php
+++ b/packages/ztd-query-core/src/Schema/ViewDefinitionSet.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+final class ViewDefinitionSet
+{
+    /** @var array<string, ViewDefinition> */
+    private array $definitions = [];
+
+    public function register(string $viewName, ViewDefinition $definition): void
+    {
+        $this->definitions[$viewName] = $definition;
+    }
+
+    public function has(string $viewName): bool
+    {
+        return isset($this->definitions[$viewName]);
+    }
+
+    public function hasAnyViews(): bool
+    {
+        return $this->definitions !== [];
+    }
+
+    /**
+     * @param list<string> $tableNames
+     * @return array<string, string>
+     */
+    public function shadowQueries(array $tableNames): array
+    {
+        $remaining = $this->definitions;
+        $ordered = [];
+        while ($remaining !== []) {
+            $progress = false;
+            foreach ($remaining as $viewName => $definition) {
+                $pendingDependencies = array_filter(
+                    $definition->dependencies,
+                    static fn (string $dependency): bool => isset($remaining[$dependency]),
+                );
+                if ($pendingDependencies !== []) {
+                    continue;
+                }
+                $ordered[$viewName] = $definition;
+                unset($remaining[$viewName]);
+                $progress = true;
+            }
+            if (!$progress) {
+                foreach ($remaining as $viewName => $definition) {
+                    $ordered[$viewName] = $definition;
+                }
+                break;
+            }
+        }
+
+        $relationNames = array_merge($tableNames, array_keys($ordered));
+        $queries = [];
+        foreach ($ordered as $viewName => $definition) {
+            $queries[$viewName] = $definition->shadowQuery($relationNames);
+        }
+
+        return $queries;
+    }
+}

--- a/packages/ztd-query-core/tests/Fake/FakeSqlTransformer.php
+++ b/packages/ztd-query-core/tests/Fake/FakeSqlTransformer.php
@@ -33,6 +33,11 @@ final class FakeSqlTransformer implements SqlTransformer
 
         $ctes = [];
         foreach ($tables as $tableName => $tableData) {
+            if (isset($tableData['viewSql'])) {
+                $ctes[] = $this->quoter->quote($tableName) . ' AS (' . $tableData['viewSql'] . ')';
+                continue;
+            }
+
             $ctes[] = $this->buildCte($tableName, $tableData);
         }
 

--- a/packages/ztd-query-core/tests/Unit/Platform/ViewReflectorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Platform/ViewReflectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\ViewReflector;
+
+#[CoversNothing]
+final class ViewReflectorTest extends TestCase
+{
+    public function testImplementationUsesViewReflectorContract(): void
+    {
+        $reflector = new class () implements ViewReflector {
+            public function reflectViews(): array
+            {
+                return [];
+            }
+        };
+
+        self::assertInstanceOf(ViewReflector::class, $reflector);
+        self::assertSame([], $reflector->reflectViews());
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Rewrite/SqlTransformerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/SqlTransformerTest.php
@@ -22,6 +22,19 @@ final class SqlTransformerTest extends TransformerContractTest
         return 'SELECT * FROM users WHERE id = 1';
     }
 
+    public function testViewContextIsRenderedAsCte(): void
+    {
+        $result = $this->createTransformer()->transform(
+            'SELECT * FROM active_users',
+            ['active_users' => ['viewSql' => 'SELECT * FROM users WHERE active = 1']],
+        );
+
+        self::assertSame(
+            'WITH "active_users" AS (SELECT * FROM users WHERE active = 1) SELECT * FROM active_users',
+            $result,
+        );
+    }
+
     #[\Override]
     protected function nativeIntegerType(): string
     {

--- a/packages/ztd-query-core/tests/Unit/Schema/ViewDefinitionSetTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ViewDefinitionSetTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Schema\ViewDefinitionSet;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(ViewDefinitionSet::class)]
+#[UsesClass(ViewDefinition::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class ViewDefinitionSetTest extends TestCase
+{
+    public function testOrdersViewsAfterTheirDependencies(): void
+    {
+        $definitions = new ViewDefinitionSet();
+        $definitions->register('summary', ViewDefinition::fromQuery('SELECT count(*) FROM active_users'));
+        $definitions->register('active_users', ViewDefinition::fromQuery('SELECT * FROM users WHERE active = 1'));
+
+        self::assertSame(
+            ['active_users', 'summary'],
+            array_keys($definitions->shadowQueries(['users'])),
+        );
+    }
+
+    public function testOrdersThreeDependencyLevelsAndUnqualifiesEveryRelationKind(): void
+    {
+        $definitions = new ViewDefinitionSet();
+        $definitions->register('summary', ViewDefinition::fromQuery('SELECT count(*) FROM tenant.active_users'));
+        $definitions->register('active_users', ViewDefinition::fromQuery('SELECT * FROM tenant.eligible_users'));
+        $definitions->register('eligible_users', ViewDefinition::fromQuery('SELECT * FROM tenant.users'));
+
+        self::assertSame(
+            [
+                'eligible_users' => 'SELECT * FROM users',
+                'active_users' => 'SELECT * FROM eligible_users',
+                'summary' => 'SELECT count(*) FROM active_users',
+            ],
+            $definitions->shadowQueries(['users']),
+        );
+    }
+
+
+    public function testKeepsCyclicDefinitionsDeterministic(): void
+    {
+        $definitions = new ViewDefinitionSet();
+        $definitions->register('left_view', ViewDefinition::fromQuery('SELECT * FROM right_view'));
+        $definitions->register('right_view', ViewDefinition::fromQuery('SELECT * FROM left_view'));
+
+        self::assertSame(
+            ['left_view', 'right_view'],
+            array_keys($definitions->shadowQueries([])),
+        );
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/ViewDefinitionSetTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ViewDefinitionSetTest.php
@@ -9,56 +9,54 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Schema\ViewDefinition;
 use ZtdQuery\Schema\ViewDefinitionSet;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(ViewDefinitionSet::class)]
 #[UsesClass(ViewDefinition::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class ViewDefinitionSetTest extends TestCase
 {
     public function testOrdersViewsAfterTheirDependencies(): void
     {
         $definitions = new ViewDefinitionSet();
-        $definitions->register('summary', ViewDefinition::fromQuery('SELECT count(*) FROM active_users'));
-        $definitions->register('active_users', ViewDefinition::fromQuery('SELECT * FROM users WHERE active = 1'));
+        $summary = new ViewDefinition('summary query', ['active_users']);
+        $activeUsers = new ViewDefinition('active users query', ['users']);
+        $definitions->register('summary', $summary);
+        $definitions->register('active_users', $activeUsers);
 
         self::assertSame(
-            ['active_users', 'summary'],
-            array_keys($definitions->shadowQueries(['users'])),
+            ['active_users' => $activeUsers, 'summary' => $summary],
+            $definitions->orderedDefinitions(),
         );
     }
 
-    public function testOrdersThreeDependencyLevelsAndUnqualifiesEveryRelationKind(): void
+    public function testOrdersThreeDependencyLevels(): void
     {
         $definitions = new ViewDefinitionSet();
-        $definitions->register('summary', ViewDefinition::fromQuery('SELECT count(*) FROM tenant.active_users'));
-        $definitions->register('active_users', ViewDefinition::fromQuery('SELECT * FROM tenant.eligible_users'));
-        $definitions->register('eligible_users', ViewDefinition::fromQuery('SELECT * FROM tenant.users'));
+        $summary = new ViewDefinition('summary query', ['active_users']);
+        $activeUsers = new ViewDefinition('active users query', ['eligible_users']);
+        $eligibleUsers = new ViewDefinition('eligible users query', ['users']);
+        $definitions->register('summary', $summary);
+        $definitions->register('active_users', $activeUsers);
+        $definitions->register('eligible_users', $eligibleUsers);
 
         self::assertSame(
             [
-                'eligible_users' => 'SELECT * FROM users',
-                'active_users' => 'SELECT * FROM eligible_users',
-                'summary' => 'SELECT count(*) FROM active_users',
+                'eligible_users' => $eligibleUsers,
+                'active_users' => $activeUsers,
+                'summary' => $summary,
             ],
-            $definitions->shadowQueries(['users']),
+            $definitions->orderedDefinitions(),
         );
     }
-
 
     public function testKeepsCyclicDefinitionsDeterministic(): void
     {
         $definitions = new ViewDefinitionSet();
-        $definitions->register('left_view', ViewDefinition::fromQuery('SELECT * FROM right_view'));
-        $definitions->register('right_view', ViewDefinition::fromQuery('SELECT * FROM left_view'));
+        $definitions->register('left_view', new ViewDefinition('left query', ['right_view']));
+        $definitions->register('right_view', new ViewDefinition('right query', ['left_view']));
 
         self::assertSame(
             ['left_view', 'right_view'],
-            array_keys($definitions->shadowQueries([])),
+            array_keys($definitions->orderedDefinitions()),
         );
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/ViewDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ViewDefinitionTest.php
@@ -5,49 +5,17 @@ declare(strict_types=1);
 namespace Tests\Unit\Schema;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Schema\ViewDefinition;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(ViewDefinition::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class ViewDefinitionTest extends TestCase
 {
-    public function testFromQueryIsPublicAndNormalizesOuterWhitespace(): void
+    public function testCarriesAQueryAndItsSemanticDependencies(): void
     {
-        $method = new \ReflectionMethod(ViewDefinition::class, 'fromQuery');
-        $definition = ViewDefinition::fromQuery("  SELECT * FROM users;  \n");
+        $definition = new ViewDefinition('SELECT * FROM users', ['users']);
 
-        self::assertTrue($method->isPublic());
         self::assertSame('SELECT * FROM users', $definition->query);
-    }
-
-    public function testExtractsQueryAndDependenciesFromCreateStatement(): void
-    {
-        $definition = ViewDefinition::fromCreateStatement(
-            'CREATE VIEW active_users AS SELECT users.id FROM public.users JOIN roles ON roles.id = users.role_id;',
-        );
-
-        self::assertNotNull($definition);
-        self::assertSame(
-            'SELECT users.id FROM public.users JOIN roles ON roles.id = users.role_id',
-            $definition->query,
-        );
-        self::assertSame(['users', 'roles'], $definition->dependencies);
-        self::assertSame(
-            'SELECT users.id FROM users JOIN roles ON roles.id = users.role_id',
-            $definition->shadowQuery(['users', 'roles']),
-        );
-    }
-
-    public function testRejectsCreateStatementWithoutViewQuery(): void
-    {
-        self::assertNull(ViewDefinition::fromCreateStatement('CREATE VIEW invalid'));
-        self::assertNull(ViewDefinition::fromCreateStatement('CREATE VIEW invalid AS   '));
+        self::assertSame(['users'], $definition->dependencies);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/ViewDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ViewDefinitionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(ViewDefinition::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class ViewDefinitionTest extends TestCase
+{
+    public function testFromQueryIsPublicAndNormalizesOuterWhitespace(): void
+    {
+        $method = new \ReflectionMethod(ViewDefinition::class, 'fromQuery');
+        $definition = ViewDefinition::fromQuery("  SELECT * FROM users;  \n");
+
+        self::assertTrue($method->isPublic());
+        self::assertSame('SELECT * FROM users', $definition->query);
+    }
+
+    public function testExtractsQueryAndDependenciesFromCreateStatement(): void
+    {
+        $definition = ViewDefinition::fromCreateStatement(
+            'CREATE VIEW active_users AS SELECT users.id FROM public.users JOIN roles ON roles.id = users.role_id;',
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame(
+            'SELECT users.id FROM public.users JOIN roles ON roles.id = users.role_id',
+            $definition->query,
+        );
+        self::assertSame(['users', 'roles'], $definition->dependencies);
+        self::assertSame(
+            'SELECT users.id FROM users JOIN roles ON roles.id = users.role_id',
+            $definition->shadowQuery(['users', 'roles']),
+        );
+    }
+
+    public function testRejectsCreateStatementWithoutViewQuery(): void
+    {
+        self::assertNull(ViewDefinition::fromCreateStatement('CREATE VIEW invalid'));
+        self::assertNull(ViewDefinition::fromCreateStatement('CREATE VIEW invalid AS   '));
+    }
+}

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -148,6 +148,7 @@ final class RewriteTarget
             fn (): string => $this->provider->insertRowAliasUpsertStatement(),
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
             fn (): string => $this->provider->temporaryTableStatement(),
+            fn (): string => $this->provider->viewStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/MySqlCteShadowComposer.php
+++ b/packages/ztd-query-mysql/src/MySqlCteShadowComposer.php
@@ -24,16 +24,29 @@ final class MySqlCteShadowComposer
     public function compose(string $sql, array $tableCtes): string
     {
         $declared = array_fill_keys($this->declaredCteNames($sql), true);
-        $ctes = [];
-        $shadowedTables = [];
-        foreach ($tableCtes as $table => $cte) {
+        $requiredSql = [$sql];
+        $requiredCtes = [];
+        foreach (array_reverse($tableCtes, true) as $table => $cte) {
             $normalized = strtolower($table);
-            if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
+            if (isset($declared[$normalized])) {
                 continue;
             }
-            $ctes[] = $cte;
-            $shadowedTables[] = $table;
+            $referenced = false;
+            foreach ($requiredSql as $requiredPart) {
+                if ($this->referencesIdentifier($requiredPart, $table)) {
+                    $referenced = true;
+                }
+            }
+            if (!$referenced) {
+                continue;
+            }
+            $requiredCtes[$table] = $cte;
+            $requiredSql[] = $cte;
         }
+
+        $requiredCtes = array_reverse($requiredCtes, true);
+        $ctes = $requiredCtes;
+        $shadowedTables = array_keys($requiredCtes);
 
         if ($ctes === []) {
             return $sql;

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -241,7 +241,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
             ];
         }
 
-        foreach ($this->views->shadowQueries(array_keys($context)) as $viewName => $viewSql) {
+        foreach ((new MySqlViewShadowRenderer())->render($this->views, array_keys($context)) as $viewName => $viewSql) {
             if (isset($context[$viewName])) {
                 continue;
             }

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -16,6 +16,7 @@ use ZtdQuery\Sql\TransactionStatement;
 use PhpMyAdmin\SqlParser\Statement;
 use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Shadow\ShadowStore;
 use PhpMyAdmin\SqlParser\Statements\AlterStatement;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
@@ -42,6 +43,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
     private MySqlMutationResolver $mutationResolver;
     private MySqlParser $parser;
     private MySqlCteShadowComposer $cteComposer;
+    private ViewDefinitionSet $views;
 
     public function __construct(
         MySqlQueryGuard $guard,
@@ -49,7 +51,8 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
         TableDefinitionRegistry $registry,
         MySqlTransformer $transformer,
         MySqlMutationResolver $mutationResolver,
-        MySqlParser $parser
+        MySqlParser $parser,
+        ?ViewDefinitionSet $views = null,
     ) {
         $this->guard = $guard;
         $this->shadowStore = $shadowStore;
@@ -58,6 +61,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
         $this->mutationResolver = $mutationResolver;
         $this->parser = $parser;
         $this->cteComposer = new MySqlCteShadowComposer();
+        $this->views = $views ?? new ViewDefinitionSet();
     }
 
     /**
@@ -178,7 +182,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
     /**
      * Build the table context map for transformers.
      *
-     * @return array<string, array{
+     * @return array<string, array{viewSql: string}|array{
      *     rows: array<int, array<string, mixed>>,
      *     columns: array<int, string>,
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
@@ -235,6 +239,13 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'primaryKeys' => $definition->primaryKeys,
                 'candidateKeys' => $definition->candidateKeys()->keys(),
             ];
+        }
+
+        foreach ($this->views->shadowQueries(array_keys($context)) as $viewName => $viewSql) {
+            if (isset($context[$viewName])) {
+                continue;
+            }
+            $context[$viewName] = ['viewSql' => $viewSql];
         }
 
         return $context;
@@ -296,6 +307,10 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
             return true;
         }
 
+        if ($this->views->has($tableName)) {
+            return true;
+        }
+
         return false;
     }
 
@@ -306,6 +321,10 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
         }
 
         if ($this->registry->hasAnyTables()) {
+            return true;
+        }
+
+        if ($this->views->hasAnyViews()) {
             return true;
         }
 

--- a/packages/ztd-query-mysql/src/MySqlSchemaReflector.php
+++ b/packages/ztd-query-mysql/src/MySqlSchemaReflector.php
@@ -6,11 +6,14 @@ namespace ZtdQuery\Platform\MySql;
 
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\SchemaReflector;
+use ZtdQuery\Platform\ViewReflector;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Sql\SqlTokenDialect;
 
 /**
  * Fetches MySQL schema information via SQL queries.
  */
-final class MySqlSchemaReflector implements SchemaReflector
+final class MySqlSchemaReflector implements SchemaReflector, ViewReflector
 {
     /**
      * Connection instance used to issue schema queries.
@@ -67,5 +70,39 @@ final class MySqlSchemaReflector implements SchemaReflector
         }
 
         return $result;
+    }
+
+    /** {@inheritDoc} */
+    public function reflectViews(): array
+    {
+        $stmt = $this->connection->query("SHOW FULL TABLES WHERE Table_type = 'VIEW'");
+        if ($stmt === false) {
+            return [];
+        }
+
+        $definitions = [];
+        foreach ($stmt->fetchAll() as $row) {
+            $viewName = array_values($row)[0] ?? null;
+            if (!is_string($viewName) || $viewName === '') {
+                continue;
+            }
+            $createStatement = $this->connection->query(
+                'SHOW CREATE VIEW `' . str_replace('`', '``', $viewName) . '`',
+            );
+            if ($createStatement === false) {
+                continue;
+            }
+            $createRows = $createStatement->fetchAll();
+            $createSql = $createRows[0]['Create View'] ?? null;
+            if (!is_string($createSql)) {
+                continue;
+            }
+            $definition = ViewDefinition::fromCreateStatement($createSql, SqlTokenDialect::MySql);
+            if ($definition !== null) {
+                $definitions[$viewName] = $definition;
+            }
+        }
+
+        return $definitions;
     }
 }

--- a/packages/ztd-query-mysql/src/MySqlSchemaReflector.php
+++ b/packages/ztd-query-mysql/src/MySqlSchemaReflector.php
@@ -8,7 +8,6 @@ use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\SchemaReflector;
 use ZtdQuery\Platform\ViewReflector;
 use ZtdQuery\Schema\ViewDefinition;
-use ZtdQuery\Sql\SqlTokenDialect;
 
 /**
  * Fetches MySQL schema information via SQL queries.
@@ -97,7 +96,7 @@ final class MySqlSchemaReflector implements SchemaReflector, ViewReflector
             if (!is_string($createSql)) {
                 continue;
             }
-            $definition = ViewDefinition::fromCreateStatement($createSql, SqlTokenDialect::MySql);
+            $definition = (new MySqlViewDefinitionParser())->fromCreateStatement($createSql);
             if ($definition !== null) {
                 $definitions[$viewName] = $definition;
             }

--- a/packages/ztd-query-mysql/src/MySqlSessionFactory.php
+++ b/packages/ztd-query-mysql/src/MySqlSessionFactory.php
@@ -14,6 +14,7 @@ use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
 use ZtdQuery\Shadow\ShadowStore;
@@ -41,6 +42,10 @@ final class MySqlSessionFactory implements SessionFactory
                 $registry->register($tableName, $definition);
             }
         }
+        $views = new ViewDefinitionSet();
+        foreach ($reflector->reflectViews() as $viewName => $definition) {
+            $views->register($viewName, $definition);
+        }
 
         $guard = new MySqlQueryGuard($parser);
         $selectTransformer = new SelectTransformer();
@@ -50,7 +55,7 @@ final class MySqlSessionFactory implements SessionFactory
         $replaceTransformer = new ReplaceTransformer($parser, $selectTransformer);
         $transformer = new MySqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer, $replaceTransformer);
         $mutationResolver = new MySqlMutationResolver($shadowStore, $registry, $schemaParser, $updateTransformer, $deleteTransformer);
-        $rewriter = new MySqlRewriter($guard, $shadowStore, $registry, $transformer, $mutationResolver, $parser);
+        $rewriter = new MySqlRewriter($guard, $shadowStore, $registry, $transformer, $mutationResolver, $parser, $views);
 
         return new Session(
             $rewriter,

--- a/packages/ztd-query-mysql/src/MySqlTypeSemantics.php
+++ b/packages/ztd-query-mysql/src/MySqlTypeSemantics.php
@@ -16,7 +16,7 @@ use ZtdQuery\Sql\SqlTokenDialect;
 final class MySqlTypeSemantics
 {
     /**
-     * @param array<string, array{
+     * @param array<string, array{viewSql: string}|array{
      *     rows: array<int, array<string, mixed>>,
      *     columns: array<int, string>,
      *     columnTypes: array<string, ColumnType>
@@ -40,7 +40,7 @@ final class MySqlTypeSemantics
     }
 
     /**
-     * @param array<string, array{
+     * @param array<string, array{viewSql: string}|array{
      *     rows: array<int, array<string, mixed>>,
      *     columns: array<int, string>,
      *     columnTypes: array<string, ColumnType>
@@ -52,6 +52,9 @@ final class MySqlTypeSemantics
         $qualified = [];
         $unqualified = [];
         foreach ($tables as $table => $context) {
+            if (isset($context['viewSql'])) {
+                continue;
+            }
             foreach ($context['columnTypes'] as $column => $type) {
                 $members = $this->enumMembers($type->nativeType);
                 if ($members === []) {

--- a/packages/ztd-query-mysql/src/MySqlViewDefinitionParser.php
+++ b/packages/ztd-query-mysql/src/MySqlViewDefinitionParser.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class MySqlViewDefinitionParser
+{
+    public function fromQuery(string $query): ViewDefinition
+    {
+        $query = rtrim(trim($query), ';');
+
+        return new ViewDefinition($query, (new MySqlSelectRelationParser())->tableNames($query));
+    }
+
+    public function fromCreateStatement(string $sql): ?ViewDefinition
+    {
+        foreach (SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql)->significantTokens() as $token) {
+            if (!$token->isTopLevel() || !$token->isKeyword('AS')) {
+                continue;
+            }
+            $query = substr($sql, $token->endOffset());
+            if (trim($query) !== '') {
+                return $this->fromQuery($query);
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlViewShadowRenderer.php
+++ b/packages/ztd-query-mysql/src/MySqlViewShadowRenderer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Schema\ViewDefinitionSet;
+
+final class MySqlViewShadowRenderer
+{
+    /**
+     * @param list<string> $tableNames
+     * @return array<string, string>
+     */
+    public function render(ViewDefinitionSet $views, array $tableNames): array
+    {
+        $definitions = $views->orderedDefinitions();
+        $relationNames = array_merge($tableNames, array_keys($definitions));
+        $queries = [];
+        $relationParser = new MySqlSelectRelationParser();
+        foreach ($definitions as $viewName => $definition) {
+            $queries[$viewName] = $relationParser->unqualify($definition->query, $relationNames);
+        }
+
+        return $queries;
+    }
+}

--- a/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/DeleteTransformer.php
@@ -55,7 +55,7 @@ final class DeleteTransformer implements SqlTransformer
         }
 
         $columnNames = [];
-        if ($targetTable !== null && isset($tables[$targetTable])) {
+        if ($targetTable !== null && isset($tables[$targetTable]['columns'])) {
             $columnNames = $tables[$targetTable]['columns'];
         }
 
@@ -242,7 +242,7 @@ final class DeleteTransformer implements SqlTransformer
 
     /**
      * @param array<string, array{alias: string}> $resolvedTables
-     * @param array<string, array{rows: array<int, array<string, mixed>>, columns: array<int, string>, columnTypes: array<string, \ZtdQuery\Schema\ColumnType>, primaryKeys?: array<int, string>}> $contexts
+     * @param array<string, array{viewSql: string}|array{rows: array<int, array<string, mixed>>, columns: array<int, string>, columnTypes: array<string, \ZtdQuery\Schema\ColumnType>, primaryKeys?: array<int, string>}> $contexts
      * @return list<MultiTableMutationTarget>
      */
     private function targetsFromContexts(array $resolvedTables, array $contexts): array
@@ -250,7 +250,7 @@ final class DeleteTransformer implements SqlTransformer
         $targets = [];
         foreach ($resolvedTables as $tableName => $tableInfo) {
             $context = $contexts[$tableName] ?? null;
-            if ($context === null) {
+            if (!isset($context['columns'])) {
                 continue;
             }
             $targets[] = new MultiTableMutationTarget(

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -51,6 +51,11 @@ final class SelectTransformer implements SqlTransformer
 
         $ctes = [];
         foreach ($tables as $tableName => $tableContext) {
+            if (isset($tableContext['viewSql'])) {
+                $ctes[$tableName] = $this->quoter->quote($tableName) . " AS ({$tableContext['viewSql']})";
+                continue;
+            }
+
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];
             $columnTypes = $tableContext['columnTypes'];
@@ -228,7 +233,7 @@ final class SelectTransformer implements SqlTransformer
     /**
      * Rewrite ORDER BY on SET columns to MySQL-compatible bit-order ranking.
      *
-     * @param array<string, array{
+     * @param array<string, array{viewSql: string}|array{
      *     rows: array<int, array<string, mixed>>,
      *     columns: array<int, string>,
      *     columnTypes: array<string, ColumnType>
@@ -244,6 +249,9 @@ final class SelectTransformer implements SqlTransformer
         $unqualifiedSetMap = [];
 
         foreach ($tables as $tableName => $tableContext) {
+            if (isset($tableContext['viewSql'])) {
+                continue;
+            }
             if (stripos($sql, $tableName) === false) {
                 continue;
             }

--- a/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/UpdateTransformer.php
@@ -223,7 +223,7 @@ final class UpdateTransformer implements SqlTransformer
 
     /**
      * @param array<string, array{alias: string}> $targetTables
-     * @param array<string, array{rows: array<int, array<string, mixed>>, columns: array<int, string>, columnTypes: array<string, \ZtdQuery\Schema\ColumnType>, primaryKeys?: array<int, string>}> $contexts
+     * @param array<string, array{viewSql: string}|array{rows: array<int, array<string, mixed>>, columns: array<int, string>, columnTypes: array<string, \ZtdQuery\Schema\ColumnType>, primaryKeys?: array<int, string>}> $contexts
      * @return list<MultiTableMutationTarget>
      */
     private function targetsFromContexts(array $targetTables, array $contexts): array
@@ -231,7 +231,7 @@ final class UpdateTransformer implements SqlTransformer
         $targets = [];
         foreach ($targetTables as $tableName => $tableInfo) {
             $context = $contexts[$tableName] ?? null;
-            if ($context === null) {
+            if (!isset($context['columns'])) {
                 continue;
             }
             $targets[] = new MultiTableMutationTarget(

--- a/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
@@ -13,6 +13,21 @@ use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 final class MySqlCteShadowComposerTest extends TestCase
 {
+    public function testIncludesTransitivelyReferencedShadowCtes(): void
+    {
+        self::assertSame(
+            "WITH \"items\" AS (SELECT 1 AS id),\n\"item_view\" AS (SELECT * FROM items)\nSELECT * FROM item_view",
+            (new CteShadowComposer())->compose(
+                'SELECT * FROM item_view',
+                [
+                    'items' => '"items" AS (SELECT 1 AS id)',
+                    'item_view' => '"item_view" AS (SELECT * FROM items)',
+                    'unrelated' => '"unrelated" AS (SELECT 2 AS id)',
+                ],
+            ),
+        );
+    }
+
     public function testAddsShadowsAfterRecursiveModifier(): void
     {
         $sql = 'WITH RECURSIVE tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree';

--- a/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
@@ -17,7 +17,7 @@ final class MySqlCteShadowComposerTest extends TestCase
     {
         self::assertSame(
             "WITH \"items\" AS (SELECT 1 AS id),\n\"item_view\" AS (SELECT * FROM items)\nSELECT * FROM item_view",
-            (new CteShadowComposer())->compose(
+            (new MySqlCteShadowComposer())->compose(
                 'SELECT * FROM item_view',
                 [
                     'items' => '"items" AS (SELECT 1 AS id)',

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -30,6 +30,8 @@ use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Shadow\Mutation\CreateTableAsSelectMutation;
 use ZtdQuery\Shadow\Mutation\CreateTableLikeMutation;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
@@ -74,6 +76,42 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
+    public function testRegisteredViewIsKnownAndMaterialized(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $parser = new MySqlParser();
+        $schemaParser = new MySqlSchemaParser($parser);
+        $definition = $schemaParser->parse($this->usersCreateTableSql());
+        self::assertNotNull($definition);
+        $registry->register('users', $definition);
+        $store->set('users', [['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com']]);
+        $selectTransformer = new SelectTransformer();
+        $insertTransformer = new InsertTransformer($parser, $selectTransformer);
+        $updateTransformer = new UpdateTransformer($parser, $selectTransformer);
+        $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
+        $replaceTransformer = new ReplaceTransformer($parser, $selectTransformer);
+        $transformer = new MySqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer, $replaceTransformer);
+        $resolver = new MySqlMutationResolver($store, $registry, $schemaParser, $updateTransformer, $deleteTransformer);
+        $views = new ViewDefinitionSet();
+        $views->register('active_users', ViewDefinition::fromQuery('SELECT id FROM app.users'));
+        $rewriter = new MySqlRewriter(new MySqlQueryGuard($parser), $store, $registry, $transformer, $resolver, $parser, $views);
+
+        $sql = $rewriter->rewrite('SELECT * FROM active_users')->sql();
+        self::assertStringStartsWith('WITH `users` AS', $sql);
+        self::assertStringContainsString('`active_users` AS (SELECT id FROM users)', $sql);
+
+        $viewOnlyStore = new ShadowStore();
+        $viewOnlyRegistry = new TableDefinitionRegistry();
+        $viewOnlyViews = new ViewDefinitionSet();
+        $viewOnlyViews->register('constant_view', ViewDefinition::fromQuery('SELECT 1 AS id'));
+        $viewOnlyResolver = new MySqlMutationResolver($viewOnlyStore, $viewOnlyRegistry, $schemaParser, $updateTransformer, $deleteTransformer);
+        $viewOnlyRewriter = new MySqlRewriter(new MySqlQueryGuard($parser), $viewOnlyStore, $viewOnlyRegistry, $transformer, $viewOnlyResolver, $parser, $viewOnlyViews);
+
+        $this->expectException(UnknownSchemaException::class);
+        $viewOnlyRewriter->rewrite('SELECT * FROM missing_table');
+    }
+
     public function testDatabaseQualifiedSelectUsesShadowCte(): void
     {
         $store = new ShadowStore();

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -17,6 +17,7 @@ use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlQueryGuard;
 use ZtdQuery\Platform\MySql\MySqlRewriter;
 use ZtdQuery\Platform\MySql\MySqlSchemaParser;
+use ZtdQuery\Platform\MySql\MySqlViewDefinitionParser;
 use ZtdQuery\Platform\MySql\MySqlUpsertAssignmentExtractor;
 use ZtdQuery\Platform\MySql\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\MySql\Transformer\InsertTransformer;
@@ -94,7 +95,7 @@ final class MySqlRewriterTest extends RewriterContractTest
         $transformer = new MySqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer, $replaceTransformer);
         $resolver = new MySqlMutationResolver($store, $registry, $schemaParser, $updateTransformer, $deleteTransformer);
         $views = new ViewDefinitionSet();
-        $views->register('active_users', ViewDefinition::fromQuery('SELECT id FROM app.users'));
+        $views->register('active_users', (new MySqlViewDefinitionParser())->fromQuery('SELECT id FROM app.users'));
         $rewriter = new MySqlRewriter(new MySqlQueryGuard($parser), $store, $registry, $transformer, $resolver, $parser, $views);
 
         $sql = $rewriter->rewrite('SELECT * FROM active_users')->sql();
@@ -104,7 +105,7 @@ final class MySqlRewriterTest extends RewriterContractTest
         $viewOnlyStore = new ShadowStore();
         $viewOnlyRegistry = new TableDefinitionRegistry();
         $viewOnlyViews = new ViewDefinitionSet();
-        $viewOnlyViews->register('constant_view', ViewDefinition::fromQuery('SELECT 1 AS id'));
+        $viewOnlyViews->register('constant_view', (new MySqlViewDefinitionParser())->fromQuery('SELECT 1 AS id'));
         $viewOnlyResolver = new MySqlMutationResolver($viewOnlyStore, $viewOnlyRegistry, $schemaParser, $updateTransformer, $deleteTransformer);
         $viewOnlyRewriter = new MySqlRewriter(new MySqlQueryGuard($parser), $viewOnlyStore, $viewOnlyRegistry, $transformer, $viewOnlyResolver, $parser, $viewOnlyViews);
 

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -75,6 +75,8 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewDefinitionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewShadowRenderer::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
     public function testRegisteredViewIsKnownAndMaterialized(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaReflectorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaReflectorTest.php
@@ -13,6 +13,61 @@ use ZtdQuery\Platform\MySql\MySqlSchemaReflector;
 #[CoversClass(MySqlSchemaReflector::class)]
 final class MySqlSchemaReflectorTest extends TestCase
 {
+    public function testReflectViewsReturnsEmptyWhenQueryFails(): void
+    {
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturn(false);
+
+        self::assertSame([], (new MySqlSchemaReflector($connection))->reflectViews());
+    }
+
+    public function testReflectViewsSkipsMalformedDefinitions(): void
+    {
+        $viewList = self::createStub(StatementInterface::class);
+        $viewList->method('fetchAll')->willReturn([
+            ['name' => null],
+            ['name' => ''],
+            ['name' => 'query_failed'],
+            ['name' => 'missing_row'],
+            ['name' => 'non_string'],
+            ['name' => 'invalid'],
+            ['name' => 'active`users'],
+            ['name' => 'all_users'],
+        ]);
+        $missingRow = self::createStub(StatementInterface::class);
+        $missingRow->method('fetchAll')->willReturn([]);
+        $nonString = self::createStub(StatementInterface::class);
+        $nonString->method('fetchAll')->willReturn([['Create View' => null]]);
+        $invalid = self::createStub(StatementInterface::class);
+        $invalid->method('fetchAll')->willReturn([['Create View' => 'CREATE VIEW invalid']]);
+        $valid = self::createStub(StatementInterface::class);
+        $valid->method('fetchAll')->willReturn([
+            ['Create View' => 'CREATE VIEW `active``users` AS SELECT * FROM app.users'],
+        ]);
+        $secondValid = self::createStub(StatementInterface::class);
+        $secondValid->method('fetchAll')->willReturn([
+            ['Create View' => 'CREATE VIEW all_users AS SELECT * FROM app.users'],
+        ]);
+        $connection = self::createMock(ConnectionInterface::class);
+        $connection->expects(self::exactly(7))->method('query')->willReturnCallback(
+            static fn (string $sql): StatementInterface|false => match ($sql) {
+                "SHOW FULL TABLES WHERE Table_type = 'VIEW'" => $viewList,
+                'SHOW CREATE VIEW `query_failed`' => false,
+                'SHOW CREATE VIEW `missing_row`' => $missingRow,
+                'SHOW CREATE VIEW `non_string`' => $nonString,
+                'SHOW CREATE VIEW `invalid`' => $invalid,
+                'SHOW CREATE VIEW `active``users`' => $valid,
+                'SHOW CREATE VIEW `all_users`' => $secondValid,
+                default => false,
+            },
+        );
+
+        $definitions = (new MySqlSchemaReflector($connection))->reflectViews();
+
+        self::assertSame(['active`users', 'all_users'], array_keys($definitions));
+        self::assertSame(['users'], $definitions['active`users']->dependencies);
+    }
+
     public function testGetCreateStatementReturnsNullWhenQueryFails(): void
     {
         $connection = self::createStub(ConnectionInterface::class);

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaReflectorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaReflectorTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\MySql\MySqlSchemaReflector;
 
 #[CoversClass(MySqlSchemaReflector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewDefinitionParser::class)]
 final class MySqlSchemaReflectorTest extends TestCase
 {
     public function testReflectViewsReturnsEmptyWhenQueryFails(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
@@ -49,6 +49,10 @@ use ZtdQuery\Session;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlReadOnlyDiagnosticStatement::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewDefinitionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewShadowRenderer::class)]
 final class MySqlSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedViews(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
@@ -11,6 +11,9 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
+use ZtdQuery\Platform\MySql\MySqlCastRenderer;
+use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
+use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlQueryGuard;
 use ZtdQuery\Platform\MySql\MySqlRewriter;
 use ZtdQuery\Platform\MySql\MySqlSchemaParser;
@@ -26,6 +29,9 @@ use ZtdQuery\Session;
 
 #[CoversClass(MySqlSessionFactory::class)]
 #[UsesClass(MySqlMutationResolver::class)]
+#[UsesClass(MySqlCastRenderer::class)]
+#[UsesClass(MySqlIdentifierQuoter::class)]
+#[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlQueryGuard::class)]
 #[UsesClass(MySqlRewriter::class)]
 #[UsesClass(MySqlSchemaParser::class)]
@@ -45,6 +51,34 @@ use ZtdQuery\Session;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
 final class MySqlSessionFactoryTest extends TestCase
 {
+    public function testCreateRegistersReflectedViews(): void
+    {
+        $empty = self::createStub(StatementInterface::class);
+        $empty->method('fetchAll')->willReturn([]);
+        $views = self::createStub(StatementInterface::class);
+        $views->method('fetchAll')->willReturn([['name' => 'active_users']]);
+        $create = self::createStub(StatementInterface::class);
+        $create->method('fetchAll')->willReturn([
+            ['Create View' => 'CREATE VIEW active_users AS SELECT 1 AS id'],
+        ]);
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            static fn (string $sql): StatementInterface => match ($sql) {
+                'SHOW TABLES' => $empty,
+                "SHOW FULL TABLES WHERE Table_type = 'VIEW'" => $views,
+                'SHOW CREATE VIEW `active_users`' => $create,
+                default => $empty,
+            },
+        );
+
+        $session = (new MySqlSessionFactory())->create($connection, ZtdConfig::default());
+
+        self::assertSame(
+            "WITH `active_users` AS (SELECT 1 AS id)\nSELECT * FROM active_users",
+            $session->rewrite('SELECT * FROM active_users')->sql(),
+        );
+    }
+
     public function testCreateReturnsSession(): void
     {
         $statement = self::createStub(StatementInterface::class);

--- a/packages/ztd-query-mysql/tests/Unit/MySqlViewDefinitionParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlViewDefinitionParserTest.php
@@ -9,19 +9,9 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\MySql\MySqlSelectRelationParser;
 use ZtdQuery\Platform\MySql\MySqlViewDefinitionParser;
-use ZtdQuery\Schema\ViewDefinition;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenDialect;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(MySqlViewDefinitionParser::class)]
 #[UsesClass(MySqlSelectRelationParser::class)]
-#[UsesClass(ViewDefinition::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenDialect::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class MySqlViewDefinitionParserTest extends TestCase
 {
     public function testParsesAQueryUsingMySqlRelationRules(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlViewDefinitionParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlViewDefinitionParserTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlSelectRelationParser;
+use ZtdQuery\Platform\MySql\MySqlViewDefinitionParser;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(MySqlViewDefinitionParser::class)]
+#[UsesClass(MySqlSelectRelationParser::class)]
+#[UsesClass(ViewDefinition::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenDialect::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class MySqlViewDefinitionParserTest extends TestCase
+{
+    public function testParsesAQueryUsingMySqlRelationRules(): void
+    {
+        $definition = (new MySqlViewDefinitionParser())->fromQuery(
+            " SELECT u.id FROM app.`users` u JOIN roles r ON r.id = u.role_id; \n",
+        );
+
+        self::assertSame('SELECT u.id FROM app.`users` u JOIN roles r ON r.id = u.role_id', $definition->query);
+        self::assertSame(['users', 'roles'], $definition->dependencies);
+    }
+
+    public function testExtractsTheQueryFromAMySqlCreateViewStatement(): void
+    {
+        $definition = (new MySqlViewDefinitionParser())->fromCreateStatement(
+            'CREATE ALGORITHM=MERGE VIEW `active_users` AS SELECT * FROM `users` WHERE active = 1;',
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame('SELECT * FROM `users` WHERE active = 1', $definition->query);
+        self::assertNull((new MySqlViewDefinitionParser())->fromCreateStatement('CREATE VIEW invalid AS   '));
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlViewShadowRendererTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlViewShadowRendererTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlSelectRelationParser;
+use ZtdQuery\Platform\MySql\MySqlViewShadowRenderer;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Schema\ViewDefinitionSet;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(MySqlViewShadowRenderer::class)]
+#[UsesClass(MySqlSelectRelationParser::class)]
+#[UsesClass(ViewDefinition::class)]
+#[UsesClass(ViewDefinitionSet::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenDialect::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class MySqlViewShadowRendererTest extends TestCase
+{
+    public function testOrdersViewsAndUnqualifiesShadowedMySqlRelations(): void
+    {
+        $views = new ViewDefinitionSet();
+        $views->register('summary', new ViewDefinition('SELECT count(*) FROM app.`active_users`', ['active_users']));
+        $views->register('active_users', new ViewDefinition('SELECT * FROM app.`users`', ['users']));
+
+        self::assertSame(
+            [
+                'active_users' => 'SELECT * FROM `users`',
+                'summary' => 'SELECT count(*) FROM `active_users`',
+            ],
+            (new MySqlViewShadowRenderer())->render($views, ['users']),
+        );
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlViewShadowRendererTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlViewShadowRendererTest.php
@@ -11,19 +11,9 @@ use ZtdQuery\Platform\MySql\MySqlSelectRelationParser;
 use ZtdQuery\Platform\MySql\MySqlViewShadowRenderer;
 use ZtdQuery\Schema\ViewDefinition;
 use ZtdQuery\Schema\ViewDefinitionSet;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenDialect;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(MySqlViewShadowRenderer::class)]
 #[UsesClass(MySqlSelectRelationParser::class)]
-#[UsesClass(ViewDefinition::class)]
-#[UsesClass(ViewDefinitionSet::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenDialect::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class MySqlViewShadowRendererTest extends TestCase
 {
     public function testOrdersViewsAndUnqualifiesShadowedMySqlRelations(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
@@ -27,6 +27,28 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testTransformMaterializesViewAfterItsShadowTable(): void
+    {
+        $tables = [
+            'users' => [
+                'rows' => [['id' => 1]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+            'active_users' => [
+                'viewSql' => 'SELECT * FROM users WHERE id > 0',
+            ],
+            'active_user_count' => [
+                'viewSql' => 'SELECT count(*) AS total FROM active_users',
+            ],
+        ];
+
+        self::assertSame(
+            "WITH `users` AS (SELECT CAST(1 AS SIGNED) AS `id`),\n`active_users` AS (SELECT * FROM users WHERE id > 0),\n`active_user_count` AS (SELECT count(*) AS total FROM active_users)\nSELECT * FROM active_user_count",
+            (new SelectTransformer())->transform('SELECT * FROM active_user_count', $tables),
+        );
+    }
+
     public function testUsesInjectedValueRenderer(): void
     {
         $valueRenderer = self::createStub(ValueRenderer::class);

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/ViewTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/ViewTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_mysql
+ * @group integration
+ * @group mysql
+ */
+#[CoversNothing]
+#[Large]
+final class ViewTest extends TestCase
+{
+    public function testViewsReadShadowWritesAcrossFiltersJoinsAggregatesAndPreparation(): void
+    {
+        [$databaseName, $pdo] = MySqlContainer::createTestDatabase();
+
+        try {
+            $pdo->exec('CREATE TABLE accounts (id INT PRIMARY KEY, region VARCHAR(20), amount INT, active BOOLEAN)');
+            $pdo->exec('CREATE TABLE regions (code VARCHAR(20) PRIMARY KEY, label VARCHAR(20))');
+            $pdo->exec('CREATE VIEW active_accounts AS SELECT id, region, amount FROM accounts WHERE active = 1');
+            $pdo->exec('CREATE VIEW account_labels AS SELECT a.id, r.label, a.amount FROM active_accounts a JOIN regions r ON r.code = a.region');
+            $pdo->exec('CREATE VIEW region_totals AS SELECT region, COUNT(*) AS account_count, SUM(amount) AS total_amount FROM active_accounts GROUP BY region');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            $ztdPdo->exec("INSERT INTO accounts VALUES (1, 'north', 100, 1), (2, 'south', 200, 0), (3, 'north', 300, 1)");
+            $ztdPdo->exec("INSERT INTO regions VALUES ('north', 'North'), ('south', 'South')");
+
+            $simple = $ztdPdo->query('SELECT id FROM active_accounts ORDER BY id');
+            self::assertNotFalse($simple);
+            self::assertSame([1, 3], $simple->fetchAll(\PDO::FETCH_COLUMN));
+
+            $prepared = $ztdPdo->prepare('SELECT id FROM active_accounts WHERE amount >= ? ORDER BY id');
+            self::assertNotFalse($prepared);
+            self::assertTrue($prepared->execute([150]));
+            self::assertSame([3], $prepared->fetchAll(\PDO::FETCH_COLUMN));
+
+            $joined = $ztdPdo->query('SELECT id, label FROM account_labels ORDER BY id');
+            self::assertNotFalse($joined);
+            self::assertSame(
+                [['id' => 1, 'label' => 'North'], ['id' => 3, 'label' => 'North']],
+                $joined->fetchAll(),
+            );
+
+            $aggregate = $ztdPdo->query('SELECT region, CAST(account_count AS SIGNED) AS account_count, CAST(total_amount AS SIGNED) AS total_amount FROM region_totals');
+            self::assertNotFalse($aggregate);
+            self::assertSame(
+                [['region' => 'north', 'account_count' => 2, 'total_amount' => 400]],
+                $aggregate->fetchAll(),
+            );
+        } finally {
+            $pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/ViewTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/ViewTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class ViewTest extends TestCase
+{
+    public function testViewsReadShadowWritesAcrossFiltersJoinsAggregatesAndPreparation(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $pdo->exec('CREATE TABLE accounts (id INTEGER PRIMARY KEY, region TEXT, amount INTEGER, active BOOLEAN)');
+            $pdo->exec('CREATE TABLE regions (code TEXT PRIMARY KEY, label TEXT)');
+            $pdo->exec('CREATE VIEW active_accounts AS SELECT id, region, amount FROM accounts WHERE active');
+            $pdo->exec('CREATE VIEW account_labels AS SELECT a.id, r.label, a.amount FROM active_accounts a JOIN regions r ON r.code = a.region');
+            $pdo->exec('CREATE VIEW region_totals AS SELECT region, COUNT(*) AS account_count, SUM(amount) AS total_amount FROM active_accounts GROUP BY region');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            $ztdPdo->exec("INSERT INTO accounts VALUES (1, 'north', 100, TRUE), (2, 'south', 200, FALSE), (3, 'north', 300, TRUE)");
+            $ztdPdo->exec("INSERT INTO regions VALUES ('north', 'North'), ('south', 'South')");
+
+            $simple = $ztdPdo->query('SELECT id FROM active_accounts ORDER BY id');
+            self::assertNotFalse($simple);
+            self::assertSame([1, 3], $simple->fetchAll(\PDO::FETCH_COLUMN));
+
+            $prepared = $ztdPdo->prepare('SELECT id FROM active_accounts WHERE amount >= ? ORDER BY id');
+            self::assertNotFalse($prepared);
+            self::assertTrue($prepared->execute([150]));
+            self::assertSame([3], $prepared->fetchAll(\PDO::FETCH_COLUMN));
+
+            $joined = $ztdPdo->query('SELECT id, label FROM account_labels ORDER BY id');
+            self::assertNotFalse($joined);
+            self::assertSame(
+                [['id' => 1, 'label' => 'North'], ['id' => 3, 'label' => 'North']],
+                $joined->fetchAll(),
+            );
+
+            $aggregate = $ztdPdo->query('SELECT region, account_count::integer AS account_count, total_amount::integer AS total_amount FROM region_totals');
+            self::assertNotFalse($aggregate);
+            self::assertSame(
+                [['region' => 'north', 'account_count' => 2, 'total_amount' => 400]],
+                $aggregate->fetchAll(),
+            );
+        } finally {
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/ViewTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/ViewTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/** @requires extension pdo_sqlite */
+#[CoversNothing]
+#[Large]
+final class ViewTest extends TestCase
+{
+    public function testViewsReadShadowWritesAcrossFiltersJoinsAggregatesAndPreparation(): void
+    {
+        $pdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $pdo->exec('CREATE TABLE accounts (id INTEGER PRIMARY KEY, region TEXT, amount INTEGER, active INTEGER)');
+        $pdo->exec('CREATE TABLE regions (code TEXT PRIMARY KEY, label TEXT)');
+        $pdo->exec('CREATE VIEW active_accounts AS SELECT id, region, amount FROM accounts WHERE active = 1');
+        $pdo->exec('CREATE VIEW account_labels AS SELECT a.id, r.label, a.amount FROM active_accounts a JOIN regions r ON r.code = a.region');
+        $pdo->exec('CREATE VIEW region_totals AS SELECT region, COUNT(*) AS account_count, SUM(amount) AS total_amount FROM active_accounts GROUP BY region');
+        $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+        $ztdPdo->exec("INSERT INTO accounts VALUES (1, 'north', 100, 1), (2, 'south', 200, 0), (3, 'north', 300, 1)");
+        $ztdPdo->exec("INSERT INTO regions VALUES ('north', 'North'), ('south', 'South')");
+
+        $simple = $ztdPdo->query('SELECT id FROM active_accounts ORDER BY id');
+        self::assertNotFalse($simple);
+        self::assertSame([1, 3], $simple->fetchAll(\PDO::FETCH_COLUMN));
+
+        $prepared = $ztdPdo->prepare('SELECT id FROM active_accounts WHERE amount >= ? ORDER BY id');
+        self::assertNotFalse($prepared);
+        self::assertTrue($prepared->execute([150]));
+        self::assertSame([3], $prepared->fetchAll(\PDO::FETCH_COLUMN));
+
+        $joined = $ztdPdo->query('SELECT id, label FROM account_labels ORDER BY id');
+        self::assertNotFalse($joined);
+        self::assertSame(
+            [['id' => 1, 'label' => 'North'], ['id' => 3, 'label' => 'North']],
+            $joined->fetchAll(),
+        );
+
+        $aggregate = $ztdPdo->query('SELECT region, account_count, total_amount FROM region_totals');
+        self::assertNotFalse($aggregate);
+        self::assertSame(
+            [['region' => 'north', 'account_count' => 2, 'total_amount' => 400]],
+            $aggregate->fetchAll(),
+        );
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -136,6 +136,7 @@ final class RewriteTarget
             fn (): string => $this->provider->truncateStatement(maxDepth: 8),
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
             fn (): string => $this->provider->temporaryTableStatement(),
+            fn (): string => $this->provider->viewStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlCteShadowComposer.php
+++ b/packages/ztd-query-postgres/src/PgSqlCteShadowComposer.php
@@ -24,16 +24,29 @@ final class PgSqlCteShadowComposer
     public function compose(string $sql, array $tableCtes): string
     {
         $declared = array_fill_keys($this->declaredCteNames($sql), true);
-        $ctes = [];
-        $shadowedTables = [];
-        foreach ($tableCtes as $table => $cte) {
+        $requiredSql = [$sql];
+        $requiredCtes = [];
+        foreach (array_reverse($tableCtes, true) as $table => $cte) {
             $normalized = strtolower($table);
-            if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
+            if (isset($declared[$normalized])) {
                 continue;
             }
-            $ctes[] = $cte;
-            $shadowedTables[] = $table;
+            $referenced = false;
+            foreach ($requiredSql as $requiredPart) {
+                if ($this->referencesIdentifier($requiredPart, $table)) {
+                    $referenced = true;
+                }
+            }
+            if (!$referenced) {
+                continue;
+            }
+            $requiredCtes[$table] = $cte;
+            $requiredSql[] = $cte;
         }
+
+        $requiredCtes = array_reverse($requiredCtes, true);
+        $ctes = $requiredCtes;
+        $shadowedTables = array_keys($requiredCtes);
 
         if ($ctes === []) {
             return $sql;

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -246,7 +246,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             ];
         }
 
-        foreach ($this->views->shadowQueries(array_keys($context)) as $viewName => $viewSql) {
+        foreach ((new PgSqlViewShadowRenderer())->render($this->views, array_keys($context)) as $viewName => $viewSql) {
             if (isset($context[$viewName])) {
                 continue;
             }

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -13,6 +13,7 @@ use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Rewrite\RewriteStateCommitter;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Sql\TransactionStatement;
 
@@ -37,6 +38,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
     private PgSqlParser $parser;
     private PgSqlReturningProjectionParser $returningProjectionParser;
     private PgSqlCteShadowComposer $cteComposer;
+    private ViewDefinitionSet $views;
 
     public function __construct(
         PgSqlQueryGuard $guard,
@@ -44,7 +46,8 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
         TableDefinitionRegistry $registry,
         PgSqlTransformer $transformer,
         PgSqlMutationResolver $mutationResolver,
-        PgSqlParser $parser
+        PgSqlParser $parser,
+        ?ViewDefinitionSet $views = null,
     ) {
         $this->guard = $guard;
         $this->shadowStore = $shadowStore;
@@ -54,6 +57,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
         $this->parser = $parser;
         $this->returningProjectionParser = new PgSqlReturningProjectionParser();
         $this->cteComposer = new PgSqlCteShadowComposer();
+        $this->views = $views ?? new ViewDefinitionSet();
     }
 
     /**
@@ -183,7 +187,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
     /**
      * Build the table context map for transformers.
      *
-     * @return array<string, array{
+     * @return array<string, array{viewSql: string}|array{
      *     rows: array<int, array<string, mixed>>,
      *     columns: array<int, string>,
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
@@ -242,6 +246,13 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             ];
         }
 
+        foreach ($this->views->shadowQueries(array_keys($context)) as $viewName => $viewSql) {
+            if (isset($context[$viewName])) {
+                continue;
+            }
+            $context[$viewName] = ['viewSql' => $viewSql];
+        }
+
         return $context;
     }
 
@@ -255,6 +266,10 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             return true;
         }
 
+        if ($this->views->has($tableName)) {
+            return true;
+        }
+
         return false;
     }
 
@@ -265,6 +280,10 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
         }
 
         if ($this->registry->hasAnyTables()) {
+            return true;
+        }
+
+        if ($this->views->hasAnyViews()) {
             return true;
         }
 

--- a/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
@@ -81,7 +81,7 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
             if (!is_string($viewName) || $viewName === '' || !is_string($query) || trim($query) === '') {
                 continue;
             }
-            $definitions[$viewName] = ViewDefinition::fromQuery($query);
+            $definitions[$viewName] = (new PgSqlViewDefinitionParser())->fromQuery($query);
         }
 
         return $definitions;

--- a/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
@@ -6,6 +6,8 @@ namespace ZtdQuery\Platform\Postgres;
 
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\SchemaReflector;
+use ZtdQuery\Platform\ViewReflector;
+use ZtdQuery\Schema\ViewDefinition;
 
 /**
  * Fetches PostgreSQL schema information via information_schema queries.
@@ -13,7 +15,7 @@ use ZtdQuery\Platform\SchemaReflector;
  * Reconstructs CREATE TABLE statements from pg_catalog/information_schema
  * since PostgreSQL has no SHOW CREATE TABLE equivalent.
  */
-final class PgSqlSchemaReflector implements SchemaReflector
+final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
 {
     private ConnectionInterface $connection;
 
@@ -60,6 +62,29 @@ final class PgSqlSchemaReflector implements SchemaReflector
         }
 
         return $result;
+    }
+
+    /** {@inheritDoc} */
+    public function reflectViews(): array
+    {
+        $stmt = $this->connection->query(
+            'SELECT viewname, definition FROM pg_views WHERE schemaname = current_schema() ORDER BY viewname',
+        );
+        if ($stmt === false) {
+            return [];
+        }
+
+        $definitions = [];
+        foreach ($stmt->fetchAll() as $row) {
+            $viewName = $row['viewname'] ?? null;
+            $query = $row['definition'] ?? null;
+            if (!is_string($viewName) || $viewName === '' || !is_string($query) || trim($query) === '') {
+                continue;
+            }
+            $definitions[$viewName] = ViewDefinition::fromQuery($query);
+        }
+
+        return $definitions;
     }
 
     private function buildCreateTableSql(string $tableName): ?string

--- a/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
+++ b/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
@@ -12,6 +12,7 @@ use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
 use ZtdQuery\Shadow\ShadowStore;
@@ -39,6 +40,10 @@ final class PgSqlSessionFactory implements SessionFactory
                 $registry->register($tableName, $definition);
             }
         }
+        $views = new ViewDefinitionSet();
+        foreach ($reflector->reflectViews() as $viewName => $definition) {
+            $views->register($viewName, $definition);
+        }
 
         $guard = new PgSqlQueryGuard($parser);
         $selectTransformer = new SelectTransformer();
@@ -47,7 +52,7 @@ final class PgSqlSessionFactory implements SessionFactory
         $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
         $transformer = new PgSqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer);
         $mutationResolver = new PgSqlMutationResolver($shadowStore, $registry, $schemaParser, $parser);
-        $rewriter = new PgSqlRewriter($guard, $shadowStore, $registry, $transformer, $mutationResolver, $parser);
+        $rewriter = new PgSqlRewriter($guard, $shadowStore, $registry, $transformer, $mutationResolver, $parser, $views);
 
         return new Session(
             $rewriter,

--- a/packages/ztd-query-postgres/src/PgSqlViewDefinitionParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlViewDefinitionParser.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PgSqlViewDefinitionParser
+{
+    public function fromQuery(string $query): ViewDefinition
+    {
+        $query = rtrim(trim($query), ';');
+
+        return new ViewDefinition($query, (new PgSqlSelectRelationParser())->tableNames($query));
+    }
+
+    public function fromCreateStatement(string $sql): ?ViewDefinition
+    {
+        foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
+            if (!$token->isTopLevel() || !$token->isKeyword('AS')) {
+                continue;
+            }
+            $query = substr($sql, $token->endOffset());
+            if (trim($query) !== '') {
+                return $this->fromQuery($query);
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlViewShadowRenderer.php
+++ b/packages/ztd-query-postgres/src/PgSqlViewShadowRenderer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Schema\ViewDefinitionSet;
+
+final class PgSqlViewShadowRenderer
+{
+    /**
+     * @param list<string> $tableNames
+     * @return array<string, string>
+     */
+    public function render(ViewDefinitionSet $views, array $tableNames): array
+    {
+        $definitions = $views->orderedDefinitions();
+        $relationNames = array_merge($tableNames, array_keys($definitions));
+        $queries = [];
+        $relationParser = new PgSqlSelectRelationParser();
+        foreach ($definitions as $viewName => $definition) {
+            $queries[$viewName] = $relationParser->unqualify($definition->query, $relationNames);
+        }
+
+        return $queries;
+    }
+}

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -49,6 +49,11 @@ final class SelectTransformer implements SqlTransformer
     {
         $ctes = [];
         foreach ($tables as $tableName => $tableContext) {
+            if (isset($tableContext['viewSql'])) {
+                $ctes[$tableName] = $this->quoter->quote($tableName) . " AS MATERIALIZED ({$tableContext['viewSql']})";
+                continue;
+            }
+
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];
             /** @var array<string, ColumnType> $columnTypes */

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
@@ -13,6 +13,21 @@ use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 final class PgSqlCteShadowComposerTest extends TestCase
 {
+    public function testIncludesTransitivelyReferencedShadowCtes(): void
+    {
+        self::assertSame(
+            "WITH \"items\" AS (SELECT 1 AS id),\n\"item_view\" AS (SELECT * FROM items)\nSELECT * FROM item_view",
+            (new PgSqlCteShadowComposer())->compose(
+                'SELECT * FROM item_view',
+                [
+                    'items' => '"items" AS (SELECT 1 AS id)',
+                    'item_view' => '"item_view" AS (SELECT * FROM items)',
+                    'unrelated' => '"unrelated" AS (SELECT 2 AS id)',
+                ],
+            ),
+        );
+    }
+
     public function testAddsShadowsAfterRecursiveModifier(): void
     {
         $sql = 'WITH RECURSIVE tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree';

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -27,6 +27,8 @@ use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\DropTableMutation;
@@ -63,6 +65,41 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlNativeUpsertProjector::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
+    public function testRegisteredViewIsKnownAndMaterialized(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $parser = new PgSqlParser();
+        $schemaParser = new PgSqlSchemaParser();
+        $definition = $schemaParser->parse($this->usersCreateTableSql());
+        self::assertNotNull($definition);
+        $registry->register('users', $definition);
+        $store->set('users', [['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com']]);
+        $selectTransformer = new SelectTransformer();
+        $insertTransformer = new InsertTransformer($parser, $selectTransformer);
+        $updateTransformer = new UpdateTransformer($parser, $selectTransformer);
+        $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
+        $transformer = new PgSqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer);
+        $resolver = new PgSqlMutationResolver($store, $registry, $schemaParser, $parser);
+        $views = new ViewDefinitionSet();
+        $views->register('active_users', ViewDefinition::fromQuery('SELECT id FROM public.users'));
+        $rewriter = new PgSqlRewriter(new PgSqlQueryGuard($parser), $store, $registry, $transformer, $resolver, $parser, $views);
+
+        $sql = $rewriter->rewrite('SELECT * FROM active_users')->sql();
+        self::assertStringStartsWith('WITH "users" AS MATERIALIZED', $sql);
+        self::assertStringContainsString('"active_users" AS MATERIALIZED (SELECT id FROM users)', $sql);
+
+        $viewOnlyStore = new ShadowStore();
+        $viewOnlyRegistry = new TableDefinitionRegistry();
+        $viewOnlyViews = new ViewDefinitionSet();
+        $viewOnlyViews->register('constant_view', ViewDefinition::fromQuery('SELECT 1 AS id'));
+        $viewOnlyResolver = new PgSqlMutationResolver($viewOnlyStore, $viewOnlyRegistry, $schemaParser, $parser);
+        $viewOnlyRewriter = new PgSqlRewriter(new PgSqlQueryGuard($parser), $viewOnlyStore, $viewOnlyRegistry, $transformer, $viewOnlyResolver, $parser, $viewOnlyViews);
+
+        $this->expectException(UnknownSchemaException::class);
+        $viewOnlyRewriter->rewrite('SELECT * FROM missing_table');
+    }
+
     public function testRegisteredTableUpsertProjectsConflictExpression(): void
     {
         $store = new ShadowStore();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -64,6 +64,8 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
     public function testRegisteredViewIsKnownAndMaterialized(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -18,6 +18,7 @@ use ZtdQuery\Platform\Postgres\PgSqlReturningProjectionParser;
 use ZtdQuery\Platform\Postgres\PgSqlRewriter;
 use ZtdQuery\Platform\Postgres\PgSqlSchemaParser;
 use ZtdQuery\Platform\Postgres\PgSqlTransformer;
+use ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser;
 use ZtdQuery\Platform\Postgres\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\InsertTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
@@ -82,7 +83,7 @@ final class PgSqlRewriterTest extends RewriterContractTest
         $transformer = new PgSqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer);
         $resolver = new PgSqlMutationResolver($store, $registry, $schemaParser, $parser);
         $views = new ViewDefinitionSet();
-        $views->register('active_users', ViewDefinition::fromQuery('SELECT id FROM public.users'));
+        $views->register('active_users', (new PgSqlViewDefinitionParser())->fromQuery('SELECT id FROM public.users'));
         $rewriter = new PgSqlRewriter(new PgSqlQueryGuard($parser), $store, $registry, $transformer, $resolver, $parser, $views);
 
         $sql = $rewriter->rewrite('SELECT * FROM active_users')->sql();
@@ -92,7 +93,7 @@ final class PgSqlRewriterTest extends RewriterContractTest
         $viewOnlyStore = new ShadowStore();
         $viewOnlyRegistry = new TableDefinitionRegistry();
         $viewOnlyViews = new ViewDefinitionSet();
-        $viewOnlyViews->register('constant_view', ViewDefinition::fromQuery('SELECT 1 AS id'));
+        $viewOnlyViews->register('constant_view', (new PgSqlViewDefinitionParser())->fromQuery('SELECT 1 AS id'));
         $viewOnlyResolver = new PgSqlMutationResolver($viewOnlyStore, $viewOnlyRegistry, $schemaParser, $parser);
         $viewOnlyRewriter = new PgSqlRewriter(new PgSqlQueryGuard($parser), $viewOnlyStore, $viewOnlyRegistry, $transformer, $viewOnlyResolver, $parser, $viewOnlyViews);
 

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Tests\Fake\FakeSequentialConnection;
 use Tests\Fake\FakeStatement;
@@ -13,6 +14,8 @@ use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\Postgres\PgSqlSchemaReflector;
 
 #[CoversClass(PgSqlSchemaReflector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser::class)]
 final class PgSqlSchemaReflectorTest extends TestCase
 {
     public function testReflectViewsReturnsEmptyWhenQueryFails(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
@@ -15,6 +15,35 @@ use ZtdQuery\Platform\Postgres\PgSqlSchemaReflector;
 #[CoversClass(PgSqlSchemaReflector::class)]
 final class PgSqlSchemaReflectorTest extends TestCase
 {
+    public function testReflectViewsReturnsEmptyWhenQueryFails(): void
+    {
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturn(false);
+
+        self::assertSame([], (new PgSqlSchemaReflector($connection))->reflectViews());
+    }
+
+    public function testReflectViewsSkipsMalformedRows(): void
+    {
+        $statement = self::createStub(StatementInterface::class);
+        $statement->method('fetchAll')->willReturn([
+            ['viewname' => null, 'definition' => 'SELECT 1'],
+            ['viewname' => '', 'definition' => 'SELECT 1'],
+            ['viewname' => 'missing_query'],
+            ['viewname' => 'non_string', 'definition' => null],
+            ['viewname' => 'blank', 'definition' => '   '],
+            ['viewname' => 'active_users', 'definition' => 'SELECT * FROM public.users WHERE active'],
+            ['viewname' => 'all_users', 'definition' => 'SELECT * FROM public.users'],
+        ]);
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturn($statement);
+
+        $definitions = (new PgSqlSchemaReflector($connection))->reflectViews();
+
+        self::assertSame(['active_users', 'all_users'], array_keys($definitions));
+        self::assertSame(['users'], $definitions['active_users']->dependencies);
+    }
+
     public function testGetCreateStatementReturnsNullWhenNoColumns(): void
     {
         $colStmt = static::createStub(StatementInterface::class);

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -50,6 +50,27 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlNativeUpsertProjector::class)]
 final class PgSqlSessionFactoryTest extends TestCase
 {
+    public function testCreateRegistersReflectedViews(): void
+    {
+        $empty = self::createStub(StatementInterface::class);
+        $empty->method('fetchAll')->willReturn([]);
+        $views = self::createStub(StatementInterface::class);
+        $views->method('fetchAll')->willReturn([
+            ['viewname' => 'active_users', 'definition' => 'SELECT 1 AS id'],
+        ]);
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            static fn (string $sql): StatementInterface => str_contains($sql, 'pg_views') ? $views : $empty,
+        );
+
+        $session = (new PgSqlSessionFactory())->create($connection, ZtdConfig::default());
+
+        self::assertSame(
+            "WITH \"active_users\" AS MATERIALIZED (SELECT 1 AS id)\nSELECT * FROM active_users",
+            $session->rewrite('SELECT * FROM active_users')->sql(),
+        );
+    }
+
     public function testCreateReturnsSession(): void
     {
         $connection = static::createStub(ConnectionInterface::class);

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -48,6 +48,8 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer::class)]
 final class PgSqlSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedViews(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlViewDefinitionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlViewDefinitionParserTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser;
+use ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(PgSqlViewDefinitionParser::class)]
+#[UsesClass(PgSqlSelectRelationParser::class)]
+#[UsesClass(ViewDefinition::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class PgSqlViewDefinitionParserTest extends TestCase
+{
+    public function testParsesAQueryUsingPostgreSqlRelationRules(): void
+    {
+        $definition = (new PgSqlViewDefinitionParser())->fromQuery(
+            " SELECT u.id FROM public.\"users\" u JOIN roles r ON r.id = u.role_id; \n",
+        );
+
+        self::assertSame('SELECT u.id FROM public."users" u JOIN roles r ON r.id = u.role_id', $definition->query);
+        self::assertSame(['users', 'roles'], $definition->dependencies);
+    }
+
+    public function testExtractsTheQueryFromAPostgreSqlCreateViewStatement(): void
+    {
+        $definition = (new PgSqlViewDefinitionParser())->fromCreateStatement(
+            'CREATE OR REPLACE VIEW "active_users" AS SELECT * FROM "users" WHERE active = TRUE;',
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame('SELECT * FROM "users" WHERE active = TRUE', $definition->query);
+        self::assertNull((new PgSqlViewDefinitionParser())->fromCreateStatement('CREATE VIEW invalid AS   '));
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlViewDefinitionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlViewDefinitionParserTest.php
@@ -9,17 +9,9 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser;
 use ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser;
-use ZtdQuery\Schema\ViewDefinition;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(PgSqlViewDefinitionParser::class)]
 #[UsesClass(PgSqlSelectRelationParser::class)]
-#[UsesClass(ViewDefinition::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class PgSqlViewDefinitionParserTest extends TestCase
 {
     public function testParsesAQueryUsingPostgreSqlRelationRules(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlViewShadowRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlViewShadowRendererTest.php
@@ -11,17 +11,9 @@ use ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser;
 use ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer;
 use ZtdQuery\Schema\ViewDefinition;
 use ZtdQuery\Schema\ViewDefinitionSet;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(PgSqlViewShadowRenderer::class)]
 #[UsesClass(PgSqlSelectRelationParser::class)]
-#[UsesClass(ViewDefinition::class)]
-#[UsesClass(ViewDefinitionSet::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class PgSqlViewShadowRendererTest extends TestCase
 {
     public function testOrdersViewsAndUnqualifiesShadowedPostgreSqlRelations(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlViewShadowRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlViewShadowRendererTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser;
+use ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Schema\ViewDefinitionSet;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(PgSqlViewShadowRenderer::class)]
+#[UsesClass(PgSqlSelectRelationParser::class)]
+#[UsesClass(ViewDefinition::class)]
+#[UsesClass(ViewDefinitionSet::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class PgSqlViewShadowRendererTest extends TestCase
+{
+    public function testOrdersViewsAndUnqualifiesShadowedPostgreSqlRelations(): void
+    {
+        $views = new ViewDefinitionSet();
+        $views->register('summary', new ViewDefinition('SELECT count(*) FROM public."active_users"', ['active_users']));
+        $views->register('active_users', new ViewDefinition('SELECT * FROM public."users"', ['users']));
+
+        self::assertSame(
+            [
+                'active_users' => 'SELECT * FROM "users"',
+                'summary' => 'SELECT count(*) FROM "active_users"',
+            ],
+            (new PgSqlViewShadowRenderer())->render($views, ['users']),
+        );
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
@@ -23,6 +23,28 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testTransformMaterializesViewAfterItsShadowTable(): void
+    {
+        $tables = [
+            'users' => [
+                'rows' => [['id' => 1]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+            'active_users' => [
+                'viewSql' => 'SELECT * FROM users WHERE id > 0',
+            ],
+            'active_user_count' => [
+                'viewSql' => 'SELECT count(*) AS total FROM active_users',
+            ],
+        ];
+
+        self::assertSame(
+            "WITH \"users\" AS MATERIALIZED (SELECT CAST(1 AS INTEGER) AS \"id\"),\n\"active_users\" AS MATERIALIZED (SELECT * FROM users WHERE id > 0),\n\"active_user_count\" AS MATERIALIZED (SELECT count(*) AS total FROM active_users)\nSELECT * FROM active_user_count",
+            (new SelectTransformer())->transform('SELECT * FROM active_user_count', $tables),
+        );
+    }
+
     public function testUsesInjectedValueRenderer(): void
     {
         $valueRenderer = self::createStub(ValueRenderer::class);

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
@@ -133,6 +133,7 @@ final class RewriteTarget
             fn () => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
             fn (): string => $this->provider->temporaryTableStatement(),
+            fn (): string => $this->provider->viewStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-sqlite/src/SqliteCteShadowComposer.php
+++ b/packages/ztd-query-sqlite/src/SqliteCteShadowComposer.php
@@ -24,16 +24,29 @@ final class SqliteCteShadowComposer
     public function compose(string $sql, array $tableCtes): string
     {
         $declared = array_fill_keys($this->declaredCteNames($sql), true);
-        $ctes = [];
-        $shadowedTables = [];
-        foreach ($tableCtes as $table => $cte) {
+        $requiredSql = [$sql];
+        $requiredCtes = [];
+        foreach (array_reverse($tableCtes, true) as $table => $cte) {
             $normalized = strtolower($table);
-            if (isset($declared[$normalized]) || !$this->referencesIdentifier($sql, $table)) {
+            if (isset($declared[$normalized])) {
                 continue;
             }
-            $ctes[] = $cte;
-            $shadowedTables[] = $table;
+            $referenced = false;
+            foreach ($requiredSql as $requiredPart) {
+                if ($this->referencesIdentifier($requiredPart, $table)) {
+                    $referenced = true;
+                }
+            }
+            if (!$referenced) {
+                continue;
+            }
+            $requiredCtes[$table] = $cte;
+            $requiredSql[] = $cte;
         }
+
+        $requiredCtes = array_reverse($requiredCtes, true);
+        $ctes = $requiredCtes;
+        $shadowedTables = array_keys($requiredCtes);
 
         if ($ctes === []) {
             return $sql;

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -224,7 +224,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
             $context[$tableName] = self::contextFromDefinition($definition, []);
         }
 
-        foreach ($this->views->shadowQueries(array_keys($context)) as $viewName => $viewSql) {
+        foreach ((new SqliteViewShadowRenderer())->render($this->views, array_keys($context)) as $viewName => $viewSql) {
             if (isset($context[$viewName])) {
                 continue;
             }

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -17,6 +17,7 @@ use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Sql\TransactionStatement;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Shadow\ShadowStore;
 
 /**
@@ -40,6 +41,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
     private SqliteParser $parser;
     private SqliteReturningProjectionParser $returningProjectionParser;
     private SqliteCteShadowComposer $cteComposer;
+    private ViewDefinitionSet $views;
 
     public function __construct(
         SqliteQueryGuard $guard,
@@ -47,7 +49,8 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
         TableDefinitionRegistry $registry,
         SqliteTransformer $transformer,
         SqliteMutationResolver $mutationResolver,
-        SqliteParser $parser
+        SqliteParser $parser,
+        ?ViewDefinitionSet $views = null,
     ) {
         $this->guard = $guard;
         $this->shadowStore = $shadowStore;
@@ -57,6 +60,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
         $this->parser = $parser;
         $this->returningProjectionParser = new SqliteReturningProjectionParser();
         $this->cteComposer = new SqliteCteShadowComposer();
+        $this->views = $views ?? new ViewDefinitionSet();
     }
 
     /**
@@ -164,7 +168,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
     /**
      * Build the table context map for transformers.
      *
-     * @return array<string, array{
+     * @return array<string, array{viewSql: string}|array{
      *     rows: array<int, array<string, mixed>>,
      *     columns: array<int, string>,
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
@@ -218,6 +222,13 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
         }
         foreach ($this->registry->getAllRemoved() as $tableName => $definition) {
             $context[$tableName] = self::contextFromDefinition($definition, []);
+        }
+
+        foreach ($this->views->shadowQueries(array_keys($context)) as $viewName => $viewSql) {
+            if (isset($context[$viewName])) {
+                continue;
+            }
+            $context[$viewName] = ['viewSql' => $viewSql];
         }
 
         return $context;
@@ -284,6 +295,10 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
             return true;
         }
 
+        if ($this->views->has($tableName)) {
+            return true;
+        }
+
         return false;
     }
 
@@ -294,6 +309,10 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
         }
 
         if ($this->registry->hasAnyTables()) {
+            return true;
+        }
+
+        if ($this->views->hasAnyViews()) {
             return true;
         }
 

--- a/packages/ztd-query-sqlite/src/SqliteSchemaReflector.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaReflector.php
@@ -102,7 +102,7 @@ final class SqliteSchemaReflector implements SchemaReflector, ViewReflector
             if (!is_string($viewName) || $viewName === '' || isset($definitions[$viewName]) || !is_string($createSql)) {
                 continue;
             }
-            $definition = ViewDefinition::fromCreateStatement($createSql);
+            $definition = (new SqliteViewDefinitionParser())->fromCreateStatement($createSql);
             if ($definition !== null) {
                 $definitions[$viewName] = $definition;
             }

--- a/packages/ztd-query-sqlite/src/SqliteSchemaReflector.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaReflector.php
@@ -6,11 +6,13 @@ namespace ZtdQuery\Platform\Sqlite;
 
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\SchemaReflector;
+use ZtdQuery\Platform\ViewReflector;
+use ZtdQuery\Schema\ViewDefinition;
 
 /**
  * Fetches SQLite schema information via sqlite_master and PRAGMA queries.
  */
-final class SqliteSchemaReflector implements SchemaReflector
+final class SqliteSchemaReflector implements SchemaReflector, ViewReflector
 {
     private ConnectionInterface $connection;
 
@@ -79,5 +81,33 @@ final class SqliteSchemaReflector implements SchemaReflector
         }
 
         return $result;
+    }
+
+    /** {@inheritDoc} */
+    public function reflectViews(): array
+    {
+        $stmt = $this->connection->query(
+            "SELECT name, sql FROM (SELECT name, sql, 0 AS precedence FROM sqlite_temp_master "
+            . "WHERE type='view' UNION ALL SELECT name, sql, 1 AS precedence FROM sqlite_master "
+            . "WHERE type='view') ORDER BY precedence, name",
+        );
+        if ($stmt === false) {
+            return [];
+        }
+
+        $definitions = [];
+        foreach ($stmt->fetchAll() as $row) {
+            $viewName = $row['name'] ?? null;
+            $createSql = $row['sql'] ?? null;
+            if (!is_string($viewName) || $viewName === '' || isset($definitions[$viewName]) || !is_string($createSql)) {
+                continue;
+            }
+            $definition = ViewDefinition::fromCreateStatement($createSql);
+            if ($definition !== null) {
+                $definitions[$viewName] = $definition;
+            }
+        }
+
+        return $definitions;
     }
 }

--- a/packages/ztd-query-sqlite/src/SqliteSessionFactory.php
+++ b/packages/ztd-query-sqlite/src/SqliteSessionFactory.php
@@ -13,6 +13,7 @@ use ZtdQuery\Platform\Sqlite\Transformer\SqliteTransformer;
 use ZtdQuery\Platform\Sqlite\Transformer\UpdateTransformer;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
 use ZtdQuery\Shadow\ShadowStore;
@@ -40,6 +41,10 @@ final class SqliteSessionFactory implements SessionFactory
                 $registry->register($tableName, $definition);
             }
         }
+        $views = new ViewDefinitionSet();
+        foreach ($reflector->reflectViews() as $viewName => $definition) {
+            $views->register($viewName, $definition);
+        }
 
         $guard = new SqliteQueryGuard($parser);
         $selectTransformer = new SelectTransformer();
@@ -48,7 +53,7 @@ final class SqliteSessionFactory implements SessionFactory
         $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
         $transformer = new SqliteTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer);
         $mutationResolver = new SqliteMutationResolver($shadowStore, $registry, $schemaParser, $parser);
-        $rewriter = new SqliteRewriter($guard, $shadowStore, $registry, $transformer, $mutationResolver, $parser);
+        $rewriter = new SqliteRewriter($guard, $shadowStore, $registry, $transformer, $mutationResolver, $parser, $views);
 
         return new Session(
             $rewriter,

--- a/packages/ztd-query-sqlite/src/SqliteViewDefinitionParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteViewDefinitionParser.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class SqliteViewDefinitionParser
+{
+    public function fromQuery(string $query): ViewDefinition
+    {
+        $query = rtrim(trim($query), ';');
+
+        return new ViewDefinition($query, (new SqliteSelectRelationParser())->tableNames($query));
+    }
+
+    public function fromCreateStatement(string $sql): ?ViewDefinition
+    {
+        foreach (SqlTokenStream::tokenize($sql)->significantTokens() as $token) {
+            if (!$token->isTopLevel() || !$token->isKeyword('AS')) {
+                continue;
+            }
+            $query = substr($sql, $token->endOffset());
+            if (trim($query) !== '') {
+                return $this->fromQuery($query);
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteViewShadowRenderer.php
+++ b/packages/ztd-query-sqlite/src/SqliteViewShadowRenderer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Schema\ViewDefinitionSet;
+
+final class SqliteViewShadowRenderer
+{
+    /**
+     * @param list<string> $tableNames
+     * @return array<string, string>
+     */
+    public function render(ViewDefinitionSet $views, array $tableNames): array
+    {
+        $definitions = $views->orderedDefinitions();
+        $relationNames = array_merge($tableNames, array_keys($definitions));
+        $queries = [];
+        $relationParser = new SqliteSelectRelationParser();
+        foreach ($definitions as $viewName => $definition) {
+            $queries[$viewName] = $relationParser->unqualify($definition->query, $relationNames);
+        }
+
+        return $queries;
+    }
+}

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -48,6 +48,11 @@ final class SelectTransformer implements SqlTransformer
     {
         $ctes = [];
         foreach ($tables as $tableName => $tableContext) {
+            if (isset($tableContext['viewSql'])) {
+                $ctes[$tableName] = $this->quoter->quote($tableName) . " AS ({$tableContext['viewSql']})";
+                continue;
+            }
+
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];
             $columnTypes = $tableContext['columnTypes'];

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
@@ -13,6 +13,21 @@ use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
 final class SqliteCteShadowComposerTest extends TestCase
 {
+    public function testIncludesTransitivelyReferencedShadowCtes(): void
+    {
+        self::assertSame(
+            "WITH \"items\" AS (SELECT 1 AS id),\n\"item_view\" AS (SELECT * FROM items)\nSELECT * FROM item_view",
+            (new SqliteCteShadowComposer())->compose(
+                'SELECT * FROM item_view',
+                [
+                    'items' => '"items" AS (SELECT 1 AS id)',
+                    'item_view' => '"item_view" AS (SELECT * FROM items)',
+                    'unrelated' => '"unrelated" AS (SELECT 2 AS id)',
+                ],
+            ),
+        );
+    }
+
     public function testAddsShadowsAfterRecursiveModifier(): void
     {
         $sql = 'WITH RECURSIVE tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent_id = t.id) SELECT * FROM tree';

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -18,6 +18,7 @@ use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
 use ZtdQuery\Platform\Sqlite\SqliteReturningProjectionParser;
 use ZtdQuery\Platform\Sqlite\SqliteRewriter;
 use ZtdQuery\Platform\Sqlite\SqliteSchemaParser;
+use ZtdQuery\Platform\Sqlite\SqliteViewDefinitionParser;
 use ZtdQuery\Platform\Sqlite\Mutation\AlterTableMutation;
 use ZtdQuery\Platform\Sqlite\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\Sqlite\Transformer\InsertTransformer;
@@ -86,7 +87,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $transformer = new SqliteTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer);
         $resolver = new SqliteMutationResolver($store, $registry, $schemaParser, $parser);
         $views = new ViewDefinitionSet();
-        $views->register('active_users', ViewDefinition::fromQuery('SELECT id FROM main.users'));
+        $views->register('active_users', (new SqliteViewDefinitionParser())->fromQuery('SELECT id FROM main.users'));
         $rewriter = new SqliteRewriter(new SqliteQueryGuard($parser), $store, $registry, $transformer, $resolver, $parser, $views);
 
         $sql = $rewriter->rewrite('SELECT * FROM active_users')->sql();
@@ -96,7 +97,7 @@ final class SqliteRewriterTest extends RewriterContractTest
         $viewOnlyStore = new ShadowStore();
         $viewOnlyRegistry = new TableDefinitionRegistry();
         $viewOnlyViews = new ViewDefinitionSet();
-        $viewOnlyViews->register('constant_view', ViewDefinition::fromQuery('SELECT 1 AS id'));
+        $viewOnlyViews->register('constant_view', (new SqliteViewDefinitionParser())->fromQuery('SELECT 1 AS id'));
         $viewOnlyResolver = new SqliteMutationResolver($viewOnlyStore, $viewOnlyRegistry, $schemaParser, $parser);
         $viewOnlyRewriter = new SqliteRewriter(new SqliteQueryGuard($parser), $viewOnlyStore, $viewOnlyRegistry, $transformer, $viewOnlyResolver, $parser, $viewOnlyViews);
 

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -27,6 +27,8 @@ use ZtdQuery\Platform\Sqlite\Transformer\UpdateTransformer;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\DropTableMutation;
@@ -67,6 +69,41 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteNativeUpsertProjector::class)]
 final class SqliteRewriterTest extends RewriterContractTest
 {
+    public function testRegisteredViewIsKnownAndMaterialized(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $parser = new SqliteParser();
+        $schemaParser = new SqliteSchemaParser();
+        $definition = $schemaParser->parse($this->usersCreateTableSql());
+        self::assertNotNull($definition);
+        $registry->register('users', $definition);
+        $store->set('users', [['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com']]);
+        $selectTransformer = new SelectTransformer();
+        $insertTransformer = new InsertTransformer($parser, $selectTransformer);
+        $updateTransformer = new UpdateTransformer($parser, $selectTransformer);
+        $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
+        $transformer = new SqliteTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer);
+        $resolver = new SqliteMutationResolver($store, $registry, $schemaParser, $parser);
+        $views = new ViewDefinitionSet();
+        $views->register('active_users', ViewDefinition::fromQuery('SELECT id FROM main.users'));
+        $rewriter = new SqliteRewriter(new SqliteQueryGuard($parser), $store, $registry, $transformer, $resolver, $parser, $views);
+
+        $sql = $rewriter->rewrite('SELECT * FROM active_users')->sql();
+        self::assertStringStartsWith('WITH "users" AS', $sql);
+        self::assertStringContainsString('"active_users" AS (SELECT id FROM users)', $sql);
+
+        $viewOnlyStore = new ShadowStore();
+        $viewOnlyRegistry = new TableDefinitionRegistry();
+        $viewOnlyViews = new ViewDefinitionSet();
+        $viewOnlyViews->register('constant_view', ViewDefinition::fromQuery('SELECT 1 AS id'));
+        $viewOnlyResolver = new SqliteMutationResolver($viewOnlyStore, $viewOnlyRegistry, $schemaParser, $parser);
+        $viewOnlyRewriter = new SqliteRewriter(new SqliteQueryGuard($parser), $viewOnlyStore, $viewOnlyRegistry, $transformer, $viewOnlyResolver, $parser, $viewOnlyViews);
+
+        $this->expectException(UnknownSchemaException::class);
+        $viewOnlyRewriter->rewrite('SELECT * FROM missing_table');
+    }
+
     public function testCteReferencesAreMatchedCaseInsensitivelyDuringSchemaValidation(): void
     {
         $registry = new TableDefinitionRegistry();

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -68,6 +68,8 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewDefinitionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewShadowRenderer::class)]
 final class SqliteRewriterTest extends RewriterContractTest
 {
     public function testRegisteredViewIsKnownAndMaterialized(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaReflectorTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaReflectorTest.php
@@ -9,8 +9,11 @@ use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\Sqlite\SqliteSchemaReflector;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(SqliteSchemaReflector::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewDefinitionParser::class)]
 final class SqliteSchemaReflectorTest extends TestCase
 {
     public function testReflectViewsReturnsEmptyWhenQueryFails(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaReflectorTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaReflectorTest.php
@@ -13,6 +13,39 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(SqliteSchemaReflector::class)]
 final class SqliteSchemaReflectorTest extends TestCase
 {
+    public function testReflectViewsReturnsEmptyWhenQueryFails(): void
+    {
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturn(false);
+
+        self::assertSame([], (new SqliteSchemaReflector($connection))->reflectViews());
+    }
+
+    public function testReflectViewsPrefersTemporaryAndSkipsMalformedRows(): void
+    {
+        $statement = self::createStub(StatementInterface::class);
+        $statement->method('fetchAll')->willReturn([
+            ['name' => null, 'sql' => 'CREATE VIEW ignored AS SELECT 1'],
+            ['name' => '', 'sql' => 'CREATE VIEW ignored AS SELECT 1'],
+            ['name' => 'non_string', 'sql' => null],
+            ['name' => 'invalid', 'sql' => 'CREATE VIEW invalid'],
+            ['name' => 'active_users', 'sql' => 'CREATE TEMP VIEW active_users AS SELECT * FROM temp.users'],
+            ['name' => 'active_users', 'sql' => 'CREATE VIEW active_users AS SELECT * FROM main.users'],
+            ['name' => 'all_users', 'sql' => 'CREATE VIEW all_users AS SELECT * FROM main.users'],
+        ]);
+        $connection = self::createMock(ConnectionInterface::class);
+        $connection->expects(self::once())->method('query')->with(
+            "SELECT name, sql FROM (SELECT name, sql, 0 AS precedence FROM sqlite_temp_master "
+            . "WHERE type='view' UNION ALL SELECT name, sql, 1 AS precedence FROM sqlite_master "
+            . "WHERE type='view') ORDER BY precedence, name",
+        )->willReturn($statement);
+
+        $definitions = (new SqliteSchemaReflector($connection))->reflectViews();
+
+        self::assertSame(['active_users', 'all_users'], array_keys($definitions));
+        self::assertSame('SELECT * FROM temp.users', $definitions['active_users']->query);
+    }
+
     public function testGetCreateStatementReturnsNullWhenQueryFails(): void
     {
         $connection = static::createStub(ConnectionInterface::class);

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -54,6 +54,27 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteNativeUpsertProjector::class)]
 final class SqliteSessionFactoryTest extends TestCase
 {
+    public function testCreateRegistersReflectedViews(): void
+    {
+        $empty = self::createStub(StatementInterface::class);
+        $empty->method('fetchAll')->willReturn([]);
+        $views = self::createStub(StatementInterface::class);
+        $views->method('fetchAll')->willReturn([
+            ['name' => 'active_users', 'sql' => 'CREATE VIEW active_users AS SELECT 1 AS id'],
+        ]);
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            static fn (string $sql): StatementInterface => str_contains($sql, "type='view'") ? $views : $empty,
+        );
+
+        $session = (new SqliteSessionFactory())->create($connection, ZtdConfig::default());
+
+        self::assertSame(
+            "WITH \"active_users\" AS (SELECT 1 AS id)\nSELECT * FROM active_users",
+            $session->rewrite('SELECT * FROM active_users')->sql(),
+        );
+    }
+
     public function testCreateReturnsSession(): void
     {
         $statement = static::createStub(StatementInterface::class);

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -52,6 +52,8 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewDefinitionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewShadowRenderer::class)]
 final class SqliteSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedViews(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteViewDefinitionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteViewDefinitionParserTest.php
@@ -9,17 +9,9 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser;
 use ZtdQuery\Platform\Sqlite\SqliteViewDefinitionParser;
-use ZtdQuery\Schema\ViewDefinition;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqliteViewDefinitionParser::class)]
 #[UsesClass(SqliteSelectRelationParser::class)]
-#[UsesClass(ViewDefinition::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class SqliteViewDefinitionParserTest extends TestCase
 {
     public function testParsesAQueryUsingSqliteRelationRules(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteViewDefinitionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteViewDefinitionParserTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser;
+use ZtdQuery\Platform\Sqlite\SqliteViewDefinitionParser;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(SqliteViewDefinitionParser::class)]
+#[UsesClass(SqliteSelectRelationParser::class)]
+#[UsesClass(ViewDefinition::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class SqliteViewDefinitionParserTest extends TestCase
+{
+    public function testParsesAQueryUsingSqliteRelationRules(): void
+    {
+        $definition = (new SqliteViewDefinitionParser())->fromQuery(
+            " SELECT u.id FROM main.[users] u JOIN roles r ON r.id = u.role_id; \n",
+        );
+
+        self::assertSame('SELECT u.id FROM main.[users] u JOIN roles r ON r.id = u.role_id', $definition->query);
+        self::assertSame(['users', 'roles'], $definition->dependencies);
+    }
+
+    public function testExtractsTheQueryFromASqliteCreateViewStatement(): void
+    {
+        $definition = (new SqliteViewDefinitionParser())->fromCreateStatement(
+            'CREATE TEMP VIEW [active_users] AS SELECT * FROM [users] WHERE active = 1;',
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame('SELECT * FROM [users] WHERE active = 1', $definition->query);
+        self::assertNull((new SqliteViewDefinitionParser())->fromCreateStatement('CREATE VIEW invalid AS   '));
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteViewShadowRendererTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteViewShadowRendererTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser;
+use ZtdQuery\Platform\Sqlite\SqliteViewShadowRenderer;
+use ZtdQuery\Schema\ViewDefinition;
+use ZtdQuery\Schema\ViewDefinitionSet;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(SqliteViewShadowRenderer::class)]
+#[UsesClass(SqliteSelectRelationParser::class)]
+#[UsesClass(ViewDefinition::class)]
+#[UsesClass(ViewDefinitionSet::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class SqliteViewShadowRendererTest extends TestCase
+{
+    public function testOrdersViewsAndUnqualifiesShadowedSqliteRelations(): void
+    {
+        $views = new ViewDefinitionSet();
+        $views->register('summary', new ViewDefinition('SELECT count(*) FROM main.[active_users]', ['active_users']));
+        $views->register('active_users', new ViewDefinition('SELECT * FROM main.[users]', ['users']));
+
+        self::assertSame(
+            [
+                'active_users' => 'SELECT * FROM [users]',
+                'summary' => 'SELECT count(*) FROM [active_users]',
+            ],
+            (new SqliteViewShadowRenderer())->render($views, ['users']),
+        );
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteViewShadowRendererTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteViewShadowRendererTest.php
@@ -11,17 +11,9 @@ use ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser;
 use ZtdQuery\Platform\Sqlite\SqliteViewShadowRenderer;
 use ZtdQuery\Schema\ViewDefinition;
 use ZtdQuery\Schema\ViewDefinitionSet;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqliteViewShadowRenderer::class)]
 #[UsesClass(SqliteSelectRelationParser::class)]
-#[UsesClass(ViewDefinition::class)]
-#[UsesClass(ViewDefinitionSet::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class SqliteViewShadowRendererTest extends TestCase
 {
     public function testOrdersViewsAndUnqualifiesShadowedSqliteRelations(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -30,6 +30,28 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testTransformMaterializesViewAfterItsShadowTable(): void
+    {
+        $tables = [
+            'users' => [
+                'rows' => [['id' => 1]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ],
+            'active_users' => [
+                'viewSql' => 'SELECT * FROM users WHERE id > 0',
+            ],
+            'active_user_count' => [
+                'viewSql' => 'SELECT count(*) AS total FROM active_users',
+            ],
+        ];
+
+        self::assertSame(
+            "WITH \"users\" AS (SELECT CAST(1 AS INTEGER) AS \"id\"),\n\"active_users\" AS (SELECT * FROM users WHERE id > 0),\n\"active_user_count\" AS (SELECT count(*) AS total FROM active_users)\nSELECT * FROM active_user_count",
+            (new SelectTransformer())->transform('SELECT * FROM active_user_count', $tables),
+        );
+    }
+
     public function testUsesInjectedValueRenderer(): void
     {
         $valueRenderer = self::createStub(ValueRenderer::class);


### PR DESCRIPTION
## Summary

- reflect database views for MySQL, PostgreSQL, and SQLite sessions
- resolve view definitions as CTEs over the current shadow-table state, including nested views
- add grammar-backed SQLFaker view generation to every platform rewrite fuzz target

## Root cause

Sessions reflected only physical tables. A query against a view therefore bypassed shadow state and read the physical base tables, while nested view dependencies were not part of CTE dependency selection.

## Impact

Queries and prepared statements against simple, joined, aggregate, and nested views now observe the same isolated shadow state as direct table queries.

## Validation

- full unit suites for core, MySQL, PostgreSQL, SQLite, and SQLFaker
- full lint/PHPStan for all affected packages and the PDO adapter
- MySQL, PostgreSQL, and SQLite PDO integration tests for views
- targeted SQLFaker-to-rewrite fuzz routes for all three dialects
- mutation testing: 100% covered MSI in core, MySQL, PostgreSQL, SQLite, and SQLFaker

Closes #123
