### PR TITLE
fix(schema): recompute generated columns in shadow state

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -163,6 +163,18 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function generatedColumnStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('create_table_stmt', [
+            'create_table_stmt' => [ProductionPattern::containing('table_element_list')],
+            'table_element' => [ProductionPattern::exactly('column_def')],
+            'field_def' => [ProductionPattern::containing('opt_generated_always', 'expr')],
+            'opt_generated_always' => [ProductionPattern::nonEmpty()],
+            'opt_stored_attribute' => [ProductionPattern::containing('STORED_SYM')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -719,4 +719,11 @@ final class MySqlProvider extends Base
     {
         return $this->sql->generate(GenerationPlans::viewStatement()->withMaxDepth($maxDepth));
     }
+    /** @return non-empty-string */
+    public function generatedColumnStatement(): string
+    {
+        $table = $this->rsg->rawIdentifier();
+
+        return "CREATE TABLE $table (base_value INT, generated_value INT GENERATED ALWAYS AS (base_value + 1) STORED)";
+    }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -720,10 +720,8 @@ final class MySqlProvider extends Base
         return $this->sql->generate(GenerationPlans::viewStatement()->withMaxDepth($maxDepth));
     }
     /** @return non-empty-string */
-    public function generatedColumnStatement(): string
+    public function generatedColumnStatement(int $maxDepth = 40): string
     {
-        $table = $this->rsg->rawIdentifier();
-
-        return "CREATE TABLE $table (base_value INT, generated_value INT GENERATED ALWAYS AS (base_value + 1) STORED)";
+        return $this->sql->generate(GenerationPlans::generatedColumnStatement()->withMaxDepth($maxDepth));
     }
 }

--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -56,6 +56,22 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function generatedColumnStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('CreateStmt', [
+            'CreateStmt' => [ProductionPattern::containing('OptTableElementList')],
+            'OptTableElementList' => [ProductionPattern::nonEmpty()],
+            'TableElement' => [ProductionPattern::exactly('columnDef')],
+            'ColQualList' => [
+                ProductionPattern::exactly('ColQualList', 'ColConstraint'),
+                ProductionPattern::exactly(),
+            ],
+            'ColConstraint' => [ProductionPattern::containing('ColConstraintElem')],
+            'ColConstraintElem' => [ProductionPattern::containing('GENERATED', 'STORED')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -430,11 +430,9 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function generatedColumnStatement(): string
+    public function generatedColumnStatement(int $maxDepth = 40): string
     {
-        $table = $this->rsg->rawIdentifier();
-
-        return "CREATE TABLE $table (base_value INTEGER, generated_value INTEGER GENERATED ALWAYS AS (base_value + 1) STORED)";
+        return $this->sql->generate(GenerationPlans::generatedColumnStatement()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -429,6 +429,14 @@ final class PostgreSqlProvider extends Base
         return $this->sql->generate(GenerationPlans::viewStatement()->withMaxDepth($maxDepth));
     }
 
+    /** @return non-empty-string */
+    public function generatedColumnStatement(): string
+    {
+        $table = $this->rsg->rawIdentifier();
+
+        return "CREATE TABLE $table (base_value INTEGER, generated_value INTEGER GENERATED ALWAYS AS (base_value + 1) STORED)";
+    }
+
     /**
      * @template TRequiresNonEmpty of bool
      * @param GenerationPlan<TRequiresNonEmpty> $plan

--- a/packages/sql-faker/src/Sqlite/GenerationPlans.php
+++ b/packages/sql-faker/src/Sqlite/GenerationPlans.php
@@ -50,6 +50,20 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function generatedColumnStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('cmd', [
+            'cmd' => [ProductionPattern::containing('create_table', 'create_table_args')],
+            'create_table_args' => [ProductionPattern::containing('columnlist')],
+            'carglist' => [
+                ProductionPattern::exactly('carglist', 'ccons'),
+                ProductionPattern::exactly(),
+            ],
+            'ccons' => [ProductionPattern::containing('GENERATED', 'generated')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('conslist', [

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -284,10 +284,8 @@ final class SqliteProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function generatedColumnStatement(): string
+    public function generatedColumnStatement(int $maxDepth = 40): string
     {
-        $table = $this->rsg->rawIdentifier();
-
-        return "CREATE TABLE $table (base_value INTEGER, generated_value INTEGER GENERATED ALWAYS AS (base_value + 1) STORED)";
+        return $this->sql->generate(GenerationPlans::generatedColumnStatement()->withMaxDepth($maxDepth));
     }
 }

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -282,4 +282,12 @@ final class SqliteProvider extends Base
     {
         return $this->sql->generate(GenerationPlans::viewStatement()->withMaxDepth($maxDepth));
     }
+
+    /** @return non-empty-string */
+    public function generatedColumnStatement(): string
+    {
+        $table = $this->rsg->rawIdentifier();
+
+        return "CREATE TABLE $table (base_value INTEGER, generated_value INTEGER GENERATED ALWAYS AS (base_value + 1) STORED)";
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -213,4 +213,16 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('no_definer_tail', 0)?->matches(['view_tail']) ?? false);
         self::assertTrue($plan->patternAt('query_primary', 0)?->matches(['query_specification']) ?? false);
     }
+
+    public function testGeneratedColumnPlanRequiresTheGeneratedAttribute(): void
+    {
+        $plan = GenerationPlans::generatedColumnStatement();
+
+        self::assertSame('create_table_stmt', $plan->startRule());
+        self::assertTrue($plan->patternAt('create_table_stmt', 0)?->matches(['table_element_list']) ?? false);
+        self::assertTrue($plan->patternAt('table_element', 0)?->matches(['column_def']) ?? false);
+        self::assertTrue($plan->patternAt('field_def', 0)?->matches(['opt_generated_always', 'expr']) ?? false);
+        self::assertTrue($plan->patternAt('opt_generated_always', 0)?->matches(['GENERATED']) ?? false);
+        self::assertTrue($plan->patternAt('opt_stored_attribute', 0)?->matches(['STORED_SYM']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -130,6 +130,15 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('SELECT_SYM', $tokens);
     }
 
+    public function testGeneratedColumnStatement(): void
+    {
+        $sql = (new MySqlProvider(Factory::create()))->generatedColumnStatement();
+
+        self::assertStringStartsWith('CREATE TABLE ', $sql);
+        self::assertStringContainsString(' GENERATED ALWAYS AS (', $sql);
+        self::assertStringEndsWith(' STORED)', $sql);
+    }
+
     public function testSql(): void
     {
         $faker = Factory::create();

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -130,13 +130,21 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('SELECT_SYM', $tokens);
     }
 
-    public function testGeneratedColumnStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testGeneratedColumnStatement(int $seed): void
     {
-        $sql = (new MySqlProvider(Factory::create()))->generatedColumnStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new MySqlProvider($faker);
+        $sql = $provider->generatedColumnStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))
+            ->tokenize($sql);
 
-        self::assertStringStartsWith('CREATE TABLE ', $sql);
-        self::assertStringContainsString(' GENERATED ALWAYS AS (', $sql);
-        self::assertStringEndsWith(' STORED)', $sql);
+        self::assertSame($sql, $provider->generatedColumnStatement(40));
+        self::assertContains('GENERATED', $tokens);
+        self::assertContains('ALWAYS_SYM', $tokens);
+        self::assertContains('STORED_SYM', $tokens);
     }
 
     public function testSql(): void

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -68,4 +68,20 @@ final class GenerationPlansTest extends TestCase
     {
         self::assertSame('ViewStmt', GenerationPlans::viewStatement()->startRule());
     }
+
+    public function testGeneratedColumnPlanRequiresTheGeneratedConstraint(): void
+    {
+        $plan = GenerationPlans::generatedColumnStatement();
+
+        self::assertSame('CreateStmt', $plan->startRule());
+        self::assertTrue($plan->patternAt('CreateStmt', 0)?->matches(['OptTableElementList']) ?? false);
+        self::assertTrue($plan->patternAt('OptTableElementList', 0)?->matches(['TableElement']) ?? false);
+        self::assertTrue($plan->patternAt('TableElement', 0)?->matches(['columnDef']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('ColQualList', 0)?->matches(['ColQualList', 'ColConstraint']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('ColQualList', 1)?->matches([]) ?? false);
+        self::assertTrue($plan->patternAt('ColConstraint', 0)?->matches(['ColConstraintElem']) ?? false);
+        self::assertTrue($plan->patternAt('ColConstraintElem', 0)?->matches(['GENERATED', 'STORED']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -113,6 +113,15 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertNotSame([], array_intersect(['SELECT', 'VALUES', 'TABLE'], $tokens));
     }
 
+    public function testGeneratedColumnStatement(): void
+    {
+        $sql = (new PostgreSqlProvider(Factory::create()))->generatedColumnStatement();
+
+        self::assertStringStartsWith('CREATE TABLE ', $sql);
+        self::assertStringContainsString(' GENERATED ALWAYS AS (', $sql);
+        self::assertStringEndsWith(' STORED)', $sql);
+    }
+
     #[\Override]
     protected function setUp(): void
     {

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -113,13 +113,21 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertNotSame([], array_intersect(['SELECT', 'VALUES', 'TABLE'], $tokens));
     }
 
-    public function testGeneratedColumnStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testGeneratedColumnStatement(int $seed): void
     {
-        $sql = (new PostgreSqlProvider(Factory::create()))->generatedColumnStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->generatedColumnStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'pg-17.2', true))
+            ->tokenize($sql);
 
-        self::assertStringStartsWith('CREATE TABLE ', $sql);
-        self::assertStringContainsString(' GENERATED ALWAYS AS (', $sql);
-        self::assertStringEndsWith(' STORED)', $sql);
+        self::assertSame($sql, $provider->generatedColumnStatement(40));
+        self::assertContains('GENERATED', $tokens);
+        self::assertContains('STORED', $tokens);
+        self::assertContains('AS', $tokens);
     }
 
     #[\Override]

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -79,4 +79,16 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('cmd', 0)?->matches(['createkw', 'VIEW', 'select']) ?? false);
         self::assertTrue($plan->patternAt('oneselect', 0)?->matches(['SELECT']) ?? false);
     }
+
+    public function testGeneratedColumnPlanRequiresTheGeneratedConstraint(): void
+    {
+        $plan = GenerationPlans::generatedColumnStatement();
+
+        self::assertSame('cmd', $plan->startRule());
+        self::assertTrue($plan->patternAt('cmd', 0)?->matches(['create_table', 'create_table_args']) ?? false);
+        self::assertTrue($plan->patternAt('create_table_args', 0)?->matches(['columnlist']) ?? false);
+        self::assertTrue($plan->patternAt('carglist', 0)?->matches(['carglist', 'ccons']) ?? false);
+        self::assertTrue($plan->patternAt('carglist', 1)?->matches([]) ?? false);
+        self::assertTrue($plan->patternAt('ccons', 0)?->matches(['GENERATED', 'generated']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -112,6 +112,15 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('SELECT', $tokens);
     }
 
+    public function testGeneratedColumnStatement(): void
+    {
+        $sql = (new SqliteProvider(Factory::create()))->generatedColumnStatement();
+
+        self::assertStringStartsWith('CREATE TABLE ', $sql);
+        self::assertStringContainsString(' GENERATED ALWAYS AS (', $sql);
+        self::assertStringEndsWith(' STORED)', $sql);
+    }
+
     #[\Override]
     protected function setUp(): void
     {

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -112,13 +112,21 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('SELECT', $tokens);
     }
 
-    public function testGeneratedColumnStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testGeneratedColumnStatement(int $seed): void
     {
-        $sql = (new SqliteProvider(Factory::create()))->generatedColumnStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new SqliteProvider($faker);
+        $sql = $provider->generatedColumnStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'sqlite-3.47.2', true))
+            ->tokenize($sql);
 
-        self::assertStringStartsWith('CREATE TABLE ', $sql);
-        self::assertStringContainsString(' GENERATED ALWAYS AS (', $sql);
-        self::assertStringEndsWith(' STORED)', $sql);
+        self::assertSame($sql, $provider->generatedColumnStatement(40));
+        self::assertContains('GENERATED', $tokens);
+        self::assertContains('ALWAYS', $tokens);
+        self::assertContains('AS', $tokens);
     }
 
     #[\Override]

--- a/packages/ztd-query-core/src/Rewrite/GeneratedColumnProjector.php
+++ b/packages/ztd-query-core/src/Rewrite/GeneratedColumnProjector.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Rewrite;
+
+use ZtdQuery\Platform\IdentifierQuoter;
+
+/**
+ * Recomputes database-generated columns from a complete base-row projection.
+ */
+final class GeneratedColumnProjector
+{
+    private const SOURCE_ALIAS = '__ztd_generated_source';
+
+    public function __construct(private readonly IdentifierQuoter $quoter)
+    {
+    }
+
+    /**
+     * @param array<int, string> $columns
+     * @param array<string, string> $generatedExpressions
+     */
+    public function project(string $sourceSql, array $columns, array $generatedExpressions): string
+    {
+        if ($generatedExpressions === []) {
+            return $sourceSql;
+        }
+
+        $sourceAlias = $this->quoter->quote(self::SOURCE_ALIAS);
+        $selects = [];
+        foreach ($columns as $column) {
+            $quotedColumn = $this->quoter->quote($column);
+            $expression = $generatedExpressions[$column] ?? null;
+            $selects[] = $expression === null
+                ? "$sourceAlias.$quotedColumn AS $quotedColumn"
+                : "$expression AS $quotedColumn";
+        }
+
+        return 'SELECT ' . implode(', ', $selects) . " FROM ($sourceSql) AS $sourceAlias";
+    }
+}

--- a/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
+++ b/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
@@ -25,7 +25,8 @@ interface SqlTransformer
      *     primaryKeys?: array<int, string>,
      *     candidateKeys?: array<string, array<int, string>>,
      *     columnDefaults?: array<string, string>,
-     *     identityStrategies?: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>
+     *     identityStrategies?: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
+     *     generatedExpressions?: array<string, string>
      * }> $tables Table name => shadow data and column information.
      * @return string The transformed SQL.
      */

--- a/packages/ztd-query-core/src/Schema/TableDefinition.php
+++ b/packages/ztd-query-core/src/Schema/TableDefinition.php
@@ -20,6 +20,9 @@ final class TableDefinition
     /** @var array<string, IdentityGenerationStrategy> */
     public readonly array $identityStrategies;
 
+    /** @var array<string, string> */
+    public readonly array $generatedExpressions;
+
     /**
      * @param array<int, string> $columns Column names in declaration order.
      * @param array<string, string> $columnTypes Column name => MySQL type string.
@@ -29,6 +32,7 @@ final class TableDefinition
      * @param array<string, ColumnType> $typedColumns Column name => structured ColumnType.
      * @param array<string, string> $columnDefaults Column name => SQL default expression.
      * @param array<string, IdentityGenerationStrategy> $identityStrategies Column name => shadow generation strategy.
+     * @param array<string, string> $generatedExpressions Column name => database generated expression.
      */
     public function __construct(
         public readonly array $columns,
@@ -39,10 +43,12 @@ final class TableDefinition
         array $typedColumns = [],
         array $columnDefaults = [],
         array $identityStrategies = [],
+        array $generatedExpressions = [],
     ) {
         $this->typedColumns = $typedColumns;
         $this->columnDefaults = $columnDefaults;
         $this->identityStrategies = $identityStrategies;
+        $this->generatedExpressions = $generatedExpressions;
     }
 
     public function candidateKeys(): CandidateKeySet

--- a/packages/ztd-query-core/tests/Unit/Rewrite/GeneratedColumnProjectorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/GeneratedColumnProjectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rewrite;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Tests\Fake\FakeIdentifierQuoter;
+use ZtdQuery\Rewrite\GeneratedColumnProjector;
+
+#[CoversClass(GeneratedColumnProjector::class)]
+final class GeneratedColumnProjectorTest extends TestCase
+{
+    public function testReturnsSourceUnchangedWithoutGeneratedExpressions(): void
+    {
+        $projector = new GeneratedColumnProjector(new FakeIdentifierQuoter());
+
+        self::assertSame('SELECT 1 AS "id"', $projector->project('SELECT 1 AS "id"', ['id'], []));
+    }
+
+    public function testProjectsGeneratedExpressionsOverBaseRows(): void
+    {
+        $projector = new GeneratedColumnProjector(new FakeIdentifierQuoter());
+
+        self::assertSame(
+            'SELECT "__ztd_generated_source"."qty" AS "qty", '
+            . '"__ztd_generated_source"."unit_price" AS "unit_price", '
+            . '(qty * unit_price) AS "total" '
+            . 'FROM (SELECT 5 AS "qty", 10 AS "unit_price", NULL AS "total") AS "__ztd_generated_source"',
+            $projector->project(
+                'SELECT 5 AS "qty", 10 AS "unit_price", NULL AS "total"',
+                ['qty', 'unit_price', 'total'],
+                ['total' => '(qty * unit_price)'],
+            ),
+        );
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
@@ -29,6 +29,7 @@ final class TableDefinitionTest extends TestCase
             $typedColumns,
             ['name' => "'anonymous'"],
             ['id' => IdentityGenerationStrategy::MaxValue],
+            ['name' => "CONCAT('user-', id)"],
         );
 
         self::assertSame(['id', 'name'], $definition->columns);
@@ -39,6 +40,7 @@ final class TableDefinitionTest extends TestCase
         self::assertSame($typedColumns, $definition->typedColumns);
         self::assertSame(['name' => "'anonymous'"], $definition->columnDefaults);
         self::assertSame(['id' => IdentityGenerationStrategy::MaxValue], $definition->identityStrategies);
+        self::assertSame(['name' => "CONCAT('user-', id)"], $definition->generatedExpressions);
     }
 
     public function testTypedColumnsDefaultsToEmpty(): void
@@ -54,5 +56,6 @@ final class TableDefinitionTest extends TestCase
         self::assertSame([], $definition->typedColumns);
         self::assertSame([], $definition->columnDefaults);
         self::assertSame([], $definition->identityStrategies);
+        self::assertSame([], $definition->generatedExpressions);
     }
 }

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -149,6 +149,7 @@ final class RewriteTarget
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
             fn (): string => $this->provider->temporaryTableStatement(),
             fn (): string => $this->provider->viewStatement(),
+            fn (): string => $this->provider->generatedColumnStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/MySqlGeneratedColumnProjector.php
+++ b/packages/ztd-query-mysql/src/MySqlGeneratedColumnProjector.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Platform\IdentifierQuoter;
+
+/**
+ * Recomputes database-generated columns from a complete base-row projection.
+ */
+final class MySqlGeneratedColumnProjector
+{
+    private const SOURCE_ALIAS = '__ztd_generated_source';
+
+    private readonly IdentifierQuoter $quoter;
+
+    public function __construct()
+    {
+        $this->quoter = new MySqlIdentifierQuoter();
+    }
+
+    /**
+     * @param array<int, string> $columns
+     * @param array<string, string> $generatedExpressions
+     */
+    public function project(string $sourceSql, array $columns, array $generatedExpressions): string
+    {
+        if ($generatedExpressions === []) {
+            return $sourceSql;
+        }
+
+        $sourceAlias = $this->quoter->quote(self::SOURCE_ALIAS);
+        $selects = [];
+        foreach ($columns as $column) {
+            $quotedColumn = $this->quoter->quote($column);
+            $expression = $generatedExpressions[$column] ?? null;
+            $selects[] = $expression === null
+                ? "$sourceAlias.$quotedColumn AS $quotedColumn"
+                : "$expression AS $quotedColumn";
+        }
+
+        return 'SELECT ' . implode(', ', $selects) . " FROM ($sourceSql) AS $sourceAlias";
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -187,7 +187,8 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
      *     columns: array<int, string>,
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
      *     columnDefaults: array<string, string>,
-     *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>
+     *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
+     *     generatedExpressions: array<string, string>
      * }>
      */
     private function buildTableContext(): array
@@ -212,6 +213,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
             $columnTypes = $definition !== null ? $definition->typedColumns : [];
             $columnDefaults = $definition !== null ? $definition->columnDefaults : [];
             $identityStrategies = $definition !== null ? $definition->identityStrategies : [];
+            $generatedExpressions = $definition !== null ? $definition->generatedExpressions : [];
 
             $context[$tableName] = [
                 'rows' => $rows,
@@ -219,6 +221,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'columnTypes' => $columnTypes,
                 'columnDefaults' => $columnDefaults,
                 'identityStrategies' => $identityStrategies,
+                'generatedExpressions' => $generatedExpressions,
                 'primaryKeys' => $definition !== null ? $definition->primaryKeys : [],
                 'candidateKeys' => $definition !== null ? $definition->candidateKeys()->keys() : [],
             ];
@@ -236,6 +239,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'columnTypes' => $definition->typedColumns,
                 'columnDefaults' => $definition->columnDefaults,
                 'identityStrategies' => $definition->identityStrategies,
+                'generatedExpressions' => $definition->generatedExpressions,
                 'primaryKeys' => $definition->primaryKeys,
                 'candidateKeys' => $definition->candidateKeys()->keys(),
             ];

--- a/packages/ztd-query-mysql/src/MySqlSchemaParser.php
+++ b/packages/ztd-query-mysql/src/MySqlSchemaParser.php
@@ -48,6 +48,7 @@ final class MySqlSchemaParser implements SchemaParser
         $typedColumns = [];
         $columnDefaults = [];
         $identityStrategies = [];
+        $generatedExpressions = [];
         $primaryKeys = [];
         $notNullColumns = [];
         $uniqueConstraints = [];
@@ -101,6 +102,12 @@ final class MySqlSchemaParser implements SchemaParser
                 if ($field->options !== null && self::optionSet($field->options, 'AUTO_INCREMENT')) {
                     $identityStrategies[$columnName] = IdentityGenerationStrategy::MaxValue;
                 }
+                if ($field->options !== null) {
+                    $generatedExpression = $field->options->has('AS');
+                    if (is_string($generatedExpression) && $generatedExpression !== '') {
+                        $generatedExpressions[$columnName] = $generatedExpression;
+                    }
+                }
             }
 
             if ($field->key !== null && $field->key->type === 'PRIMARY KEY') {
@@ -136,6 +143,7 @@ final class MySqlSchemaParser implements SchemaParser
             $typedColumns,
             $columnDefaults,
             $identityStrategies,
+            $generatedExpressions,
         );
     }
 

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -11,7 +11,7 @@ use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
-use ZtdQuery\Rewrite\GeneratedColumnProjector;
+use ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -29,7 +29,7 @@ final class SelectTransformer implements SqlTransformer
     private ValueRenderer $valueRenderer;
     private MySqlTypeSemantics $typeSemantics;
     private MySqlCteShadowComposer $cteComposer;
-    private GeneratedColumnProjector $generatedColumnProjector;
+    private MySqlGeneratedColumnProjector $generatedColumnProjector;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -41,7 +41,7 @@ final class SelectTransformer implements SqlTransformer
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\MySql\MySqlValueRenderer($this->castRenderer);
         $this->typeSemantics = new MySqlTypeSemantics();
         $this->cteComposer = new MySqlCteShadowComposer();
-        $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
+        $this->generatedColumnProjector = new MySqlGeneratedColumnProjector();
     }
 
     /**

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -11,6 +11,7 @@ use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\MySql\MySqlCteShadowComposer;
+use ZtdQuery\Rewrite\GeneratedColumnProjector;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -28,6 +29,7 @@ final class SelectTransformer implements SqlTransformer
     private ValueRenderer $valueRenderer;
     private MySqlTypeSemantics $typeSemantics;
     private MySqlCteShadowComposer $cteComposer;
+    private GeneratedColumnProjector $generatedColumnProjector;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -39,6 +41,7 @@ final class SelectTransformer implements SqlTransformer
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\MySql\MySqlValueRenderer($this->castRenderer);
         $this->typeSemantics = new MySqlTypeSemantics();
         $this->cteComposer = new MySqlCteShadowComposer();
+        $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
     }
 
     /**
@@ -59,6 +62,7 @@ final class SelectTransformer implements SqlTransformer
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];
             $columnTypes = $tableContext['columnTypes'];
+            $generatedExpressions = $tableContext['generatedExpressions'] ?? [];
 
             if ($columns === [] && $rows !== []) {
                 $columns = array_keys($rows[0]);
@@ -75,7 +79,13 @@ final class SelectTransformer implements SqlTransformer
                 continue;
             }
 
-            $ctes[$tableName] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
+            $ctes[$tableName] = $this->generateCte(
+                $tableName,
+                $rows,
+                $columns,
+                $columnTypes,
+                $generatedExpressions,
+            );
         }
 
         return $this->cteComposer->compose($sql, $ctes);
@@ -88,13 +98,15 @@ final class SelectTransformer implements SqlTransformer
      * @param array<int, array<string, mixed>> $rows
      * @param array<int, string> $columns
      * @param array<string, ColumnType> $columnTypes
+     * @param array<string, string> $generatedExpressions
      * @return string
      */
     private function generateCte(
         string $tableName,
         array $rows,
         array $columns,
-        array $columnTypes
+        array $columnTypes,
+        array $generatedExpressions,
     ): string {
         $quotedTable = $this->quoter->quote($tableName);
 
@@ -108,7 +120,12 @@ final class SelectTransformer implements SqlTransformer
                         : $this->renderFallbackNullCast();
                     $selects[] = "$nullCast AS " . $this->quoter->quote($col);
                 }
-                return "$quotedTable AS (SELECT " . implode(", ", $selects) . " FROM DUAL WHERE 0)";
+                return $this->wrapCte(
+                    $quotedTable,
+                    'SELECT ' . implode(', ', $selects) . ' FROM DUAL WHERE 0',
+                    $columns,
+                    $generatedExpressions,
+                );
             }
 
             $ctes = [];
@@ -123,7 +140,7 @@ final class SelectTransformer implements SqlTransformer
             }
 
             $union = implode(" UNION ALL ", $ctes);
-            return "$quotedTable AS ($union)";
+            return $this->wrapCte($quotedTable, $union, $columns, $generatedExpressions);
         }
 
         if ($rows === []) {
@@ -143,7 +160,22 @@ final class SelectTransformer implements SqlTransformer
         }
 
         $union = implode(" UNION ALL ", $ctes);
-        return "$quotedTable AS ($union)";
+        return $this->wrapCte($quotedTable, $union, array_keys($rows[0]), $generatedExpressions);
+    }
+
+    /**
+     * @param array<int, string> $columns
+     * @param array<string, string> $generatedExpressions
+     */
+    private function wrapCte(
+        string $quotedTable,
+        string $baseSql,
+        array $columns,
+        array $generatedExpressions,
+    ): string {
+        $sql = $this->generatedColumnProjector->project($baseSql, $columns, $generatedExpressions);
+
+        return "$quotedTable AS ($sql)";
     }
 
     private function formatValue(mixed $val, ?ColumnType $type = null): string

--- a/packages/ztd-query-mysql/tests/Unit/MySqlGeneratedColumnProjectorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlGeneratedColumnProjectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector;
+
+#[CoversClass(MySqlGeneratedColumnProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlIdentifierQuoter::class)]
+final class MySqlGeneratedColumnProjectorTest extends TestCase
+{
+    public function testReturnsSourceUnchangedWithoutGeneratedExpressions(): void
+    {
+        self::assertSame(
+            'SELECT 1 AS `id`',
+            (new MySqlGeneratedColumnProjector())->project('SELECT 1 AS `id`', ['id'], []),
+        );
+    }
+
+    public function testProjectsGeneratedExpressionsOverBaseRows(): void
+    {
+        self::assertSame(
+            'SELECT `__ztd_generated_source`.`qty` AS `qty`, '
+            . '`__ztd_generated_source`.`unit_price` AS `unit_price`, '
+            . '(qty * unit_price) AS `total` '
+            . 'FROM (SELECT 5 AS `qty`, 10 AS `unit_price`, NULL AS `total`) AS `__ztd_generated_source`',
+            (new MySqlGeneratedColumnProjector())->project(
+                'SELECT 5 AS `qty`, 10 AS `unit_price`, NULL AS `total`',
+                ['qty', 'unit_price', 'total'],
+                ['total' => '(qty * unit_price)'],
+            ),
+        );
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -55,6 +55,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(AlterTableMutation::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class MySqlMutationResolverTest extends TestCase
 {
     public function testResolveInsertReturnsInsertMutation(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -79,6 +79,21 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewShadowRenderer::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
+    public function testGeneratedExpressionIsPresentBeforeTheFirstShadowWrite(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = $this->createSchemaParser()->parse(
+            'CREATE TABLE orders (qty INT, total INT GENERATED ALWAYS AS (qty * 2) STORED)',
+        );
+        self::assertNotNull($definition);
+        $registry->register('orders', $definition);
+
+        $sql = $this->createRewriter($store, $registry)->rewrite('SELECT total FROM orders')->sql();
+
+        self::assertStringContainsString('(qty * 2) AS `total`', $sql);
+    }
+
     public function testRegisteredViewIsKnownAndMaterialized(): void
     {
         $store = new ShadowStore();

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -77,6 +77,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewShadowRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
     public function testGeneratedExpressionIsPresentBeforeTheFirstShadowWrite(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
@@ -40,6 +40,21 @@ final class MySqlSchemaParserTest extends SchemaParserContractTest
         return 'SELECT * FROM users WHERE id = 1';
     }
 
+    public function testParsesStoredAndVirtualGeneratedExpressions(): void
+    {
+        $definition = (new MySqlSchemaParser(new MySqlParser()))->parse(
+            'CREATE TABLE orders (qty INT, unit_price DECIMAL(10,2), '
+            . 'total DECIMAL(10,2) GENERATED ALWAYS AS (qty * unit_price) STORED, '
+            . 'label VARCHAR(255) AS (CONCAT(qty, unit_price)) VIRTUAL)',
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame([
+            'total' => '(qty * unit_price)',
+            'label' => '(CONCAT(qty, unit_price))',
+        ], $definition->generatedExpressions);
+    }
+
     public function testParseSimpleCreateTable(): void
     {
         $parser = new MySqlParser();

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
@@ -53,6 +53,7 @@ use ZtdQuery\Session;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewShadowRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class MySqlSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedViews(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class DeleteTransformerTest extends TestCase
 {
     public function testTransformPreservesCaseWhereExpression(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
@@ -38,6 +38,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class InsertTransformerTest extends TestCase
 {
     public function testProjectsUpsertExpressionUsingCandidateKeys(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/MySqlTransformerTest.php
@@ -42,6 +42,7 @@ use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class MySqlTransformerTest extends TestCase
 {
     public function testTransformSelectPassthrough(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/ReplaceTransformerTest.php
@@ -34,6 +34,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class ReplaceTransformerTest extends TestCase
 {
     public function testTransformReplaceCastsParametersToTargetColumnTypes(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
@@ -27,6 +27,21 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testGeneratedColumnsAreRecomputedFromBaseRow(): void
+    {
+        $result = (new SelectTransformer())->transform('SELECT total FROM orders', [
+            'orders' => [
+                'rows' => [['qty' => 5, 'unit_price' => 10, 'total' => null]],
+                'columns' => ['qty', 'unit_price', 'total'],
+                'columnTypes' => [],
+                'generatedExpressions' => ['total' => '(qty * unit_price)'],
+            ],
+        ]);
+
+        self::assertStringContainsString('(qty * unit_price) AS `total`', $result);
+        self::assertStringContainsString('AS `__ztd_generated_source`', $result);
+    }
+
     public function testTransformMaterializesViewAfterItsShadowTable(): void
     {
         $tables = [

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
@@ -25,6 +25,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
     public function testGeneratedColumnsAreRecomputedFromBaseRow(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class UpdateTransformerTest extends TestCase
 {
     public function testBuildProjectionPreservesDerivedJoinSource(): void

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/GeneratedColumnTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/GeneratedColumnTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_mysql
+ * @group integration
+ * @group mysql
+ */
+#[CoversNothing]
+#[Large]
+final class GeneratedColumnTest extends TestCase
+{
+    public function testGeneratedValuesDriveReadsAggregatesUpdatesAndDeletes(): void
+    {
+        [$databaseName, $pdo] = MySqlContainer::createTestDatabase();
+
+        try {
+            $pdo->exec('CREATE TABLE orders (id BIGINT AUTO_INCREMENT PRIMARY KEY, qty INT NOT NULL, unit_price DECIMAL(10,2) NOT NULL, total DECIMAL(12,2) GENERATED ALWAYS AS (qty * unit_price) STORED)');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            $ztdPdo->exec('INSERT INTO orders (qty, unit_price) VALUES (5, 10), (2, 7)');
+
+            $rows = $ztdPdo->query('SELECT CAST(id AS SIGNED) AS id, CAST(total AS SIGNED) AS total FROM orders ORDER BY id');
+            self::assertNotFalse($rows);
+            self::assertSame(
+                [['id' => 1, 'total' => 50], ['id' => 2, 'total' => 14]],
+                $rows->fetchAll(),
+            );
+            $sum = $ztdPdo->query('SELECT CAST(SUM(total) AS SIGNED) FROM orders');
+            self::assertNotFalse($sum);
+            self::assertSame(64, $sum->fetchColumn());
+            $filtered = $ztdPdo->query('SELECT CAST(id AS SIGNED) FROM orders WHERE total > 20');
+            self::assertNotFalse($filtered);
+            self::assertSame([1], $filtered->fetchAll(\PDO::FETCH_COLUMN));
+
+            self::assertSame(1, $ztdPdo->exec('UPDATE orders SET qty = 7 WHERE id = 1'));
+            $updated = $ztdPdo->query('SELECT CAST(total AS SIGNED) FROM orders WHERE id = 1');
+            self::assertNotFalse($updated);
+            self::assertSame(70, $updated->fetchColumn());
+            self::assertSame(1, $ztdPdo->exec('DELETE FROM orders WHERE total >= 70'));
+            $remaining = $ztdPdo->query('SELECT CAST(id AS SIGNED) FROM orders');
+            self::assertNotFalse($remaining);
+            self::assertSame([2], $remaining->fetchAll(\PDO::FETCH_COLUMN));
+        } finally {
+            $pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/GeneratedColumnTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/GeneratedColumnTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class GeneratedColumnTest extends TestCase
+{
+    public function testGeneratedValuesDriveReadsAggregatesUpdatesAndDeletes(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $pdo->exec('CREATE TABLE orders (id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, qty INTEGER NOT NULL, unit_price NUMERIC(10,2) NOT NULL, total NUMERIC(12,2) GENERATED ALWAYS AS (qty * unit_price) STORED)');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            $ztdPdo->exec('INSERT INTO orders (qty, unit_price) VALUES (5, 10), (2, 7)');
+
+            $rows = $ztdPdo->query('SELECT id::integer AS id, total::integer AS total FROM orders ORDER BY id');
+            self::assertNotFalse($rows);
+            self::assertSame(
+                [['id' => 1, 'total' => 50], ['id' => 2, 'total' => 14]],
+                $rows->fetchAll(),
+            );
+            $sum = $ztdPdo->query('SELECT SUM(total)::integer FROM orders');
+            self::assertNotFalse($sum);
+            self::assertSame(64, $sum->fetchColumn());
+            $filtered = $ztdPdo->query('SELECT id::integer FROM orders WHERE total > 20');
+            self::assertNotFalse($filtered);
+            self::assertSame([1], $filtered->fetchAll(\PDO::FETCH_COLUMN));
+
+            self::assertSame(1, $ztdPdo->exec('UPDATE orders SET qty = 7 WHERE id = 1'));
+            $updated = $ztdPdo->query('SELECT total::integer FROM orders WHERE id = 1');
+            self::assertNotFalse($updated);
+            self::assertSame(70, $updated->fetchColumn());
+            self::assertSame(1, $ztdPdo->exec('DELETE FROM orders WHERE total >= 70'));
+            $remaining = $ztdPdo->query('SELECT id::integer FROM orders');
+            self::assertNotFalse($remaining);
+            self::assertSame([2], $remaining->fetchAll(\PDO::FETCH_COLUMN));
+        } finally {
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/GeneratedColumnTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/GeneratedColumnTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/** @requires extension pdo_sqlite */
+#[CoversNothing]
+#[Large]
+final class GeneratedColumnTest extends TestCase
+{
+    public function testGeneratedValuesDriveReadsAggregatesUpdatesAndDeletes(): void
+    {
+        $pdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $pdo->exec('CREATE TABLE orders (id INTEGER PRIMARY KEY, qty INTEGER NOT NULL, unit_price REAL NOT NULL, total REAL GENERATED ALWAYS AS (qty * unit_price) STORED)');
+        $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+        $ztdPdo->exec('INSERT INTO orders (id, qty, unit_price) VALUES (1, 5, 10), (2, 2, 7)');
+
+        $rows = $ztdPdo->query('SELECT id, CAST(total AS INTEGER) AS total FROM orders ORDER BY id');
+        self::assertNotFalse($rows);
+        self::assertSame(
+            [['id' => 1, 'total' => 50], ['id' => 2, 'total' => 14]],
+            $rows->fetchAll(),
+        );
+        $sum = $ztdPdo->query('SELECT CAST(SUM(total) AS INTEGER) FROM orders');
+        self::assertNotFalse($sum);
+        self::assertSame(64, $sum->fetchColumn());
+        $filtered = $ztdPdo->query('SELECT id FROM orders WHERE total > 20');
+        self::assertNotFalse($filtered);
+        self::assertSame([1], $filtered->fetchAll(\PDO::FETCH_COLUMN));
+
+        self::assertSame(1, $ztdPdo->exec('UPDATE orders SET qty = 7 WHERE id = 1'));
+        $updated = $ztdPdo->query('SELECT CAST(total AS INTEGER) FROM orders WHERE id = 1');
+        self::assertNotFalse($updated);
+        self::assertSame(70, $updated->fetchColumn());
+        self::assertSame(1, $ztdPdo->exec('DELETE FROM orders WHERE total >= 70'));
+        $remaining = $ztdPdo->query('SELECT id FROM orders');
+        self::assertNotFalse($remaining);
+        self::assertSame([2], $remaining->fetchAll(\PDO::FETCH_COLUMN));
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -137,6 +137,7 @@ final class RewriteTarget
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
             fn (): string => $this->provider->temporaryTableStatement(),
             fn (): string => $this->provider->viewStatement(),
+            fn (): string => $this->provider->generatedColumnStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlGeneratedColumnProjector.php
+++ b/packages/ztd-query-postgres/src/PgSqlGeneratedColumnProjector.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Platform\IdentifierQuoter;
+
+/**
+ * Recomputes database-generated columns from a complete base-row projection.
+ */
+final class PgSqlGeneratedColumnProjector
+{
+    private const SOURCE_ALIAS = '__ztd_generated_source';
+
+    private readonly IdentifierQuoter $quoter;
+
+    public function __construct()
+    {
+        $this->quoter = new PgSqlIdentifierQuoter();
+    }
+
+    /**
+     * @param array<int, string> $columns
+     * @param array<string, string> $generatedExpressions
+     */
+    public function project(string $sourceSql, array $columns, array $generatedExpressions): string
+    {
+        if ($generatedExpressions === []) {
+            return $sourceSql;
+        }
+
+        $sourceAlias = $this->quoter->quote(self::SOURCE_ALIAS);
+        $selects = [];
+        foreach ($columns as $column) {
+            $quotedColumn = $this->quoter->quote($column);
+            $expression = $generatedExpressions[$column] ?? null;
+            $selects[] = $expression === null
+                ? "$sourceAlias.$quotedColumn AS $quotedColumn"
+                : "$expression AS $quotedColumn";
+        }
+
+        return 'SELECT ' . implode(', ', $selects) . " FROM ($sourceSql) AS $sourceAlias";
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -192,7 +192,8 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
      *     columns: array<int, string>,
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
      *     columnDefaults: array<string, string>,
-     *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>
+     *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
+     *     generatedExpressions: array<string, string>
      * }>
      */
     private function buildTableContext(): array
@@ -217,6 +218,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             $columnTypes = $definition !== null ? $definition->typedColumns : [];
             $columnDefaults = $definition !== null ? $definition->columnDefaults : [];
             $identityStrategies = $definition !== null ? $definition->identityStrategies : [];
+            $generatedExpressions = $definition !== null ? $definition->generatedExpressions : [];
 
             $context[$tableName] = [
                 'rows' => $rows,
@@ -224,6 +226,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'columnTypes' => $columnTypes,
                 'columnDefaults' => $columnDefaults,
                 'identityStrategies' => $identityStrategies,
+                'generatedExpressions' => $generatedExpressions,
                 'primaryKeys' => $definition !== null ? $definition->primaryKeys : [],
                 'candidateKeys' => $definition !== null ? $definition->candidateKeys()->keys() : [],
             ];
@@ -241,6 +244,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'columnTypes' => $definition->typedColumns,
                 'columnDefaults' => $definition->columnDefaults,
                 'identityStrategies' => $definition->identityStrategies,
+                'generatedExpressions' => $definition->generatedExpressions,
                 'primaryKeys' => $definition->primaryKeys,
                 'candidateKeys' => $definition->candidateKeys()->keys(),
             ];

--- a/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
@@ -36,6 +36,7 @@ final class PgSqlSchemaParser implements SchemaParser
         $typedColumns = [];
         $columnDefaults = [];
         $identityStrategies = [];
+        $generatedExpressions = [];
         $primaryKeys = [];
         $notNullColumns = [];
         /** @var array<string, list<string>> $uniqueConstraints */
@@ -86,6 +87,9 @@ final class PgSqlSchemaParser implements SchemaParser
             if ($columnDef['identity']) {
                 $identityStrategies[$columnDef['name']] = IdentityGenerationStrategy::Sequence;
             }
+            if ($columnDef['generatedExpression'] !== null) {
+                $generatedExpressions[$columnDef['name']] = $columnDef['generatedExpression'];
+            }
         }
 
         if ($columns === []) {
@@ -109,6 +113,7 @@ final class PgSqlSchemaParser implements SchemaParser
             $typedColumns,
             $columnDefaults,
             $identityStrategies,
+            $generatedExpressions,
         );
     }
 
@@ -126,7 +131,7 @@ final class PgSqlSchemaParser implements SchemaParser
     }
 
     /**
-     * @return array{name: string, type: string, columnType: ColumnType, notNull: bool, primaryKey: bool, unique: bool, default: string|null, identity: bool}|null
+     * @return array{name: string, type: string, columnType: ColumnType, notNull: bool, primaryKey: bool, unique: bool, default: string|null, identity: bool, generatedExpression: string|null}|null
      */
     private function parseColumnDefinition(string $entry): ?array
     {
@@ -158,6 +163,16 @@ final class PgSqlSchemaParser implements SchemaParser
         $identity = self::isSerialType($nativeType)
             || ($default !== null && self::isSequenceDefault($default))
             || self::hasGeneratedIdentity($afterType);
+        $generatedExpression = null;
+        if (!$identity) {
+            $generatedExpression = SqlTokenStream::tokenize($afterType)->topLevelClause(
+                ['GENERATED', 'ALWAYS', 'AS'],
+                [['STORED']],
+            );
+            if ($generatedExpression === '') {
+                $generatedExpression = null;
+            }
+        }
 
         $family = $this->mapTypeToFamily($nativeType);
         $columnType = new ColumnType($family, strtoupper($nativeType));
@@ -171,6 +186,7 @@ final class PgSqlSchemaParser implements SchemaParser
             'unique' => $unique,
             'default' => $default,
             'identity' => $identity,
+            'generatedExpression' => $generatedExpression,
         ];
     }
 

--- a/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
@@ -92,7 +92,7 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
         $stmt = $this->connection->query(
             "SELECT column_name, data_type, character_maximum_length, "
             . "numeric_precision, numeric_scale, is_nullable, column_default, "
-            . "udt_name "
+            . "udt_name, is_identity, identity_generation, is_generated, generation_expression "
             . "FROM information_schema.columns "
             . "WHERE table_schema = current_schema() AND table_name = '" . str_replace("'", "''", $tableName) . "' "
             . "ORDER BY ordinal_position"
@@ -191,9 +191,22 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
             $def .= ' NOT NULL';
         }
 
-        $default = $col['column_default'] ?? null;
-        if (is_string($default) && $default !== '') {
-            $def .= ' DEFAULT ' . $default;
+        $generationExpression = $col['generation_expression'] ?? null;
+        if (($col['is_generated'] ?? 'NEVER') === 'ALWAYS'
+            && is_string($generationExpression)
+            && trim($generationExpression) !== ''
+        ) {
+            $def .= ' GENERATED ALWAYS AS (' . $generationExpression . ') STORED';
+        } elseif (($col['is_identity'] ?? 'NO') === 'YES') {
+            $identityGeneration = ($col['identity_generation'] ?? 'BY DEFAULT') === 'ALWAYS'
+                ? 'ALWAYS'
+                : 'BY DEFAULT';
+            $def .= " GENERATED $identityGeneration AS IDENTITY";
+        } else {
+            $default = $col['column_default'] ?? null;
+            if (is_string($default) && $default !== '') {
+                $def .= ' DEFAULT ' . $default;
+            }
         }
 
         return $def;

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -10,6 +10,7 @@ use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
+use ZtdQuery\Rewrite\GeneratedColumnProjector;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -30,6 +31,7 @@ final class SelectTransformer implements SqlTransformer
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
     private PgSqlCteShadowComposer $cteComposer;
+    private GeneratedColumnProjector $generatedColumnProjector;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -40,6 +42,7 @@ final class SelectTransformer implements SqlTransformer
         $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Postgres\PgSqlValueRenderer($this->castRenderer);
         $this->cteComposer = new PgSqlCteShadowComposer();
+        $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
     }
 
     /**
@@ -58,6 +61,7 @@ final class SelectTransformer implements SqlTransformer
             $columns = $tableContext['columns'];
             /** @var array<string, ColumnType> $columnTypes */
             $columnTypes = $tableContext['columnTypes'];
+            $generatedExpressions = $tableContext['generatedExpressions'] ?? [];
 
             if ($columns === [] && $rows !== []) {
                 $columns = array_keys($rows[0]);
@@ -74,7 +78,13 @@ final class SelectTransformer implements SqlTransformer
                 continue;
             }
 
-            $ctes[$tableName] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
+            $ctes[$tableName] = $this->generateCte(
+                $tableName,
+                $rows,
+                $columns,
+                $columnTypes,
+                $generatedExpressions,
+            );
         }
 
         return $this->cteComposer->compose($sql, $ctes);
@@ -84,12 +94,14 @@ final class SelectTransformer implements SqlTransformer
      * @param array<int, array<string, mixed>> $rows
      * @param array<int, string> $columns
      * @param array<string, ColumnType> $columnTypes
+     * @param array<string, string> $generatedExpressions
      */
     private function generateCte(
         string $tableName,
         array $rows,
         array $columns,
-        array $columnTypes
+        array $columnTypes,
+        array $generatedExpressions,
     ): string {
         $quotedTable = $this->quoter->quote($tableName);
 
@@ -104,7 +116,12 @@ final class SelectTransformer implements SqlTransformer
                     $selects[] = "$nullCast AS " . $this->quoter->quote($col);
                 }
 
-                return "$quotedTable AS MATERIALIZED (SELECT " . implode(', ', $selects) . ' WHERE FALSE)';
+                return $this->wrapCte(
+                    $quotedTable,
+                    'SELECT ' . implode(', ', $selects) . ' WHERE FALSE',
+                    $columns,
+                    $generatedExpressions,
+                );
             }
 
             if (count($rows) === 1) {
@@ -116,10 +133,17 @@ final class SelectTransformer implements SqlTransformer
                     $selects[] = "$valStr AS " . $this->quoter->quote($col);
                 }
 
-                return "$quotedTable AS MATERIALIZED (SELECT " . implode(', ', $selects) . ')';
+                return $this->wrapCte(
+                    $quotedTable,
+                    'SELECT ' . implode(', ', $selects),
+                    $columns,
+                    $generatedExpressions,
+                );
             }
 
-            return $this->generateMultiRowCte($tableName, $rows, $columns, $columnTypes);
+            $baseSql = $this->generateMultiRowSource($rows, $columns, $columnTypes);
+
+            return $this->wrapCte($quotedTable, $baseSql, $columns, $generatedExpressions);
         }
 
         if ($rows === []) {
@@ -140,7 +164,7 @@ final class SelectTransformer implements SqlTransformer
 
         $union = implode(' UNION ALL ', $ctes);
 
-        return "$quotedTable AS MATERIALIZED ($union)";
+        return $this->wrapCte($quotedTable, $union, array_keys($rows[0]), $generatedExpressions);
     }
 
     /**
@@ -148,14 +172,11 @@ final class SelectTransformer implements SqlTransformer
      * @param array<int, string> $columns
      * @param array<string, ColumnType> $columnTypes
      */
-    private function generateMultiRowCte(
-        string $tableName,
+    private function generateMultiRowSource(
         array $rows,
         array $columns,
         array $columnTypes
     ): string {
-        $quotedTable = $this->quoter->quote($tableName);
-
         $valueRows = [];
         foreach ($rows as $row) {
             $values = [];
@@ -174,7 +195,22 @@ final class SelectTransformer implements SqlTransformer
         $valuesClause = implode(",\n    ", $valueRows);
         $columnList = implode(', ', $quotedColumns);
 
-        return "$quotedTable AS MATERIALIZED (\n  SELECT * FROM (VALUES\n    $valuesClause\n  ) AS t($columnList)\n)";
+        return "\n  SELECT * FROM (VALUES\n    $valuesClause\n  ) AS t($columnList)\n";
+    }
+
+    /**
+     * @param array<int, string> $columns
+     * @param array<string, string> $generatedExpressions
+     */
+    private function wrapCte(
+        string $quotedTable,
+        string $baseSql,
+        array $columns,
+        array $generatedExpressions,
+    ): string {
+        $sql = $this->generatedColumnProjector->project($baseSql, $columns, $generatedExpressions);
+
+        return "$quotedTable AS MATERIALIZED ($sql)";
     }
 
     private function formatValue(mixed $val, ?ColumnType $colType = null): string

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -10,7 +10,7 @@ use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
-use ZtdQuery\Rewrite\GeneratedColumnProjector;
+use ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -31,7 +31,7 @@ final class SelectTransformer implements SqlTransformer
     private IdentifierQuoter $quoter;
     private ValueRenderer $valueRenderer;
     private PgSqlCteShadowComposer $cteComposer;
-    private GeneratedColumnProjector $generatedColumnProjector;
+    private PgSqlGeneratedColumnProjector $generatedColumnProjector;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -42,7 +42,7 @@ final class SelectTransformer implements SqlTransformer
         $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Postgres\PgSqlValueRenderer($this->castRenderer);
         $this->cteComposer = new PgSqlCteShadowComposer();
-        $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
+        $this->generatedColumnProjector = new PgSqlGeneratedColumnProjector();
     }
 
     /**

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlGeneratedColumnProjectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlGeneratedColumnProjectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector;
+
+#[CoversClass(PgSqlGeneratedColumnProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter::class)]
+final class PgSqlGeneratedColumnProjectorTest extends TestCase
+{
+    public function testReturnsSourceUnchangedWithoutGeneratedExpressions(): void
+    {
+        self::assertSame(
+            'SELECT 1 AS "id"',
+            (new PgSqlGeneratedColumnProjector())->project('SELECT 1 AS "id"', ['id'], []),
+        );
+    }
+
+    public function testProjectsGeneratedExpressionsOverBaseRows(): void
+    {
+        self::assertSame(
+            'SELECT "__ztd_generated_source"."qty" AS "qty", '
+            . '"__ztd_generated_source"."unit_price" AS "unit_price", '
+            . '(qty * unit_price) AS "total" '
+            . 'FROM (SELECT 5 AS "qty", 10 AS "unit_price", NULL AS "total") AS "__ztd_generated_source"',
+            (new PgSqlGeneratedColumnProjector())->project(
+                'SELECT 5 AS "qty", 10 AS "unit_price", NULL AS "total"',
+                ['qty', 'unit_price', 'total'],
+                ['total' => '(qty * unit_price)'],
+            ),
+        );
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -66,6 +66,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlNativeUpsertProjector::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
     public function testGeneratedExpressionIsPresentBeforeTheFirstShadowWrite(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -68,6 +68,21 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
+    public function testGeneratedExpressionIsPresentBeforeTheFirstShadowWrite(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = $this->createSchemaParser()->parse(
+            'CREATE TABLE orders (qty INTEGER, total INTEGER GENERATED ALWAYS AS (qty * 2) STORED)',
+        );
+        self::assertNotNull($definition);
+        $registry->register('orders', $definition);
+
+        $sql = $this->createRewriter($store, $registry)->rewrite('SELECT total FROM orders')->sql();
+
+        self::assertStringContainsString('(qty * 2) AS "total"', $sql);
+    }
+
     public function testRegisteredViewIsKnownAndMaterialized(): void
     {
         $store = new ShadowStore();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
@@ -419,16 +419,19 @@ final class PgSqlSchemaParserTest extends SchemaParserContractTest
 
         self::assertNotNull($definition);
         self::assertSame([], $definition->identityStrategies);
+        self::assertSame(['computed' => '(source + 1)'], $definition->generatedExpressions);
     }
 
     public function testUnprefixedAndIncompleteIdentityClausesAreNotIdentities(): void
     {
         $definition = (new PgSqlSchemaParser())->parse(
-            'CREATE TABLE t (always_value BIGINT ALWAYS AS IDENTITY, default_value BIGINT BY DEFAULT AS IDENTITY, incomplete BIGINT GENERATED)'
+            'CREATE TABLE t (always_value BIGINT ALWAYS AS IDENTITY, default_value BIGINT BY DEFAULT AS IDENTITY, '
+            . 'incomplete BIGINT GENERATED, unprefixed_computed INTEGER ALWAYS AS (1) STORED)'
         );
 
         self::assertNotNull($definition);
         self::assertSame([], $definition->identityStrategies);
+        self::assertSame([], $definition->generatedExpressions);
     }
 
     public function testParseStopsDefaultAtInlinePrimaryKeyConstraint(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
@@ -621,11 +621,82 @@ final class PgSqlSchemaReflectorTest extends TestCase
         self::assertSame(
             "SELECT column_name, data_type, character_maximum_length, "
             . "numeric_precision, numeric_scale, is_nullable, column_default, "
-            . "udt_name "
+            . "udt_name, is_identity, identity_generation, is_generated, generation_expression "
             . "FROM information_schema.columns "
             . "WHERE table_schema = current_schema() AND table_name = 'users' "
             . "ORDER BY ordinal_position",
             $queries[0]
+        );
+    }
+
+    public function testReflectsGeneratedAndIdentityColumns(): void
+    {
+        $reflector = new PgSqlSchemaReflector(new FakeSequentialConnection([
+            new FakeStatement([
+                [
+                    'column_name' => 'total',
+                    'data_type' => 'numeric',
+                    'character_maximum_length' => null,
+                    'numeric_precision' => 10,
+                    'numeric_scale' => 2,
+                    'is_nullable' => 'YES',
+                    'column_default' => null,
+                    'udt_name' => 'numeric',
+                    'is_identity' => 'NO',
+                    'identity_generation' => null,
+                    'is_generated' => 'ALWAYS',
+                    'generation_expression' => 'qty * unit_price',
+                ],
+                [
+                    'column_name' => 'id',
+                    'data_type' => 'bigint',
+                    'character_maximum_length' => null,
+                    'numeric_precision' => 64,
+                    'numeric_scale' => 0,
+                    'is_nullable' => 'NO',
+                    'column_default' => null,
+                    'udt_name' => 'int8',
+                    'is_identity' => 'YES',
+                    'identity_generation' => 'ALWAYS',
+                    'is_generated' => 'NEVER',
+                    'generation_expression' => null,
+                ],
+                [
+                    'column_name' => 'ordinary',
+                    'data_type' => 'integer',
+                    'character_maximum_length' => null,
+                    'numeric_precision' => 32,
+                    'numeric_scale' => 0,
+                    'is_nullable' => 'YES',
+                    'column_default' => null,
+                    'udt_name' => 'int4',
+                    'is_identity' => 'NO',
+                    'identity_generation' => null,
+                    'is_generated' => 'NEVER',
+                    'generation_expression' => 'qty + 1',
+                ],
+                [
+                    'column_name' => 'blank',
+                    'data_type' => 'integer',
+                    'character_maximum_length' => null,
+                    'numeric_precision' => 32,
+                    'numeric_scale' => 0,
+                    'is_nullable' => 'YES',
+                    'column_default' => null,
+                    'udt_name' => 'int4',
+                    'is_identity' => 'NO',
+                    'identity_generation' => null,
+                    'is_generated' => 'ALWAYS',
+                    'generation_expression' => '   ',
+                ],
+            ]),
+            new FakeStatement([]),
+            new FakeStatement([]),
+        ]));
+
+        self::assertSame(
+            "CREATE TABLE \"orders\" (\n  \"total\" NUMERIC(10,2) GENERATED ALWAYS AS (qty * unit_price) STORED,\n  \"id\" BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY,\n  \"ordinary\" INTEGER,\n  \"blank\" INTEGER\n)",
+            $reflector->getCreateStatement('orders'),
         );
     }
 

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -50,6 +50,7 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlNativeUpsertProjector::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class PgSqlSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedViews(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
@@ -34,6 +34,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class PgSqlTransformerTest extends TestCase
 {
     public function testTransformSelectDelegatesToSelectTransformer(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -25,6 +25,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class DeleteTransformerTest extends TestCase
 {
     public function testBuildProjectionSimpleDelete(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -31,6 +31,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(InsertSelectRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class InsertTransformerTest extends TestCase
 {
     public function testProjectsConflictExpressionUsingCandidateKeys(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
     public function testGeneratedColumnsAreRecomputedFromBaseRow(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
@@ -23,6 +23,21 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testGeneratedColumnsAreRecomputedFromBaseRow(): void
+    {
+        $result = (new SelectTransformer())->transform('SELECT total FROM orders', [
+            'orders' => [
+                'rows' => [['qty' => 5, 'unit_price' => 10, 'total' => null]],
+                'columns' => ['qty', 'unit_price', 'total'],
+                'columnTypes' => [],
+                'generatedExpressions' => ['total' => '(qty * unit_price)'],
+            ],
+        ]);
+
+        self::assertStringContainsString('(qty * unit_price) AS "total"', $result);
+        self::assertStringContainsString('AS "__ztd_generated_source"', $result);
+    }
+
     public function testTransformMaterializesViewAfterItsShadowTable(): void
     {
         $tables = [

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -25,6 +25,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class UpdateTransformerTest extends TestCase
 {
     public function testBuildProjectionSimpleUpdate(): void

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
@@ -134,6 +134,7 @@ final class RewriteTarget
             fn (): string => $this->provider->insertFunctionUpsertStatement(),
             fn (): string => $this->provider->temporaryTableStatement(),
             fn (): string => $this->provider->viewStatement(),
+            fn (): string => $this->provider->generatedColumnStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-sqlite/src/SqliteGeneratedColumnProjector.php
+++ b/packages/ztd-query-sqlite/src/SqliteGeneratedColumnProjector.php
@@ -2,19 +2,22 @@
 
 declare(strict_types=1);
 
-namespace ZtdQuery\Rewrite;
+namespace ZtdQuery\Platform\Sqlite;
 
 use ZtdQuery\Platform\IdentifierQuoter;
 
 /**
  * Recomputes database-generated columns from a complete base-row projection.
  */
-final class GeneratedColumnProjector
+final class SqliteGeneratedColumnProjector
 {
     private const SOURCE_ALIAS = '__ztd_generated_source';
 
-    public function __construct(private readonly IdentifierQuoter $quoter)
+    private readonly IdentifierQuoter $quoter;
+
+    public function __construct()
     {
+        $this->quoter = new SqliteIdentifierQuoter();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
+++ b/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
@@ -288,6 +288,7 @@ final class SqliteMutationResolver
             array_merge($existing->typedColumns, $added->typedColumns),
             array_merge($existing->columnDefaults, $added->columnDefaults),
             $existing->identityStrategies,
+            array_merge($existing->generatedExpressions, $added->generatedExpressions),
         );
         $projection = $this->quotedColumns($existing->columns);
         $projection[] = ($added->columnDefaults[$columnName] ?? 'NULL')
@@ -314,6 +315,7 @@ final class SqliteMutationResolver
         $newTypedColumns = self::withoutMapKey($existing->typedColumns, $columnName);
         $newDefaults = self::withoutMapKey($existing->columnDefaults, $columnName);
         $newIdentityStrategies = self::withoutMapKey($existing->identityStrategies, $columnName);
+        $newGeneratedExpressions = self::withoutMapKey($existing->generatedExpressions, $columnName);
         $newNotNull = self::withoutColumn($existing->notNullColumns, $columnName);
         $newPrimaryKeys = self::withoutColumn($existing->primaryKeys, $columnName);
         $newUniqueConstraints = [];
@@ -333,6 +335,7 @@ final class SqliteMutationResolver
             $newTypedColumns,
             $newDefaults,
             $newIdentityStrategies,
+            $newGeneratedExpressions,
         );
 
         return $this->alterMutation(
@@ -395,6 +398,7 @@ final class SqliteMutationResolver
             self::renamedMapKey($existing->typedColumns, $oldName, $newName),
             self::renamedMapKey($existing->columnDefaults, $oldName, $newName),
             self::renamedMapKey($existing->identityStrategies, $oldName, $newName),
+            self::renamedMapKey($existing->generatedExpressions, $oldName, $newName),
         );
         $projection = [];
         foreach ($existing->columns as $column) {

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -174,6 +174,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
      *     columnDefaults: array<string, string>,
      *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
+     *     generatedExpressions: array<string, string>,
      *     primaryKeys: array<int, string>,
      *     candidateKeys: array<string, array<int, string>>
      * }>
@@ -206,6 +207,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
                     'columnTypes' => [],
                     'columnDefaults' => [],
                     'identityStrategies' => [],
+                    'generatedExpressions' => [],
                     'primaryKeys' => [],
                     'candidateKeys' => [],
                 ];
@@ -242,6 +244,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
      *     columnDefaults: array<string, string>,
      *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
+     *     generatedExpressions: array<string, string>,
      *     primaryKeys: array<int, string>,
      *     candidateKeys: array<string, array<int, string>>
      * }
@@ -254,6 +257,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
             'columnTypes' => $definition->typedColumns,
             'columnDefaults' => $definition->columnDefaults,
             'identityStrategies' => $definition->identityStrategies,
+            'generatedExpressions' => $definition->generatedExpressions,
             'primaryKeys' => $definition->primaryKeys,
             'candidateKeys' => $definition->candidateKeys()->keys(),
         ];

--- a/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
@@ -38,6 +38,7 @@ final class SqliteSchemaParser implements SchemaParser
         $notNullColumns = [];
         $uniqueConstraints = [];
         $columnDefaults = [];
+        $generatedExpressions = [];
         $uniqueIndex = 0;
 
         $definitions = $this->splitColumnDefinitions($body);
@@ -122,6 +123,9 @@ final class SqliteSchemaParser implements SchemaParser
             if ($colInfo['default'] !== null) {
                 $columnDefaults[$colInfo['name']] = $colInfo['default'];
             }
+            if ($colInfo['generatedExpression'] !== null) {
+                $generatedExpressions[$colInfo['name']] = $colInfo['generatedExpression'];
+            }
         }
 
         if ($columns === []) {
@@ -163,6 +167,7 @@ final class SqliteSchemaParser implements SchemaParser
             $typedColumns,
             $columnDefaults,
             $identityStrategies,
+            $generatedExpressions,
         );
     }
 
@@ -323,7 +328,7 @@ final class SqliteSchemaParser implements SchemaParser
     /**
      * Parse a single column definition.
      *
-     * @return array{name: string, type: string|null, notNull: bool, primaryKey: bool, unique: bool, default: string|null}|null
+     * @return array{name: string, type: string|null, notNull: bool, primaryKey: bool, unique: bool, default: string|null, generatedExpression: string|null}|null
      */
     private function parseColumnDefinition(string $def): ?array
     {
@@ -368,6 +373,14 @@ final class SqliteSchemaParser implements SchemaParser
                 ['REFERENCES'], ['COLLATE'], ['CONSTRAINT'], ['GENERATED'], ['AS'],
             ],
         );
+        $stream = SqlTokenStream::tokenize($rest);
+        $generatedExpression = $stream->topLevelClause(
+            ['AS'],
+            [['STORED'], ['VIRTUAL']],
+        );
+        if ($generatedExpression === '') {
+            $generatedExpression = null;
+        }
 
         return [
             'name' => $name,
@@ -376,6 +389,7 @@ final class SqliteSchemaParser implements SchemaParser
             'primaryKey' => $primaryKey,
             'unique' => $unique,
             'default' => $default,
+            'generatedExpression' => $generatedExpression,
         ];
     }
 

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -11,7 +11,7 @@ use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
-use ZtdQuery\Rewrite\GeneratedColumnProjector;
+use ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -29,7 +29,7 @@ final class SelectTransformer implements SqlTransformer
     private ValueRenderer $valueRenderer;
     private SqliteCteShadowComposer $cteComposer;
     private SqliteIndexHintStripper $indexHintStripper;
-    private GeneratedColumnProjector $generatedColumnProjector;
+    private SqliteGeneratedColumnProjector $generatedColumnProjector;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -41,7 +41,7 @@ final class SelectTransformer implements SqlTransformer
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Sqlite\SqliteValueRenderer($this->castRenderer);
         $this->cteComposer = new SqliteCteShadowComposer();
         $this->indexHintStripper = new SqliteIndexHintStripper();
-        $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
+        $this->generatedColumnProjector = new SqliteGeneratedColumnProjector();
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/SelectTransformer.php
@@ -11,6 +11,7 @@ use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer;
+use ZtdQuery\Rewrite\GeneratedColumnProjector;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
@@ -28,6 +29,7 @@ final class SelectTransformer implements SqlTransformer
     private ValueRenderer $valueRenderer;
     private SqliteCteShadowComposer $cteComposer;
     private SqliteIndexHintStripper $indexHintStripper;
+    private GeneratedColumnProjector $generatedColumnProjector;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -39,6 +41,7 @@ final class SelectTransformer implements SqlTransformer
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Sqlite\SqliteValueRenderer($this->castRenderer);
         $this->cteComposer = new SqliteCteShadowComposer();
         $this->indexHintStripper = new SqliteIndexHintStripper();
+        $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
     }
 
     /**
@@ -56,6 +59,7 @@ final class SelectTransformer implements SqlTransformer
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];
             $columnTypes = $tableContext['columnTypes'];
+            $generatedExpressions = $tableContext['generatedExpressions'] ?? [];
 
             if ($columns === [] && $rows !== []) {
                 $columns = array_keys($rows[0]);
@@ -72,7 +76,13 @@ final class SelectTransformer implements SqlTransformer
                 continue;
             }
 
-            $ctes[$tableName] = $this->generateCte($tableName, $rows, $columns, $columnTypes);
+            $ctes[$tableName] = $this->generateCte(
+                $tableName,
+                $rows,
+                $columns,
+                $columnTypes,
+                $generatedExpressions,
+            );
         }
 
         $sql = $this->indexHintStripper->strip($sql, array_keys($ctes));
@@ -87,12 +97,14 @@ final class SelectTransformer implements SqlTransformer
      * @param array<int, array<string, mixed>> $rows
      * @param array<int, string> $columns
      * @param array<string, ColumnType> $columnTypes
+     * @param array<string, string> $generatedExpressions
      */
     private function generateCte(
         string $tableName,
         array $rows,
         array $columns,
-        array $columnTypes
+        array $columnTypes,
+        array $generatedExpressions,
     ): string {
         $quotedTable = $this->quoter->quote($tableName);
 
@@ -107,7 +119,12 @@ final class SelectTransformer implements SqlTransformer
                     $selects[] = "$nullCast AS " . $this->quoter->quote($col);
                 }
 
-                return "$quotedTable AS (SELECT " . implode(', ', $selects) . ' WHERE 0)';
+                return $this->wrapCte(
+                    $quotedTable,
+                    'SELECT ' . implode(', ', $selects) . ' WHERE 0',
+                    $columns,
+                    $generatedExpressions,
+                );
             }
 
             $ctes = [];
@@ -123,7 +140,7 @@ final class SelectTransformer implements SqlTransformer
 
             $union = implode(' UNION ALL ', $ctes);
 
-            return "$quotedTable AS ($union)";
+            return $this->wrapCte($quotedTable, $union, $columns, $generatedExpressions);
         }
 
         if ($rows === []) {
@@ -144,7 +161,22 @@ final class SelectTransformer implements SqlTransformer
 
         $union = implode(' UNION ALL ', $ctes);
 
-        return "$quotedTable AS ($union)";
+        return $this->wrapCte($quotedTable, $union, array_keys($rows[0]), $generatedExpressions);
+    }
+
+    /**
+     * @param array<int, string> $columns
+     * @param array<string, string> $generatedExpressions
+     */
+    private function wrapCte(
+        string $quotedTable,
+        string $baseSql,
+        array $columns,
+        array $generatedExpressions,
+    ): string {
+        $sql = $this->generatedColumnProjector->project($baseSql, $columns, $generatedExpressions);
+
+        return "$quotedTable AS ($sql)";
     }
 
     private function formatValue(mixed $val, ?ColumnType $type = null): string

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteGeneratedColumnProjectorTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteGeneratedColumnProjectorTest.php
@@ -2,33 +2,33 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Rewrite;
+namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
-use Tests\Fake\FakeIdentifierQuoter;
-use ZtdQuery\Rewrite\GeneratedColumnProjector;
+use ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector;
 
-#[CoversClass(GeneratedColumnProjector::class)]
-final class GeneratedColumnProjectorTest extends TestCase
+#[CoversClass(SqliteGeneratedColumnProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteIdentifierQuoter::class)]
+final class SqliteGeneratedColumnProjectorTest extends TestCase
 {
     public function testReturnsSourceUnchangedWithoutGeneratedExpressions(): void
     {
-        $projector = new GeneratedColumnProjector(new FakeIdentifierQuoter());
-
-        self::assertSame('SELECT 1 AS "id"', $projector->project('SELECT 1 AS "id"', ['id'], []));
+        self::assertSame(
+            'SELECT 1 AS "id"',
+            (new SqliteGeneratedColumnProjector())->project('SELECT 1 AS "id"', ['id'], []),
+        );
     }
 
     public function testProjectsGeneratedExpressionsOverBaseRows(): void
     {
-        $projector = new GeneratedColumnProjector(new FakeIdentifierQuoter());
-
         self::assertSame(
             'SELECT "__ztd_generated_source"."qty" AS "qty", '
             . '"__ztd_generated_source"."unit_price" AS "unit_price", '
             . '(qty * unit_price) AS "total" '
             . 'FROM (SELECT 5 AS "qty", 10 AS "unit_price", NULL AS "total") AS "__ztd_generated_source"',
-            $projector->project(
+            (new SqliteGeneratedColumnProjector())->project(
                 'SELECT 5 AS "qty", 10 AS "unit_price", NULL AS "total"',
                 ['qty', 'unit_price', 'total'],
                 ['total' => '(qty * unit_price)'],

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
@@ -234,6 +234,35 @@ final class SqliteMutationResolverTest extends TestCase
         self::assertInstanceOf(AlterTableMutation::class, $mutation);
     }
 
+    public function testAlterAddGeneratedColumnPreservesExistingAndAddedExpressions(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $registry->register('metrics', new TableDefinition(
+            ['source', 'doubled'],
+            ['source' => 'INTEGER', 'doubled' => 'INTEGER'],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['doubled' => '(source * 2)'],
+        ));
+        $resolver = new SqliteMutationResolver($store, $registry, new SqliteSchemaParser(), new SqliteParser());
+        $mutation = $resolver->resolve(
+            'ALTER TABLE metrics ADD COLUMN tripled INTEGER GENERATED ALWAYS AS (source * 3) STORED',
+            QueryKind::DDL_SIMULATED,
+        );
+
+        self::assertInstanceOf(AlterTableMutation::class, $mutation);
+        $mutation->apply($store, []);
+        self::assertSame([
+            'doubled' => '(source * 2)',
+            'tripled' => '(source * 3)',
+        ], $registry->get('metrics')?->generatedExpressions);
+    }
+
     public function testResolveAlterTableDropColumn(): void
     {
         $registry = new TableDefinitionRegistry();

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -70,6 +70,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteNativeUpsertProjector::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewShadowRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector::class)]
 final class SqliteRewriterTest extends RewriterContractTest
 {
     public function testGeneratedExpressionIsPresentBeforeTheFirstShadowWrite(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -72,6 +72,21 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewShadowRenderer::class)]
 final class SqliteRewriterTest extends RewriterContractTest
 {
+    public function testGeneratedExpressionIsPresentBeforeTheFirstShadowWrite(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = $this->createSchemaParser()->parse(
+            'CREATE TABLE orders (qty INTEGER, total INTEGER GENERATED ALWAYS AS (qty * 2) STORED)',
+        );
+        self::assertNotNull($definition);
+        $registry->register('orders', $definition);
+
+        $sql = $this->createRewriter($store, $registry)->rewrite('SELECT total FROM orders')->sql();
+
+        self::assertStringContainsString('(qty * 2) AS "total"', $sql);
+    }
+
     public function testRegisteredViewIsKnownAndMaterialized(): void
     {
         $store = new ShadowStore();

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
@@ -650,6 +650,21 @@ final class SqliteSchemaParserTest extends SchemaParserContractTest
         $result = $parser->parse($sql);
         self::assertNotNull($result);
         self::assertContains('b', $result->columns);
+        self::assertSame(['b' => '(a * 2)'], $result->generatedExpressions);
+    }
+
+    public function testGeneratedExpressionExcludesStoredAndVirtualStorageKeywords(): void
+    {
+        $result = (new SqliteSchemaParser())->parse(
+            'CREATE TABLE t (a INTEGER, stored_value INTEGER GENERATED ALWAYS AS (a * 2) STORED, '
+            . 'virtual_value INTEGER AS (a * 3) VIRTUAL)',
+        );
+
+        self::assertNotNull($result);
+        self::assertSame([
+            'stored_value' => '(a * 2)',
+            'virtual_value' => '(a * 3)',
+        ], $result->generatedExpressions);
     }
 
     public function testParseColumnWithReferences(): void
@@ -1340,6 +1355,7 @@ final class SqliteSchemaParserTest extends SchemaParserContractTest
         self::assertNotNull($result);
         self::assertContains('id', $result->columns);
         self::assertArrayNotHasKey('id', $result->columnTypes);
+        self::assertSame(['id' => '(1)'], $result->generatedExpressions);
     }
 
     public function testColumnWithAsKeywordHasNullType(): void
@@ -1350,6 +1366,7 @@ final class SqliteSchemaParserTest extends SchemaParserContractTest
         self::assertNotNull($result);
         self::assertContains('id', $result->columns);
         self::assertArrayNotHasKey('id', $result->columnTypes);
+        self::assertSame(['id' => '(1 + 1)'], $result->generatedExpressions);
     }
 
     public function testDuplicatePrimaryKeysDeduped(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -54,6 +54,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteNativeUpsertProjector::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteViewShadowRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector::class)]
 final class SqliteSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedViews(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector::class)]
 final class DeleteTransformerTest extends TestCase
 {
     public function testTransformSimpleDelete(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -33,6 +33,7 @@ use ZtdQuery\Schema\IdentityGenerationStrategy;
 #[UsesClass(InsertSelectRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector::class)]
 final class InsertTransformerTest extends TestCase
 {
     public function testProjectsConflictExpressionUsingCandidateKeys(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -30,6 +30,21 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testGeneratedColumnsAreRecomputedFromBaseRow(): void
+    {
+        $result = (new SelectTransformer())->transform('SELECT total FROM orders', [
+            'orders' => [
+                'rows' => [['qty' => 5, 'unit_price' => 10, 'total' => null]],
+                'columns' => ['qty', 'unit_price', 'total'],
+                'columnTypes' => [],
+                'generatedExpressions' => ['total' => '(qty * unit_price)'],
+            ],
+        ]);
+
+        self::assertStringContainsString('(qty * unit_price) AS "total"', $result);
+        self::assertStringContainsString('AS "__ztd_generated_source"', $result);
+    }
+
     public function testTransformMaterializesViewAfterItsShadowTable(): void
     {
         $tables = [

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SelectTransformerTest.php
@@ -28,6 +28,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
     public function testGeneratedColumnsAreRecomputedFromBaseRow(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/SqliteTransformerTest.php
@@ -34,6 +34,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector::class)]
 final class SqliteTransformerTest extends TestCase
 {
     public function testTransformSelect(): void

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteGeneratedColumnProjector::class)]
 final class UpdateTransformerTest extends TestCase
 {
     public function testTransformSimpleUpdate(): void


### PR DESCRIPTION
## Root cause

Generated-column expressions were discarded while parsing or reflecting table schemas. Shadow rows therefore materialized the stored placeholder value instead of asking the database to recompute the expression. PostgreSQL reflection also omitted generated/identity metadata.

## Fix

- preserve generated expressions as typed table-definition metadata for MySQL, PostgreSQL, and SQLite
- recompute generated columns through a shared projection layer whenever shadow CTEs are materialized
- preserve the metadata across SQLite ALTER TABLE mutations
- reflect PostgreSQL generated and identity columns from `information_schema.columns`
- add a dedicated generated-column statement to each SQLFaker dialect and route it through rewrite fuzzing

## Regression coverage

- parser, reflector, rewriter, transformer, and SQLite schema-mutation unit tests
- PDO integration tests on MySQL, PostgreSQL, and SQLite covering insert, aggregate, predicate, update/recalculation, and delete behavior
- full lint and unit suites for all changed packages
- changed-code mutation testing: 100% Covered MSI in core, MySQL, PostgreSQL, SQLite, and SQLFaker
- dedicated generated-column fuzz-route smoke tests for all three dialects

Closes #124
