### PR TITLE
fix(shadow): enforce foreign key cascades

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -175,6 +175,24 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function foreignKeyCascadeStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('create_table_stmt', [
+            'create_table_stmt' => [ProductionPattern::containing('table_element_list')],
+            'table_element' => [ProductionPattern::exactly('table_constraint_def')],
+            'table_constraint_def' => [ProductionPattern::containing('FOREIGN', 'KEY_SYM', 'references')],
+            'opt_ref_list' => [ProductionPattern::nonEmpty()],
+            'opt_on_update_delete' => [
+                ProductionPattern::containing('UPDATE_SYM', 'DELETE_SYM'),
+            ],
+            'delete_option' => [
+                ProductionPattern::exactly('CASCADE'),
+                ProductionPattern::exactly('CASCADE'),
+            ],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -725,12 +725,8 @@ final class MySqlProvider extends Base
         return $this->sql->generate(GenerationPlans::generatedColumnStatement()->withMaxDepth($maxDepth));
     }
     /** @return non-empty-string */
-    public function foreignKeyCascadeStatement(): string
+    public function foreignKeyCascadeStatement(int $maxDepth = 40): string
     {
-        $child = $this->rsg->rawIdentifier();
-        $parent = $this->rsg->rawIdentifier();
-
-        return "CREATE TABLE $child (id INT PRIMARY KEY, parent_id INT, CONSTRAINT fk_parent "
-            . "FOREIGN KEY (parent_id) REFERENCES $parent (id) ON DELETE CASCADE ON UPDATE CASCADE)";
+        return $this->sql->generate(GenerationPlans::foreignKeyCascadeStatement()->withMaxDepth($maxDepth));
     }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -724,4 +724,13 @@ final class MySqlProvider extends Base
     {
         return $this->sql->generate(GenerationPlans::generatedColumnStatement()->withMaxDepth($maxDepth));
     }
+    /** @return non-empty-string */
+    public function foreignKeyCascadeStatement(): string
+    {
+        $child = $this->rsg->rawIdentifier();
+        $parent = $this->rsg->rawIdentifier();
+
+        return "CREATE TABLE $child (id INT PRIMARY KEY, parent_id INT, CONSTRAINT fk_parent "
+            . "FOREIGN KEY (parent_id) REFERENCES $parent (id) ON DELETE CASCADE ON UPDATE CASCADE)";
+    }
 }

--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -72,6 +72,22 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function foreignKeyCascadeStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('CreateStmt', [
+            'CreateStmt' => [ProductionPattern::containing('OptTableElementList')],
+            'OptTableElementList' => [ProductionPattern::nonEmpty()],
+            'TableElement' => [ProductionPattern::exactly('TableConstraint')],
+            'ConstraintElem' => [ProductionPattern::containing('FOREIGN', 'KEY', 'REFERENCES')],
+            'key_actions' => [ProductionPattern::containing('key_update', 'key_delete')],
+            'key_action' => [
+                ProductionPattern::exactly('CASCADE'),
+                ProductionPattern::exactly('CASCADE'),
+            ],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -436,13 +436,9 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function foreignKeyCascadeStatement(): string
+    public function foreignKeyCascadeStatement(int $maxDepth = 40): string
     {
-        $child = $this->rsg->rawIdentifier();
-        $parent = $this->rsg->rawIdentifier();
-
-        return "CREATE TABLE $child (id INTEGER PRIMARY KEY, parent_id INTEGER, CONSTRAINT fk_parent "
-            . "FOREIGN KEY (parent_id) REFERENCES $parent (id) ON DELETE CASCADE ON UPDATE CASCADE)";
+        return $this->sql->generate(GenerationPlans::foreignKeyCascadeStatement()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -435,6 +435,16 @@ final class PostgreSqlProvider extends Base
         return $this->sql->generate(GenerationPlans::generatedColumnStatement()->withMaxDepth($maxDepth));
     }
 
+    /** @return non-empty-string */
+    public function foreignKeyCascadeStatement(): string
+    {
+        $child = $this->rsg->rawIdentifier();
+        $parent = $this->rsg->rawIdentifier();
+
+        return "CREATE TABLE $child (id INTEGER PRIMARY KEY, parent_id INTEGER, CONSTRAINT fk_parent "
+            . "FOREIGN KEY (parent_id) REFERENCES $parent (id) ON DELETE CASCADE ON UPDATE CASCADE)";
+    }
+
     /**
      * @template TRequiresNonEmpty of bool
      * @param GenerationPlan<TRequiresNonEmpty> $plan

--- a/packages/sql-faker/src/Sqlite/GenerationPlans.php
+++ b/packages/sql-faker/src/Sqlite/GenerationPlans.php
@@ -64,6 +64,30 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function foreignKeyCascadeStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('cmd', [
+            'cmd' => [ProductionPattern::containing('create_table', 'create_table_args')],
+            'create_table_args' => [ProductionPattern::containing('columnlist', 'conslist_opt')],
+            'conslist_opt' => [ProductionPattern::nonEmpty()],
+            'tcons' => [ProductionPattern::containing('FOREIGN', 'KEY', 'REFERENCES')],
+            'refargs' => [
+                ProductionPattern::exactly('refargs', 'refarg'),
+                ProductionPattern::exactly('refargs', 'refarg'),
+                ProductionPattern::exactly(),
+            ],
+            'refarg' => [
+                ProductionPattern::containing('ON', 'DELETE'),
+                ProductionPattern::containing('ON', 'UPDATE'),
+            ],
+            'refact' => [
+                ProductionPattern::exactly('CASCADE'),
+                ProductionPattern::exactly('CASCADE'),
+            ],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('conslist', [

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -288,4 +288,14 @@ final class SqliteProvider extends Base
     {
         return $this->sql->generate(GenerationPlans::generatedColumnStatement()->withMaxDepth($maxDepth));
     }
+
+    /** @return non-empty-string */
+    public function foreignKeyCascadeStatement(): string
+    {
+        $child = $this->rsg->rawIdentifier();
+        $parent = $this->rsg->rawIdentifier();
+
+        return "CREATE TABLE $child (id INTEGER PRIMARY KEY, parent_id INTEGER, CONSTRAINT fk_parent "
+            . "FOREIGN KEY (parent_id) REFERENCES $parent (id) ON DELETE CASCADE ON UPDATE CASCADE)";
+    }
 }

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -290,12 +290,8 @@ final class SqliteProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function foreignKeyCascadeStatement(): string
+    public function foreignKeyCascadeStatement(int $maxDepth = 40): string
     {
-        $child = $this->rsg->rawIdentifier();
-        $parent = $this->rsg->rawIdentifier();
-
-        return "CREATE TABLE $child (id INTEGER PRIMARY KEY, parent_id INTEGER, CONSTRAINT fk_parent "
-            . "FOREIGN KEY (parent_id) REFERENCES $parent (id) ON DELETE CASCADE ON UPDATE CASCADE)";
+        return $this->sql->generate(GenerationPlans::foreignKeyCascadeStatement()->withMaxDepth($maxDepth));
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -231,7 +231,16 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::foreignKeyCascadeStatement();
 
         self::assertSame('create_table_stmt', $plan->startRule());
-        self::assertNotNull($plan->patternAt('opt_on_update_delete', 0));
-        self::assertNotNull($plan->patternAt('delete_option', 1));
+        self::assertTrue($plan->patternAt('create_table_stmt', 0)?->matches(['table_element_list']) ?? false);
+        self::assertTrue($plan->patternAt('table_element', 0)?->matches(['table_constraint_def']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('table_constraint_def', 0)?->matches(['FOREIGN', 'KEY_SYM', 'references']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('opt_ref_list', 0)?->matches(['reference']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('opt_on_update_delete', 0)?->matches(['UPDATE_SYM', 'DELETE_SYM']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('delete_option', 0)?->matches(['CASCADE']) ?? false);
+        self::assertTrue($plan->patternAt('delete_option', 1)?->matches(['CASCADE']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -225,4 +225,13 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('opt_generated_always', 0)?->matches(['GENERATED']) ?? false);
         self::assertTrue($plan->patternAt('opt_stored_attribute', 0)?->matches(['STORED_SYM']) ?? false);
     }
+
+    public function testForeignKeyCascadePlanRequiresBothCascadeActions(): void
+    {
+        $plan = GenerationPlans::foreignKeyCascadeStatement();
+
+        self::assertSame('create_table_stmt', $plan->startRule());
+        self::assertNotNull($plan->patternAt('opt_on_update_delete', 0));
+        self::assertNotNull($plan->patternAt('delete_option', 1));
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -147,13 +147,22 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('STORED_SYM', $tokens);
     }
 
-    public function testForeignKeyCascadeStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testForeignKeyCascadeStatement(int $seed): void
     {
-        $sql = (new MySqlProvider(Factory::create()))->foreignKeyCascadeStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new MySqlProvider($faker);
+        $sql = $provider->foreignKeyCascadeStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))
+            ->tokenize($sql);
 
-        self::assertMatchesRegularExpression('/^CREATE TABLE \w+ \(id INT PRIMARY KEY, parent_id INT,/', $sql);
-        self::assertStringContainsString('CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES ', $sql);
-        self::assertStringEndsWith('(id) ON DELETE CASCADE ON UPDATE CASCADE)', $sql);
+        self::assertSame($sql, $provider->foreignKeyCascadeStatement(40));
+        self::assertContains('FOREIGN', $tokens);
+        self::assertContains('REFERENCES', $tokens);
+        self::assertStringContainsString('ON_SYM UPDATE_SYM CASCADE', implode(' ', $tokens));
+        self::assertStringContainsString('ON_SYM DELETE_SYM CASCADE', implode(' ', $tokens));
     }
 
     public function testSql(): void

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -147,6 +147,15 @@ final class MySqlProviderTest extends TestCase
         self::assertContains('STORED_SYM', $tokens);
     }
 
+    public function testForeignKeyCascadeStatement(): void
+    {
+        $sql = (new MySqlProvider(Factory::create()))->foreignKeyCascadeStatement();
+
+        self::assertMatchesRegularExpression('/^CREATE TABLE \w+ \(id INT PRIMARY KEY, parent_id INT,/', $sql);
+        self::assertStringContainsString('CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES ', $sql);
+        self::assertStringEndsWith('(id) ON DELETE CASCADE ON UPDATE CASCADE)', $sql);
+    }
+
     public function testSql(): void
     {
         $faker = Factory::create();

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -84,4 +84,13 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('ColConstraint', 0)?->matches(['ColConstraintElem']) ?? false);
         self::assertTrue($plan->patternAt('ColConstraintElem', 0)?->matches(['GENERATED', 'STORED']) ?? false);
     }
+
+    public function testForeignKeyCascadePlanRequiresBothCascadeActions(): void
+    {
+        $plan = GenerationPlans::foreignKeyCascadeStatement();
+
+        self::assertSame('CreateStmt', $plan->startRule());
+        self::assertNotNull($plan->patternAt('key_actions', 0));
+        self::assertNotNull($plan->patternAt('key_action', 1));
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -90,7 +90,14 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::foreignKeyCascadeStatement();
 
         self::assertSame('CreateStmt', $plan->startRule());
-        self::assertNotNull($plan->patternAt('key_actions', 0));
-        self::assertNotNull($plan->patternAt('key_action', 1));
+        self::assertTrue($plan->patternAt('CreateStmt', 0)?->matches(['OptTableElementList']) ?? false);
+        self::assertTrue($plan->patternAt('OptTableElementList', 0)?->matches(['TableElement']) ?? false);
+        self::assertTrue($plan->patternAt('TableElement', 0)?->matches(['TableConstraint']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('ConstraintElem', 0)?->matches(['FOREIGN', 'KEY', 'REFERENCES']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('key_actions', 0)?->matches(['key_update', 'key_delete']) ?? false);
+        self::assertTrue($plan->patternAt('key_action', 0)?->matches(['CASCADE']) ?? false);
+        self::assertTrue($plan->patternAt('key_action', 1)?->matches(['CASCADE']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -130,6 +130,15 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('AS', $tokens);
     }
 
+    public function testForeignKeyCascadeStatement(): void
+    {
+        $sql = (new PostgreSqlProvider(Factory::create()))->foreignKeyCascadeStatement();
+
+        self::assertMatchesRegularExpression('/^CREATE TABLE \w+ \(id INTEGER PRIMARY KEY, parent_id INTEGER,/', $sql);
+        self::assertStringContainsString('CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES ', $sql);
+        self::assertStringEndsWith('(id) ON DELETE CASCADE ON UPDATE CASCADE)', $sql);
+    }
+
     #[\Override]
     protected function setUp(): void
     {

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -130,13 +130,22 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('AS', $tokens);
     }
 
-    public function testForeignKeyCascadeStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testForeignKeyCascadeStatement(int $seed): void
     {
-        $sql = (new PostgreSqlProvider(Factory::create()))->foreignKeyCascadeStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->foreignKeyCascadeStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'pg-17.2', true))
+            ->tokenize($sql);
 
-        self::assertMatchesRegularExpression('/^CREATE TABLE \w+ \(id INTEGER PRIMARY KEY, parent_id INTEGER,/', $sql);
-        self::assertStringContainsString('CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES ', $sql);
-        self::assertStringEndsWith('(id) ON DELETE CASCADE ON UPDATE CASCADE)', $sql);
+        self::assertSame($sql, $provider->foreignKeyCascadeStatement(40));
+        self::assertContains('FOREIGN', $tokens);
+        self::assertContains('REFERENCES', $tokens);
+        self::assertStringContainsString('ON UPDATE CASCADE', implode(' ', $tokens));
+        self::assertStringContainsString('ON DELETE_P CASCADE', implode(' ', $tokens));
     }
 
     #[\Override]

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -97,7 +97,18 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::foreignKeyCascadeStatement();
 
         self::assertSame('cmd', $plan->startRule());
-        self::assertNotNull($plan->patternAt('refarg', 1));
-        self::assertNotNull($plan->patternAt('refact', 1));
+        self::assertTrue($plan->patternAt('cmd', 0)?->matches(['create_table', 'create_table_args']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('create_table_args', 0)?->matches(['columnlist', 'conslist_opt']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('conslist_opt', 0)?->matches(['tcons']) ?? false);
+        self::assertTrue($plan->patternAt('tcons', 0)?->matches(['FOREIGN', 'KEY', 'REFERENCES']) ?? false);
+        self::assertTrue($plan->patternAt('refargs', 0)?->matches(['refargs', 'refarg']) ?? false);
+        self::assertTrue($plan->patternAt('refargs', 1)?->matches(['refargs', 'refarg']) ?? false);
+        self::assertTrue($plan->patternAt('refargs', 2)?->matches([]) ?? false);
+        self::assertTrue($plan->patternAt('refarg', 0)?->matches(['ON', 'DELETE']) ?? false);
+        self::assertTrue($plan->patternAt('refarg', 1)?->matches(['ON', 'UPDATE']) ?? false);
+        self::assertTrue($plan->patternAt('refact', 0)?->matches(['CASCADE']) ?? false);
+        self::assertTrue($plan->patternAt('refact', 1)?->matches(['CASCADE']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -91,4 +91,13 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('carglist', 1)?->matches([]) ?? false);
         self::assertTrue($plan->patternAt('ccons', 0)?->matches(['GENERATED', 'generated']) ?? false);
     }
+
+    public function testForeignKeyCascadePlanRequiresBothCascadeActions(): void
+    {
+        $plan = GenerationPlans::foreignKeyCascadeStatement();
+
+        self::assertSame('cmd', $plan->startRule());
+        self::assertNotNull($plan->patternAt('refarg', 1));
+        self::assertNotNull($plan->patternAt('refact', 1));
+    }
 }

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -129,6 +129,15 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('AS', $tokens);
     }
 
+    public function testForeignKeyCascadeStatement(): void
+    {
+        $sql = (new SqliteProvider(Factory::create()))->foreignKeyCascadeStatement();
+
+        self::assertMatchesRegularExpression('/^CREATE TABLE \w+ \(id INTEGER PRIMARY KEY, parent_id INTEGER,/', $sql);
+        self::assertStringContainsString('CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES ', $sql);
+        self::assertStringEndsWith('(id) ON DELETE CASCADE ON UPDATE CASCADE)', $sql);
+    }
+
     #[\Override]
     protected function setUp(): void
     {

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -129,13 +129,22 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('AS', $tokens);
     }
 
-    public function testForeignKeyCascadeStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testForeignKeyCascadeStatement(int $seed): void
     {
-        $sql = (new SqliteProvider(Factory::create()))->foreignKeyCascadeStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new SqliteProvider($faker);
+        $sql = $provider->foreignKeyCascadeStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'sqlite-3.47.2', true))
+            ->tokenize($sql);
 
-        self::assertMatchesRegularExpression('/^CREATE TABLE \w+ \(id INTEGER PRIMARY KEY, parent_id INTEGER,/', $sql);
-        self::assertStringContainsString('CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES ', $sql);
-        self::assertStringEndsWith('(id) ON DELETE CASCADE ON UPDATE CASCADE)', $sql);
+        self::assertSame($sql, $provider->foreignKeyCascadeStatement(40));
+        self::assertContains('FOREIGN', $tokens);
+        self::assertContains('REFERENCES', $tokens);
+        self::assertStringContainsString('ON UPDATE CASCADE', implode(' ', $tokens));
+        self::assertStringContainsString('ON DELETE CASCADE', implode(' ', $tokens));
     }
 
     #[\Override]

--- a/packages/ztd-query-core/src/Schema/ForeignKeyDefinition.php
+++ b/packages/ztd-query-core/src/Schema/ForeignKeyDefinition.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+final class ForeignKeyDefinition
+{
+    /**
+     * @param non-empty-list<string> $columns
+     * @param list<string> $referencedColumns
+     */
+    public function __construct(
+        public readonly array $columns,
+        public readonly string $referencedTable,
+        public readonly array $referencedColumns,
+        public readonly ReferentialAction $onDelete = ReferentialAction::NoAction,
+        public readonly ReferentialAction $onUpdate = ReferentialAction::NoAction,
+    ) {
+    }
+}

--- a/packages/ztd-query-core/src/Schema/ForeignKeyDefinitionParser.php
+++ b/packages/ztd-query-core/src/Schema/ForeignKeyDefinitionParser.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class ForeignKeyDefinitionParser
+{
+    /** @return array<string, ForeignKeyDefinition> */
+    public function parseCreateTable(
+        string $sql,
+        SqlTokenDialect $dialect = SqlTokenDialect::Standard,
+    ): array {
+        $body = $this->tableBody($sql, $dialect);
+        if ($body === null) {
+            return [];
+        }
+
+        $foreignKeys = [];
+        $index = 0;
+        foreach (SqlTokenStream::tokenize($body, $dialect)->splitTopLevel() as $entry) {
+            $stream = SqlTokenStream::tokenize($entry, $dialect);
+            $first = $stream->identifierAt();
+            $firstKeyword = $stream->firstTopLevelKeyword();
+            $inlineColumn = $first !== null && !in_array(
+                $firstKeyword,
+                ['CONSTRAINT', 'FOREIGN', 'PRIMARY', 'UNIQUE', 'CHECK', 'EXCLUDE'],
+                true,
+            ) ? $first['name'] : null;
+            $name = 'foreign_' . $index++;
+            $definition = $this->parseEntry($stream, $name, $inlineColumn);
+            if ($definition === null) {
+                continue;
+            }
+
+            $foreignKeys[$definition['name']] = $definition['foreignKey'];
+        }
+
+        return $foreignKeys;
+    }
+
+    private function tableBody(string $sql, SqlTokenDialect $dialect): ?string
+    {
+        $tokens = SqlTokenStream::tokenize($sql, $dialect)->significantTokens();
+        $afterTable = false;
+        $opening = null;
+        foreach ($tokens as $token) {
+            if ($token->isTopLevel() && $token->isKeyword('TABLE')) {
+                $afterTable = true;
+                continue;
+            }
+            if ($afterTable && self::isSymbol($token, '(') && $token->isTopLevel()) {
+                $opening = $token;
+                break;
+            }
+        }
+        if ($opening === null) {
+            return null;
+        }
+
+        foreach ($tokens as $token) {
+            if ($token->offset <= $opening->offset
+                || !$token->isTopLevel()
+                || !self::isSymbol($token, ')')
+            ) {
+                continue;
+            }
+
+            return substr($sql, $opening->endOffset(), $token->offset - $opening->endOffset());
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{name: string, foreignKey: ForeignKeyDefinition}|null
+     */
+    private function parseEntry(
+        SqlTokenStream $stream,
+        string $defaultName,
+        ?string $inlineColumn,
+    ): ?array {
+        $tokens = $stream->significantTokens();
+        $references = self::keywordIndex($tokens, 'REFERENCES');
+        if ($references === null) {
+            return null;
+        }
+
+        $columns = $inlineColumn !== null
+            ? [$inlineColumn]
+            : $this->foreignKeyColumns($stream, $tokens, $references);
+        if ($columns === []) {
+            return null;
+        }
+
+        $referenced = $this->referencedRelation($stream, $tokens, $references + 1);
+        if ($referenced === null) {
+            return null;
+        }
+
+        $name = $defaultName;
+        if (($tokens[0] ?? null)?->isKeyword('CONSTRAINT') === true) {
+            $constraint = $stream->identifierAt(1);
+            if ($constraint !== null) {
+                $name = $constraint['name'];
+            }
+        }
+
+        return [
+            'name' => $name,
+            'foreignKey' => new ForeignKeyDefinition(
+                $columns,
+                $referenced['table'],
+                $referenced['columns'],
+                $this->action($tokens, 'DELETE'),
+                $this->action($tokens, 'UPDATE'),
+            ),
+        ];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return list<string>
+     */
+    private function foreignKeyColumns(
+        SqlTokenStream $stream,
+        array $tokens,
+        int $references,
+    ): array {
+        $foreign = self::keywordIndex($tokens, 'FOREIGN');
+        if ($foreign === null || ($tokens[$foreign + 1] ?? null)?->isKeyword('KEY') !== true) {
+            return [];
+        }
+
+        $opening = self::symbolIndex($tokens, '(', $foreign + 2);
+
+        return $opening !== null && $opening < $references
+            ? $this->identifierList($stream, $tokens, $opening)
+            : [];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{table: string, columns: list<string>}|null
+     */
+    private function referencedRelation(
+        SqlTokenStream $stream,
+        array $tokens,
+        int $start,
+    ): ?array {
+        $identifier = $stream->identifierAt($start);
+        if ($identifier === null) {
+            return null;
+        }
+
+        $table = $identifier['name'];
+        $next = $identifier['next'];
+        while (self::isSymbol($tokens[$next] ?? null, '.')) {
+            $component = $stream->identifierAt($next + 1);
+            if ($component === null) {
+                break;
+            }
+            $table = $component['name'];
+            $next = $component['next'];
+        }
+
+        $opening = self::symbolIndex($tokens, '(', $next);
+        $columns = $opening !== null ? $this->identifierList($stream, $tokens, $opening) : [];
+
+        return ['table' => $table, 'columns' => $columns];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return list<string>
+     */
+    private function identifierList(SqlTokenStream $stream, array $tokens, int $opening): array
+    {
+        $closing = null;
+        $depth = $tokens[$opening]->depth;
+        foreach ($tokens as $index => $token) {
+            if ($index <= $opening
+                || $token->depth !== $depth
+                || !self::isSymbol($token, ')')
+            ) {
+                continue;
+            }
+            $closing = $token;
+            break;
+        }
+        if ($closing === null) {
+            return [];
+        }
+
+        $openingToken = $tokens[$opening];
+        $sql = '';
+        foreach ($stream->tokens() as $token) {
+            $sql .= $token->text;
+        }
+        $list = substr($sql, $openingToken->endOffset(), $closing->offset - $openingToken->endOffset());
+        $identifiers = [];
+        foreach (SqlTokenStream::tokenize($list)->splitTopLevel() as $part) {
+            $identifier = SqlTokenStream::tokenize($part)->identifierAt();
+            if ($identifier !== null) {
+                $identifiers[] = $identifier['name'];
+            }
+        }
+
+        return $identifiers;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function action(array $tokens, string $event): ReferentialAction
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isTopLevel()
+                || !$token->isKeyword('ON')
+                || ($tokens[$index + 1] ?? null)?->isKeyword($event) !== true
+            ) {
+                continue;
+            }
+
+            $first = strtoupper($tokens[$index + 2]->text ?? '');
+            $second = strtoupper($tokens[$index + 3]->text ?? '');
+
+            return match ([$first, $second]) {
+                ['CASCADE', ''], ['CASCADE', 'ON'], ['CASCADE', 'DEFERRABLE'] => ReferentialAction::Cascade,
+                ['RESTRICT', ''], ['RESTRICT', 'ON'], ['RESTRICT', 'DEFERRABLE'] => ReferentialAction::Restrict,
+                ['SET', 'NULL'] => ReferentialAction::SetNull,
+                ['SET', 'DEFAULT'] => ReferentialAction::SetDefault,
+                ['NO', 'ACTION'] => ReferentialAction::NoAction,
+                default => match ($first) {
+                    'CASCADE' => ReferentialAction::Cascade,
+                    'RESTRICT' => ReferentialAction::Restrict,
+                    default => ReferentialAction::NoAction,
+                },
+            };
+        }
+
+        return ReferentialAction::NoAction;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private static function keywordIndex(array $tokens, string $keyword): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isTopLevel() && $token->isKeyword($keyword)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private static function symbolIndex(array $tokens, string $symbol, int $start): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($index >= $start && $token->isTopLevel() && self::isSymbol($token, $symbol)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private static function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        return $token !== null && $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
+    }
+}

--- a/packages/ztd-query-core/src/Schema/ForeignKeyDefinitionParser.php
+++ b/packages/ztd-query-core/src/Schema/ForeignKeyDefinitionParser.php
@@ -22,7 +22,6 @@ final class ForeignKeyDefinitionParser
         }
 
         $foreignKeys = [];
-        $index = 0;
         foreach (SqlTokenStream::tokenize($body, $dialect)->splitTopLevel() as $entry) {
             $stream = SqlTokenStream::tokenize($entry, $dialect);
             $first = $stream->identifierAt();
@@ -32,7 +31,7 @@ final class ForeignKeyDefinitionParser
                 ['CONSTRAINT', 'FOREIGN', 'PRIMARY', 'UNIQUE', 'CHECK', 'EXCLUDE'],
                 true,
             ) ? $first['name'] : null;
-            $name = 'foreign_' . $index++;
+            $name = sprintf('foreign_%d', count($foreignKeys));
             $definition = $this->parseEntry($stream, $name, $inlineColumn);
             if ($definition === null) {
                 continue;
@@ -47,31 +46,32 @@ final class ForeignKeyDefinitionParser
     private function tableBody(string $sql, SqlTokenDialect $dialect): ?string
     {
         $tokens = SqlTokenStream::tokenize($sql, $dialect)->significantTokens();
-        $afterTable = false;
-        $opening = null;
-        foreach ($tokens as $token) {
-            if ($token->isTopLevel() && $token->isKeyword('TABLE')) {
-                $afterTable = true;
-                continue;
-            }
-            if ($afterTable && self::isSymbol($token, '(') && $token->isTopLevel()) {
-                $opening = $token;
-                break;
-            }
-        }
-        if ($opening === null) {
+        $first = $tokens[0] ?? null;
+        if ($first === null || !$first->isKeyword('CREATE')) {
             return null;
         }
 
+        $tableFound = false;
+        $opening = null;
         foreach ($tokens as $token) {
-            if ($token->offset <= $opening->offset
-                || !$token->isTopLevel()
-                || !self::isSymbol($token, ')')
-            ) {
+            if (!$token->isTopLevel()) {
                 continue;
             }
-
-            return substr($sql, $opening->endOffset(), $token->offset - $opening->endOffset());
+            if (!$tableFound) {
+                if ($token->isKeyword('TABLE')) {
+                    $tableFound = true;
+                }
+                continue;
+            }
+            if ($opening === null) {
+                if (self::isSymbol($token, '(')) {
+                    $opening = $token;
+                }
+                continue;
+            }
+            if (self::isSymbol($token, ')')) {
+                return substr($sql, $opening->endOffset(), $token->offset - $opening->endOffset());
+            }
         }
 
         return null;
@@ -104,7 +104,7 @@ final class ForeignKeyDefinitionParser
         }
 
         $name = $defaultName;
-        if (($tokens[0] ?? null)?->isKeyword('CONSTRAINT') === true) {
+        if ($tokens[0]->isKeyword('CONSTRAINT')) {
             $constraint = $stream->identifierAt(1);
             if ($constraint !== null) {
                 $name = $constraint['name'];
@@ -132,16 +132,18 @@ final class ForeignKeyDefinitionParser
         array $tokens,
         int $references,
     ): array {
-        $foreign = self::keywordIndex($tokens, 'FOREIGN');
-        if ($foreign === null || ($tokens[$foreign + 1] ?? null)?->isKeyword('KEY') !== true) {
+        $foreign = self::keywordIndex(array_slice($tokens, 0, $references), 'FOREIGN');
+        if ($foreign === null) {
             return [];
         }
 
-        $opening = self::symbolIndex($tokens, '(', $foreign + 2);
+        $key = $tokens[$foreign + 1];
+        if (!$key->isKeyword('KEY')) {
+            return [];
+        }
 
-        return $opening !== null && $opening < $references
-            ? $this->identifierList($stream, $tokens, $opening)
-            : [];
+        $opening = $foreign + 2;
+        return $this->identifierList($stream, $tokens, $opening);
     }
 
     /**
@@ -163,7 +165,7 @@ final class ForeignKeyDefinitionParser
         while (self::isSymbol($tokens[$next] ?? null, '.')) {
             $component = $stream->identifierAt($next + 1);
             if ($component === null) {
-                break;
+                return null;
             }
             $table = $component['name'];
             $next = $component['next'];
@@ -181,65 +183,71 @@ final class ForeignKeyDefinitionParser
      */
     private function identifierList(SqlTokenStream $stream, array $tokens, int $opening): array
     {
-        $closing = null;
         $depth = $tokens[$opening]->depth;
-        foreach ($tokens as $index => $token) {
-            if ($index <= $opening
-                || $token->depth !== $depth
-                || !self::isSymbol($token, ')')
-            ) {
+        $candidates = array_slice($tokens, $opening);
+        array_shift($candidates);
+        $identifiers = [];
+        $index = $opening;
+        foreach ($candidates as $token) {
+            $index++;
+            if ($token->depth === $depth) {
+                if (self::isSymbol($token, ')')) {
+                    return $identifiers;
+                }
+
+                return [];
+            }
+            if ($token->depth !== $depth + 1) {
                 continue;
             }
-            $closing = $token;
-            break;
-        }
-        if ($closing === null) {
-            return [];
-        }
 
-        $openingToken = $tokens[$opening];
-        $sql = '';
-        foreach ($stream->tokens() as $token) {
-            $sql .= $token->text;
-        }
-        $list = substr($sql, $openingToken->endOffset(), $closing->offset - $openingToken->endOffset());
-        $identifiers = [];
-        foreach (SqlTokenStream::tokenize($list)->splitTopLevel() as $part) {
-            $identifier = SqlTokenStream::tokenize($part)->identifierAt();
+            $identifier = $stream->identifierAt($index);
             if ($identifier !== null) {
                 $identifiers[] = $identifier['name'];
             }
         }
 
-        return $identifiers;
+        return [];
     }
 
     /** @param list<SqlToken> $tokens */
     private function action(array $tokens, string $event): ReferentialAction
     {
         foreach ($tokens as $index => $token) {
-            if (!$token->isTopLevel()
-                || !$token->isKeyword('ON')
-                || ($tokens[$index + 1] ?? null)?->isKeyword($event) !== true
-            ) {
+            if (!$token->isTopLevel() || !$token->isKeyword('ON')) {
+                continue;
+            }
+            $eventToken = $tokens[$index + 1] ?? null;
+            if ($eventToken === null || !$eventToken->isKeyword($event)) {
                 continue;
             }
 
-            $first = strtoupper($tokens[$index + 2]->text ?? '');
-            $second = strtoupper($tokens[$index + 3]->text ?? '');
+            $action = $tokens[$index + 2] ?? null;
+            if ($action === null) {
+                return ReferentialAction::NoAction;
+            }
+            if ($action->isKeyword('CASCADE')) {
+                return ReferentialAction::Cascade;
+            }
+            if ($action->isKeyword('RESTRICT')) {
+                return ReferentialAction::Restrict;
+            }
+            if (!$action->isKeyword('SET')) {
+                return ReferentialAction::NoAction;
+            }
 
-            return match ([$first, $second]) {
-                ['CASCADE', ''], ['CASCADE', 'ON'], ['CASCADE', 'DEFERRABLE'] => ReferentialAction::Cascade,
-                ['RESTRICT', ''], ['RESTRICT', 'ON'], ['RESTRICT', 'DEFERRABLE'] => ReferentialAction::Restrict,
-                ['SET', 'NULL'] => ReferentialAction::SetNull,
-                ['SET', 'DEFAULT'] => ReferentialAction::SetDefault,
-                ['NO', 'ACTION'] => ReferentialAction::NoAction,
-                default => match ($first) {
-                    'CASCADE' => ReferentialAction::Cascade,
-                    'RESTRICT' => ReferentialAction::Restrict,
-                    default => ReferentialAction::NoAction,
-                },
-            };
+            $qualifier = $tokens[$index + 3] ?? null;
+            if ($qualifier === null) {
+                return ReferentialAction::NoAction;
+            }
+            if ($qualifier->isKeyword('NULL')) {
+                return ReferentialAction::SetNull;
+            }
+            if ($qualifier->isKeyword('DEFAULT')) {
+                return ReferentialAction::SetDefault;
+            }
+
+            return ReferentialAction::NoAction;
         }
 
         return ReferentialAction::NoAction;
@@ -271,6 +279,10 @@ final class ForeignKeyDefinitionParser
 
     private static function isSymbol(?SqlToken $token, string $symbol): bool
     {
-        return $token !== null && $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
+        if ($token === null) {
+            return false;
+        }
+
+        return $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
     }
 }

--- a/packages/ztd-query-core/src/Schema/ReferentialAction.php
+++ b/packages/ztd-query-core/src/Schema/ReferentialAction.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+enum ReferentialAction: string
+{
+    case NoAction = 'NO ACTION';
+    case Restrict = 'RESTRICT';
+    case Cascade = 'CASCADE';
+    case SetNull = 'SET NULL';
+    case SetDefault = 'SET DEFAULT';
+}

--- a/packages/ztd-query-core/src/Schema/TableDefinition.php
+++ b/packages/ztd-query-core/src/Schema/TableDefinition.php
@@ -23,6 +23,9 @@ final class TableDefinition
     /** @var array<string, string> */
     public readonly array $generatedExpressions;
 
+    /** @var array<string, ForeignKeyDefinition> */
+    public readonly array $foreignKeys;
+
     /**
      * @param array<int, string> $columns Column names in declaration order.
      * @param array<string, string> $columnTypes Column name => MySQL type string.
@@ -33,6 +36,7 @@ final class TableDefinition
      * @param array<string, string> $columnDefaults Column name => SQL default expression.
      * @param array<string, IdentityGenerationStrategy> $identityStrategies Column name => shadow generation strategy.
      * @param array<string, string> $generatedExpressions Column name => database generated expression.
+     * @param array<string, ForeignKeyDefinition> $foreignKeys Constraint name => foreign-key definition.
      */
     public function __construct(
         public readonly array $columns,
@@ -44,11 +48,13 @@ final class TableDefinition
         array $columnDefaults = [],
         array $identityStrategies = [],
         array $generatedExpressions = [],
+        array $foreignKeys = [],
     ) {
         $this->typedColumns = $typedColumns;
         $this->columnDefaults = $columnDefaults;
         $this->identityStrategies = $identityStrategies;
         $this->generatedExpressions = $generatedExpressions;
+        $this->foreignKeys = $foreignKeys;
     }
 
     public function candidateKeys(): CandidateKeySet

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -25,6 +25,7 @@ use ZtdQuery\Shadow\Mutation\ShadowMutation;
 use ZtdQuery\Shadow\Mutation\ResultSetMutation;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTransactionManager;
+use ZtdQuery\Shadow\ReferentialIntegrityEnforcer;
 use ZtdQuery\Sql\TransactionStatement;
 
 /**
@@ -78,6 +79,8 @@ final class Session
 
     private ?TableDefinitionRegistry $registry;
 
+    private ?ReferentialIntegrityEnforcer $referentialIntegrity;
+
     private ?string $lastInsertId = null;
 
     /**
@@ -103,6 +106,7 @@ final class Session
         $this->connection = $connection;
         $this->transactions = $transactions ?? new ShadowTransactionManager($shadowStore);
         $this->registry = $registry;
+        $this->referentialIntegrity = $registry !== null ? new ReferentialIntegrityEnforcer($registry) : null;
     }
 
     /**
@@ -257,7 +261,7 @@ final class Session
         if ($mutation === null) {
             throw new RuntimeException('ZTD Write Protection: Missing shadow mutation for write simulation.');
         }
-        $impact = $this->applyMutation($mutation, $resultSet);
+        $impact = $this->applyMutation($mutation, $resultSet, $plan->sql());
         $returningProjection = $plan->returningProjection();
         $resultRows = $returningProjection !== null
             ? $returningProjection->project($impact->returningRows())
@@ -290,7 +294,7 @@ final class Session
         }
 
         $resultSet = $this->resultSelectRunner->runResultSet($plan->sql(), $executor);
-        $this->applyMutation($mutation, $resultSet);
+        $this->applyMutation($mutation, $resultSet, $plan->sql());
 
         return $resultSet->rows;
     }
@@ -327,7 +331,7 @@ final class Session
             $plan->sql(),
             fn (string $s) => $this->connection->query($s),
         );
-        $impact = $this->applyMutation($mutation, $resultSet);
+        $impact = $this->applyMutation($mutation, $resultSet, $sql);
 
         return $impact->affectedRowCount($plan->affectedRowsMode());
     }
@@ -338,16 +342,28 @@ final class Session
      *
      * @throws DatabaseException When shadow mutation application fails.
      */
-    private function applyMutation(ShadowMutation $mutation, ResultSet $resultSet): MutationImpact
-    {
+    private function applyMutation(
+        ShadowMutation $mutation,
+        ResultSet $resultSet,
+        string $sql,
+    ): MutationImpact {
         $before = $this->shadowStore->get($mutation->tableName());
+        $snapshot = $this->shadowStore->snapshot();
         try {
             if ($mutation instanceof ResultSetMutation) {
                 $mutation->applyResultSet($this->shadowStore, $resultSet);
             } else {
                 $mutation->apply($this->shadowStore, $resultSet->rows);
             }
+            $this->referentialIntegrity?->synchronize(
+                $snapshot,
+                $this->shadowStore,
+                $mutation,
+                $resultSet->rows,
+                $sql,
+            );
         } catch (SimulationException $e) {
+            $this->shadowStore->restore($snapshot);
             throw new DatabaseException($e->getMessage(), null, 0, $e);
         }
         $impact = new MutationImpact(

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -77,9 +77,9 @@ final class Session
 
     private ShadowTransactionManager $transactions;
 
-    private ?TableDefinitionRegistry $registry;
+    private TableDefinitionRegistry $registry;
 
-    private ?ReferentialIntegrityEnforcer $referentialIntegrity;
+    private ReferentialIntegrityEnforcer $referentialIntegrity;
 
     private ?string $lastInsertId = null;
 
@@ -105,8 +105,8 @@ final class Session
         $this->config = $config;
         $this->connection = $connection;
         $this->transactions = $transactions ?? new ShadowTransactionManager($shadowStore);
-        $this->registry = $registry;
-        $this->referentialIntegrity = $registry !== null ? new ReferentialIntegrityEnforcer($registry) : null;
+        $this->registry = $registry ?? new TableDefinitionRegistry();
+        $this->referentialIntegrity = new ReferentialIntegrityEnforcer($this->registry);
     }
 
     /**
@@ -355,7 +355,7 @@ final class Session
             } else {
                 $mutation->apply($this->shadowStore, $resultSet->rows);
             }
-            $this->referentialIntegrity?->synchronize(
+            $this->referentialIntegrity->synchronize(
                 $snapshot,
                 $this->shadowStore,
                 $mutation,
@@ -386,7 +386,7 @@ final class Session
             return;
         }
 
-        $definition = $this->registry?->get($mutation->tableName());
+        $definition = $this->registry->get($mutation->tableName());
         $identityColumns = $definition !== null ? array_keys($definition->identityStrategies) : [];
         if ($identityColumns === [] && $definition !== null && count($definition->primaryKeys) === 1) {
             $identityColumns = $definition->primaryKeys;

--- a/packages/ztd-query-core/src/Shadow/Mutation/DataMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/DataMutation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+/**
+ * Marker for mutations that can change rows participating in referential integrity.
+ */
+interface DataMutation extends ShadowMutation
+{
+}

--- a/packages/ztd-query-core/src/Shadow/Mutation/DeleteMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/DeleteMutation.php
@@ -9,7 +9,7 @@ use ZtdQuery\Shadow\ShadowStore;
 /**
  * Applies DELETE result rows to the shadow store.
  */
-final class DeleteMutation implements ShadowMutation
+final class DeleteMutation implements DataMutation
 {
     /**
      * Target table to delete from.

--- a/packages/ztd-query-core/src/Shadow/Mutation/InsertMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/InsertMutation.php
@@ -13,7 +13,7 @@ use ZtdQuery\Shadow\ShadowStore;
 /**
  * Applies INSERT result rows to the shadow store.
  */
-final class InsertMutation implements ShadowMutation
+final class InsertMutation implements DataMutation
 {
     /**
      * Target table to insert into.

--- a/packages/ztd-query-core/src/Shadow/Mutation/MultiDeleteMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MultiDeleteMutation.php
@@ -10,7 +10,7 @@ use ZtdQuery\Shadow\ShadowStore;
  * Applies multi-table DELETE operation to the shadow store.
  * This mutation handles DELETE statements that target multiple tables.
  */
-final class MultiDeleteMutation implements ShadowMutation
+final class MultiDeleteMutation implements DataMutation
 {
     /** @var list<MultiTableMutationTarget> */
     private array $targets;

--- a/packages/ztd-query-core/src/Shadow/Mutation/MultiTruncateMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MultiTruncateMutation.php
@@ -9,7 +9,7 @@ use ZtdQuery\Shadow\ShadowStore;
 /**
  * Applies a single TRUNCATE statement to every target shadow table.
  */
-final class MultiTruncateMutation implements ShadowMutation
+final class MultiTruncateMutation implements DataMutation
 {
     /** @param list<string> $tableNames */
     public function __construct(

--- a/packages/ztd-query-core/src/Shadow/Mutation/MultiUpdateMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MultiUpdateMutation.php
@@ -10,7 +10,7 @@ use ZtdQuery\Shadow\ShadowStore;
  * Applies multi-table UPDATE operation to the shadow store.
  * This mutation handles UPDATE statements that target multiple tables.
  */
-final class MultiUpdateMutation implements ShadowMutation
+final class MultiUpdateMutation implements DataMutation
 {
     /** @var list<MultiTableMutationTarget> */
     private array $targets;

--- a/packages/ztd-query-core/src/Shadow/Mutation/ReplaceMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/ReplaceMutation.php
@@ -11,7 +11,7 @@ use ZtdQuery\Shadow\ShadowStore;
  * Applies REPLACE INTO operation to the shadow store.
  * REPLACE deletes the existing row and inserts the new one.
  */
-final class ReplaceMutation implements ShadowMutation
+final class ReplaceMutation implements DataMutation
 {
     /**
      * Target table to replace into.

--- a/packages/ztd-query-core/src/Shadow/Mutation/TruncateMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/TruncateMutation.php
@@ -9,7 +9,7 @@ use ZtdQuery\Shadow\ShadowStore;
 /**
  * Applies TRUNCATE operation to the shadow store by clearing all rows.
  */
-final class TruncateMutation implements ShadowMutation
+final class TruncateMutation implements DataMutation
 {
     /**
      * Target table to truncate.

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpdateMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpdateMutation.php
@@ -12,7 +12,7 @@ use ZtdQuery\Shadow\ShadowStore;
 /**
  * Applies UPDATE result rows to the shadow store.
  */
-final class UpdateMutation implements ShadowMutation
+final class UpdateMutation implements DataMutation
 {
     /**
      * Target table to update.

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
@@ -11,7 +11,7 @@ use ZtdQuery\Shadow\ShadowStore;
 /**
  * Applies INSERT ... ON DUPLICATE KEY UPDATE (UPSERT) to the shadow store.
  */
-final class UpsertMutation implements ShadowMutation
+final class UpsertMutation implements DataMutation
 {
     /**
      * Target table to upsert into.

--- a/packages/ztd-query-core/src/Shadow/ReferentialIntegrityEnforcer.php
+++ b/packages/ztd-query-core/src/Shadow/ReferentialIntegrityEnforcer.php
@@ -1,0 +1,469 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow;
+
+use ZtdQuery\Exception\ForeignKeyViolationException;
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
+use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Shadow\Mutation\DeleteMutation;
+use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\MultiDeleteMutation;
+use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
+use ZtdQuery\Shadow\Mutation\MultiUpdateMutation;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
+use ZtdQuery\Shadow\Mutation\ReplaceMutation;
+use ZtdQuery\Shadow\Mutation\ShadowMutation;
+use ZtdQuery\Shadow\Mutation\TruncateMutation;
+use ZtdQuery\Shadow\Mutation\UpdateMutation;
+use ZtdQuery\Shadow\Mutation\UpsertMutation;
+
+final class ReferentialIntegrityEnforcer
+{
+    public function __construct(private readonly TableDefinitionRegistry $registry)
+    {
+    }
+
+    /** @param array<int, array<string, mixed>> $resultRows */
+    public function synchronize(
+        ShadowStore $before,
+        ShadowStore $after,
+        ShadowMutation $mutation,
+        array $resultRows,
+        string $sql,
+    ): void {
+        if (!$this->isDataMutation($mutation)) {
+            return;
+        }
+
+        $events = $this->initialEvents($before, $after, $mutation, $resultRows);
+        while ($events !== []) {
+            $event = array_shift($events);
+            foreach ($this->registry->getAll() as $childTable => $childDefinition) {
+                foreach ($childDefinition->foreignKeys as $constraintName => $foreignKey) {
+                    if (strcasecmp($foreignKey->referencedTable, $event['table']) !== 0) {
+                        continue;
+                    }
+                    $cascade = $this->cascade(
+                        $after,
+                        $childTable,
+                        $constraintName,
+                        $foreignKey,
+                        $event['deleted'],
+                        $event['updated'],
+                        $sql,
+                    );
+                    if ($cascade !== null) {
+                        $events[] = $cascade;
+                    }
+                }
+            }
+        }
+
+        $this->validate($after, $sql);
+    }
+
+    private function isDataMutation(ShadowMutation $mutation): bool
+    {
+        return $mutation instanceof InsertMutation
+            || $mutation instanceof UpdateMutation
+            || $mutation instanceof DeleteMutation
+            || $mutation instanceof ReplaceMutation
+            || $mutation instanceof UpsertMutation
+            || $mutation instanceof TruncateMutation
+            || $mutation instanceof MultiUpdateMutation
+            || $mutation instanceof MultiDeleteMutation
+            || $mutation instanceof MultiTruncateMutation;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $resultRows
+     * @return list<array{
+     *     table: string,
+     *     deleted: list<array<string, mixed>>,
+     *     updated: list<array{before: array<string, mixed>, after: array<string, mixed>}>
+     * }>
+     */
+    private function initialEvents(
+        ShadowStore $before,
+        ShadowStore $after,
+        ShadowMutation $mutation,
+        array $resultRows,
+    ): array {
+        $tables = array_unique(array_merge(
+            array_keys($before->getAll()),
+            array_keys($after->getAll()),
+        ));
+        $events = [];
+        foreach ($tables as $table) {
+            $definition = $this->registry->get($table);
+            $primaryKeys = array_values($definition->primaryKeys ?? []);
+            $identityRows = $mutation instanceof UpdateMutation && $mutation->tableName() === $table
+                ? $resultRows
+                : [];
+            $event = $this->transition(
+                $table,
+                array_values($before->get($table)),
+                array_values($after->get($table)),
+                $primaryKeys,
+                array_values($identityRows),
+            );
+            if ($event['deleted'] !== [] || $event['updated'] !== []) {
+                $events[] = $event;
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $beforeRows
+     * @param list<array<string, mixed>> $afterRows
+     * @param list<string> $primaryKeys
+     * @param list<array<string, mixed>> $identityRows
+     * @return array{
+     *     table: string,
+     *     deleted: list<array<string, mixed>>,
+     *     updated: list<array{before: array<string, mixed>, after: array<string, mixed>}>
+     * }
+     */
+    private function transition(
+        string $table,
+        array $beforeRows,
+        array $afterRows,
+        array $primaryKeys,
+        array $identityRows,
+    ): array {
+        $matchedBefore = [];
+        $matchedAfter = [];
+        $updated = [];
+        if ($primaryKeys !== []) {
+            $identity = new MutationRowIdentity();
+            foreach ($identityRows as $resultRow) {
+                $change = $identity->extract($resultRow, $primaryKeys);
+                $beforeIndex = self::matchingRowIndex($beforeRows, $change['identity'], $primaryKeys, $matchedBefore);
+                $afterIndex = self::matchingRowIndex($afterRows, $change['row'], $primaryKeys, $matchedAfter);
+                if ($beforeIndex === null || $afterIndex === null) {
+                    continue;
+                }
+                $matchedBefore[$beforeIndex] = true;
+                $matchedAfter[$afterIndex] = true;
+                if ($beforeRows[$beforeIndex] !== $afterRows[$afterIndex]) {
+                    $updated[] = ['before' => $beforeRows[$beforeIndex], 'after' => $afterRows[$afterIndex]];
+                }
+            }
+
+            foreach ($beforeRows as $beforeIndex => $beforeRow) {
+                if (isset($matchedBefore[$beforeIndex])) {
+                    continue;
+                }
+                $afterIndex = self::matchingRowIndex($afterRows, $beforeRow, $primaryKeys, $matchedAfter);
+                if ($afterIndex === null) {
+                    continue;
+                }
+                $matchedBefore[$beforeIndex] = true;
+                $matchedAfter[$afterIndex] = true;
+                if ($beforeRow !== $afterRows[$afterIndex]) {
+                    $updated[] = ['before' => $beforeRow, 'after' => $afterRows[$afterIndex]];
+                }
+            }
+        } else {
+            foreach ($beforeRows as $beforeIndex => $beforeRow) {
+                $afterIndex = self::matchingExactRowIndex($afterRows, $beforeRow, $matchedAfter);
+                if ($afterIndex !== null) {
+                    $matchedBefore[$beforeIndex] = true;
+                    $matchedAfter[$afterIndex] = true;
+                }
+            }
+        }
+
+        $deleted = [];
+        foreach ($beforeRows as $index => $row) {
+            if (!isset($matchedBefore[$index])) {
+                $deleted[] = $row;
+            }
+        }
+
+        return ['table' => $table, 'deleted' => $deleted, 'updated' => $updated];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $deletedParents
+     * @param list<array{before: array<string, mixed>, after: array<string, mixed>}> $updatedParents
+     * @return array{
+     *     table: string,
+     *     deleted: list<array<string, mixed>>,
+     *     updated: list<array{before: array<string, mixed>, after: array<string, mixed>}>
+     * }|null
+     */
+    private function cascade(
+        ShadowStore $store,
+        string $childTable,
+        string $constraintName,
+        ForeignKeyDefinition $foreignKey,
+        array $deletedParents,
+        array $updatedParents,
+        string $sql,
+    ): ?array {
+        $parentDefinition = $this->registry->get($foreignKey->referencedTable);
+        $referencedColumns = array_values($foreignKey->referencedColumns !== []
+            ? $foreignKey->referencedColumns
+            : ($parentDefinition->primaryKeys ?? []));
+        if (count($foreignKey->columns) !== count($referencedColumns)) {
+            return null;
+        }
+
+        $rows = $store->get($childTable);
+        $updatedChildren = [];
+        foreach ($updatedParents as $parentChange) {
+            $oldValues = self::keyValues($parentChange['before'], $referencedColumns);
+            $newValues = self::keyValues($parentChange['after'], $referencedColumns);
+            if ($oldValues === null || $newValues === null || $oldValues === $newValues) {
+                continue;
+            }
+            if ($this->parentKeyExists($store, $foreignKey->referencedTable, $referencedColumns, $oldValues)) {
+                continue;
+            }
+
+            foreach ($rows as $index => $row) {
+                if (!self::rowMatchesValues($row, $foreignKey->columns, $oldValues)) {
+                    continue;
+                }
+                $updated = $this->applyAction(
+                    $row,
+                    $foreignKey->columns,
+                    $newValues,
+                    $foreignKey->onUpdate,
+                    $childTable,
+                    $constraintName,
+                    $foreignKey,
+                    $sql,
+                );
+                $rows[$index] = $updated;
+                $updatedChildren[] = ['before' => $row, 'after' => $updated];
+            }
+        }
+
+        $deletedChildren = [];
+        foreach ($deletedParents as $parentRow) {
+            $oldValues = self::keyValues($parentRow, $referencedColumns);
+            if ($oldValues === null
+                || $this->parentKeyExists($store, $foreignKey->referencedTable, $referencedColumns, $oldValues)
+            ) {
+                continue;
+            }
+
+            $remaining = [];
+            foreach ($rows as $row) {
+                if (!self::rowMatchesValues($row, $foreignKey->columns, $oldValues)) {
+                    $remaining[] = $row;
+                    continue;
+                }
+                if ($foreignKey->onDelete === ReferentialAction::Cascade) {
+                    $deletedChildren[] = $row;
+                    continue;
+                }
+                $updated = $this->applyAction(
+                    $row,
+                    $foreignKey->columns,
+                    array_fill(0, count($foreignKey->columns), null),
+                    $foreignKey->onDelete,
+                    $childTable,
+                    $constraintName,
+                    $foreignKey,
+                    $sql,
+                );
+                $remaining[] = $updated;
+                $updatedChildren[] = ['before' => $row, 'after' => $updated];
+            }
+            $rows = $remaining;
+        }
+
+        if ($deletedChildren === [] && $updatedChildren === []) {
+            return null;
+        }
+
+        $store->set($childTable, array_values($rows));
+
+        return ['table' => $childTable, 'deleted' => $deletedChildren, 'updated' => $updatedChildren];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param non-empty-list<string> $columns
+     * @param list<mixed> $values
+     * @return array<string, mixed>
+     */
+    private function applyAction(
+        array $row,
+        array $columns,
+        array $values,
+        ReferentialAction $action,
+        string $childTable,
+        string $constraintName,
+        ForeignKeyDefinition $foreignKey,
+        string $sql,
+    ): array {
+        if ($action !== ReferentialAction::Cascade && $action !== ReferentialAction::SetNull) {
+            throw $this->violation($sql, $childTable, $constraintName, $foreignKey);
+        }
+
+        foreach ($columns as $index => $column) {
+            $row[$column] = $action === ReferentialAction::SetNull ? null : ($values[$index] ?? null);
+        }
+
+        return $row;
+    }
+
+    private function validate(ShadowStore $store, string $sql): void
+    {
+        foreach ($this->registry->getAll() as $childTable => $definition) {
+            foreach ($definition->foreignKeys as $constraintName => $foreignKey) {
+                $parentDefinition = $this->registry->get($foreignKey->referencedTable);
+                $referencedColumns = array_values($foreignKey->referencedColumns !== []
+                    ? $foreignKey->referencedColumns
+                    : ($parentDefinition->primaryKeys ?? []));
+                if (count($foreignKey->columns) !== count($referencedColumns)) {
+                    continue;
+                }
+
+                foreach ($store->get($childTable) as $row) {
+                    $values = self::keyValues($row, $foreignKey->columns);
+                    if ($values === null || in_array(null, $values, true)) {
+                        continue;
+                    }
+                    if (!$this->parentKeyExists(
+                        $store,
+                        $foreignKey->referencedTable,
+                        $referencedColumns,
+                        $values,
+                    )) {
+                        throw $this->violation($sql, $childTable, $constraintName, $foreignKey);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $columns
+     * @param list<mixed> $values
+     */
+    private function parentKeyExists(
+        ShadowStore $store,
+        string $table,
+        array $columns,
+        array $values,
+    ): bool {
+        foreach ($store->get($table) as $row) {
+            if (self::rowMatchesValues($row, $columns, $values)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function violation(
+        string $sql,
+        string $childTable,
+        string $constraintName,
+        ForeignKeyDefinition $foreignKey,
+    ): ForeignKeyViolationException {
+        return new ForeignKeyViolationException(
+            $sql,
+            $childTable,
+            $constraintName,
+            $foreignKey->referencedTable,
+            $foreignKey->referencedColumns[0] ?? '',
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed> $candidate
+     * @param list<string> $keys
+     * @param array<int, bool> $excluded
+     */
+    private static function matchingRowIndex(array $rows, array $candidate, array $keys, array $excluded): ?int
+    {
+        foreach ($rows as $index => $row) {
+            if (!isset($excluded[$index]) && self::rowsMatch($row, $candidate, $keys)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed> $candidate
+     * @param array<int, bool> $excluded
+     */
+    private static function matchingExactRowIndex(array $rows, array $candidate, array $excluded): ?int
+    {
+        foreach ($rows as $index => $row) {
+            if (!isset($excluded[$index]) && $row === $candidate) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $left
+     * @param array<string, mixed> $right
+     * @param list<string> $keys
+     */
+    private static function rowsMatch(array $left, array $right, array $keys): bool
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $left)
+                || !array_key_exists($key, $right)
+                || $left[$key] !== $right[$key]
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param list<string> $columns
+     * @return list<mixed>|null
+     */
+    private static function keyValues(array $row, array $columns): ?array
+    {
+        $values = [];
+        foreach ($columns as $column) {
+            if (!array_key_exists($column, $row)) {
+                return null;
+            }
+            $values[] = $row[$column];
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param list<string> $columns
+     * @param list<mixed> $values
+     */
+    private static function rowMatchesValues(array $row, array $columns, array $values): bool
+    {
+        foreach ($columns as $index => $column) {
+            if (!array_key_exists($column, $row) || $row[$column] !== ($values[$index] ?? null)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/packages/ztd-query-core/src/Shadow/ReferentialIntegrityEnforcer.php
+++ b/packages/ztd-query-core/src/Shadow/ReferentialIntegrityEnforcer.php
@@ -8,17 +8,10 @@ use ZtdQuery\Exception\ForeignKeyViolationException;
 use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\ReferentialAction;
 use ZtdQuery\Schema\TableDefinitionRegistry;
-use ZtdQuery\Shadow\Mutation\DeleteMutation;
-use ZtdQuery\Shadow\Mutation\InsertMutation;
-use ZtdQuery\Shadow\Mutation\MultiDeleteMutation;
-use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
-use ZtdQuery\Shadow\Mutation\MultiUpdateMutation;
+use ZtdQuery\Shadow\Mutation\DataMutation;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
-use ZtdQuery\Shadow\Mutation\ReplaceMutation;
 use ZtdQuery\Shadow\Mutation\ShadowMutation;
-use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
-use ZtdQuery\Shadow\Mutation\UpsertMutation;
 
 final class ReferentialIntegrityEnforcer
 {
@@ -34,7 +27,7 @@ final class ReferentialIntegrityEnforcer
         array $resultRows,
         string $sql,
     ): void {
-        if (!$this->isDataMutation($mutation)) {
+        if (!$mutation instanceof DataMutation) {
             return;
         }
 
@@ -65,19 +58,6 @@ final class ReferentialIntegrityEnforcer
         $this->validate($after, $sql);
     }
 
-    private function isDataMutation(ShadowMutation $mutation): bool
-    {
-        return $mutation instanceof InsertMutation
-            || $mutation instanceof UpdateMutation
-            || $mutation instanceof DeleteMutation
-            || $mutation instanceof ReplaceMutation
-            || $mutation instanceof UpsertMutation
-            || $mutation instanceof TruncateMutation
-            || $mutation instanceof MultiUpdateMutation
-            || $mutation instanceof MultiDeleteMutation
-            || $mutation instanceof MultiTruncateMutation;
-    }
-
     /**
      * @param array<int, array<string, mixed>> $resultRows
      * @return list<array{
@@ -92,23 +72,20 @@ final class ReferentialIntegrityEnforcer
         ShadowMutation $mutation,
         array $resultRows,
     ): array {
-        $tables = array_unique(array_merge(
-            array_keys($before->getAll()),
-            array_keys($after->getAll()),
-        ));
         $events = [];
-        foreach ($tables as $table) {
+        $identityTable = $mutation instanceof UpdateMutation ? $mutation->tableName() : null;
+        foreach (array_keys($before->getAll()) as $table) {
             $definition = $this->registry->get($table);
-            $primaryKeys = array_values($definition->primaryKeys ?? []);
-            $identityRows = $mutation instanceof UpdateMutation && $mutation->tableName() === $table
+            $primaryKeys = $definition->primaryKeys ?? [];
+            $identityRows = $identityTable === $table
                 ? $resultRows
                 : [];
             $event = $this->transition(
                 $table,
-                array_values($before->get($table)),
-                array_values($after->get($table)),
+                $before->get($table),
+                $after->get($table),
                 $primaryKeys,
-                array_values($identityRows),
+                $identityRows,
             );
             if ($event['deleted'] !== [] || $event['updated'] !== []) {
                 $events[] = $event;
@@ -119,10 +96,10 @@ final class ReferentialIntegrityEnforcer
     }
 
     /**
-     * @param list<array<string, mixed>> $beforeRows
-     * @param list<array<string, mixed>> $afterRows
-     * @param list<string> $primaryKeys
-     * @param list<array<string, mixed>> $identityRows
+     * @param array<int, array<string, mixed>> $beforeRows
+     * @param array<int, array<string, mixed>> $afterRows
+     * @param array<int, string> $primaryKeys
+     * @param array<int, array<string, mixed>> $identityRows
      * @return array{
      *     table: string,
      *     deleted: list<array<string, mixed>>,
@@ -148,23 +125,23 @@ final class ReferentialIntegrityEnforcer
                 if ($beforeIndex === null || $afterIndex === null) {
                     continue;
                 }
-                $matchedBefore[$beforeIndex] = true;
-                $matchedAfter[$afterIndex] = true;
+                $matchedBefore[] = $beforeIndex;
+                $matchedAfter[] = $afterIndex;
                 if ($beforeRows[$beforeIndex] !== $afterRows[$afterIndex]) {
                     $updated[] = ['before' => $beforeRows[$beforeIndex], 'after' => $afterRows[$afterIndex]];
                 }
             }
 
             foreach ($beforeRows as $beforeIndex => $beforeRow) {
-                if (isset($matchedBefore[$beforeIndex])) {
+                if (in_array($beforeIndex, $matchedBefore, true)) {
                     continue;
                 }
                 $afterIndex = self::matchingRowIndex($afterRows, $beforeRow, $primaryKeys, $matchedAfter);
                 if ($afterIndex === null) {
                     continue;
                 }
-                $matchedBefore[$beforeIndex] = true;
-                $matchedAfter[$afterIndex] = true;
+                $matchedBefore[] = $beforeIndex;
+                $matchedAfter[] = $afterIndex;
                 if ($beforeRow !== $afterRows[$afterIndex]) {
                     $updated[] = ['before' => $beforeRow, 'after' => $afterRows[$afterIndex]];
                 }
@@ -173,15 +150,15 @@ final class ReferentialIntegrityEnforcer
             foreach ($beforeRows as $beforeIndex => $beforeRow) {
                 $afterIndex = self::matchingExactRowIndex($afterRows, $beforeRow, $matchedAfter);
                 if ($afterIndex !== null) {
-                    $matchedBefore[$beforeIndex] = true;
-                    $matchedAfter[$afterIndex] = true;
+                    $matchedBefore[] = $beforeIndex;
+                    $matchedAfter[] = $afterIndex;
                 }
             }
         }
 
         $deleted = [];
         foreach ($beforeRows as $index => $row) {
-            if (!isset($matchedBefore[$index])) {
+            if (!in_array($index, $matchedBefore, true)) {
                 $deleted[] = $row;
             }
         }
@@ -207,10 +184,7 @@ final class ReferentialIntegrityEnforcer
         array $updatedParents,
         string $sql,
     ): ?array {
-        $parentDefinition = $this->registry->get($foreignKey->referencedTable);
-        $referencedColumns = array_values($foreignKey->referencedColumns !== []
-            ? $foreignKey->referencedColumns
-            : ($parentDefinition->primaryKeys ?? []));
+        $referencedColumns = $this->referencedColumns($foreignKey);
         if (count($foreignKey->columns) !== count($referencedColumns)) {
             return null;
         }
@@ -220,7 +194,7 @@ final class ReferentialIntegrityEnforcer
         foreach ($updatedParents as $parentChange) {
             $oldValues = self::keyValues($parentChange['before'], $referencedColumns);
             $newValues = self::keyValues($parentChange['after'], $referencedColumns);
-            if ($oldValues === null || $newValues === null || $oldValues === $newValues) {
+            if ($oldValues === null || $newValues === null) {
                 continue;
             }
             if ($this->parentKeyExists($store, $foreignKey->referencedTable, $referencedColumns, $oldValues)) {
@@ -268,7 +242,7 @@ final class ReferentialIntegrityEnforcer
                 $updated = $this->applyAction(
                     $row,
                     $foreignKey->columns,
-                    array_fill(0, count($foreignKey->columns), null),
+                    [],
                     $foreignKey->onDelete,
                     $childTable,
                     $constraintName,
@@ -321,10 +295,7 @@ final class ReferentialIntegrityEnforcer
     {
         foreach ($this->registry->getAll() as $childTable => $definition) {
             foreach ($definition->foreignKeys as $constraintName => $foreignKey) {
-                $parentDefinition = $this->registry->get($foreignKey->referencedTable);
-                $referencedColumns = array_values($foreignKey->referencedColumns !== []
-                    ? $foreignKey->referencedColumns
-                    : ($parentDefinition->primaryKeys ?? []));
+                $referencedColumns = $this->referencedColumns($foreignKey);
                 if (count($foreignKey->columns) !== count($referencedColumns)) {
                     continue;
                 }
@@ -372,25 +343,42 @@ final class ReferentialIntegrityEnforcer
         string $constraintName,
         ForeignKeyDefinition $foreignKey,
     ): ForeignKeyViolationException {
+        $referencedColumns = $this->referencedColumns($foreignKey);
+
         return new ForeignKeyViolationException(
             $sql,
             $childTable,
             $constraintName,
             $foreignKey->referencedTable,
-            $foreignKey->referencedColumns[0] ?? '',
+            $referencedColumns[0] ?? '',
         );
     }
 
+    /** @return list<string> */
+    private function referencedColumns(ForeignKeyDefinition $foreignKey): array
+    {
+        if ($foreignKey->referencedColumns !== []) {
+            return $foreignKey->referencedColumns;
+        }
+
+        $referencedTable = $this->registry->get($foreignKey->referencedTable);
+        if ($referencedTable === null) {
+            return [];
+        }
+
+        return array_values($referencedTable->primaryKeys);
+    }
+
     /**
-     * @param list<array<string, mixed>> $rows
+     * @param array<int, array<string, mixed>> $rows
      * @param array<string, mixed> $candidate
-     * @param list<string> $keys
-     * @param array<int, bool> $excluded
+     * @param array<int, string> $keys
+     * @param list<int> $excluded
      */
     private static function matchingRowIndex(array $rows, array $candidate, array $keys, array $excluded): ?int
     {
         foreach ($rows as $index => $row) {
-            if (!isset($excluded[$index]) && self::rowsMatch($row, $candidate, $keys)) {
+            if (!in_array($index, $excluded, true) && self::rowsMatch($row, $candidate, $keys)) {
                 return $index;
             }
         }
@@ -399,14 +387,14 @@ final class ReferentialIntegrityEnforcer
     }
 
     /**
-     * @param list<array<string, mixed>> $rows
+     * @param array<int, array<string, mixed>> $rows
      * @param array<string, mixed> $candidate
-     * @param array<int, bool> $excluded
+     * @param list<int> $excluded
      */
     private static function matchingExactRowIndex(array $rows, array $candidate, array $excluded): ?int
     {
         foreach ($rows as $index => $row) {
-            if (!isset($excluded[$index]) && $row === $candidate) {
+            if (!in_array($index, $excluded, true) && $row === $candidate) {
                 return $index;
             }
         }
@@ -417,7 +405,7 @@ final class ReferentialIntegrityEnforcer
     /**
      * @param array<string, mixed> $left
      * @param array<string, mixed> $right
-     * @param list<string> $keys
+     * @param array<int, string> $keys
      */
     private static function rowsMatch(array $left, array $right, array $keys): bool
     {

--- a/packages/ztd-query-core/tests/Unit/Schema/ForeignKeyDefinitionParserTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ForeignKeyDefinitionParserTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\ForeignKeyDefinitionParser;
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(ForeignKeyDefinitionParser::class)]
+#[UsesClass(ForeignKeyDefinition::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class ForeignKeyDefinitionParserTest extends TestCase
+{
+    public function testParsesNamedCompositeConstraintWithoutRegexSubstitution(): void
+    {
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child (id INT, tenant_id INT, parent_id INT, '
+            . 'CONSTRAINT "fk child parent" FOREIGN KEY (tenant_id, parent_id) '
+            . 'REFERENCES app.parents (tenant_id, id) ON UPDATE CASCADE ON DELETE SET NULL)',
+        );
+
+        self::assertSame(['fk child parent'], array_keys($foreignKeys));
+        self::assertSame(['tenant_id', 'parent_id'], $foreignKeys['fk child parent']->columns);
+        self::assertSame('parents', $foreignKeys['fk child parent']->referencedTable);
+        self::assertSame(['tenant_id', 'id'], $foreignKeys['fk child parent']->referencedColumns);
+        self::assertSame(ReferentialAction::SetNull, $foreignKeys['fk child parent']->onDelete);
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['fk child parent']->onUpdate);
+    }
+
+    public function testParsesInlineAndMySqlQuotedReferences(): void
+    {
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE `child` (`id` INT, `parent_id` INT REFERENCES `app`.`parents` (`id`) ON DELETE RESTRICT)',
+            SqlTokenDialect::MySql,
+        );
+
+        self::assertCount(1, $foreignKeys);
+        $foreignKey = array_values($foreignKeys)[0];
+        self::assertSame(['parent_id'], $foreignKey->columns);
+        self::assertSame('parents', $foreignKey->referencedTable);
+        self::assertSame(['id'], $foreignKey->referencedColumns);
+        self::assertSame(ReferentialAction::Restrict, $foreignKey->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKey->onUpdate);
+    }
+
+    public function testUsesReferencedPrimaryKeyWhenColumnListIsOmitted(): void
+    {
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child (parent_id INTEGER REFERENCES parent ON DELETE CASCADE)',
+        );
+
+        self::assertSame([], array_values($foreignKeys)[0]->referencedColumns);
+        self::assertSame(ReferentialAction::Cascade, array_values($foreignKeys)[0]->onDelete);
+    }
+
+    public function testRejectsStatementsAndMalformedReferencesWithoutTableBody(): void
+    {
+        $parser = new ForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable('CREATE TABLE child AS SELECT 1'));
+        self::assertSame([], $parser->parseCreateTable('CREATE TABLE child (id INT, FOREIGN KEY REFERENCES parent(id))'));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/ForeignKeyDefinitionParserTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ForeignKeyDefinitionParserTest.php
@@ -69,4 +69,139 @@ final class ForeignKeyDefinitionParserTest extends TestCase
         self::assertSame([], $parser->parseCreateTable('CREATE TABLE child AS SELECT 1'));
         self::assertSame([], $parser->parseCreateTable('CREATE TABLE child (id INT, FOREIGN KEY REFERENCES parent(id))'));
     }
+
+    public function testParsesEveryActionAndAssignsSequentialSyntheticNames(): void
+    {
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+            'create table child ('
+            . 'id int, '
+            . 'cascade_id int references cascade_parent(id) on delete cascade on update restrict, '
+            . 'default_id int references default_parent(id) on delete set default on update no action, '
+            . 'null_id int references null_parent(id) on delete set null, '
+            . 'foreign key (id, cascade_id) references composite_parent(tenant_id, id) '
+            . 'on delete restrict on update cascade'
+            . ')',
+        );
+
+        self::assertSame(['foreign_0', 'foreign_1', 'foreign_2', 'foreign_3'], array_keys($foreignKeys));
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['foreign_0']->onDelete);
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_0']->onUpdate);
+        self::assertSame(ReferentialAction::SetDefault, $foreignKeys['foreign_1']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_1']->onUpdate);
+        self::assertSame(ReferentialAction::SetNull, $foreignKeys['foreign_2']->onDelete);
+        self::assertSame(['id', 'cascade_id'], $foreignKeys['foreign_3']->columns);
+        self::assertSame(['tenant_id', 'id'], $foreignKeys['foreign_3']->referencedColumns);
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_3']->onDelete);
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['foreign_3']->onUpdate);
+    }
+
+    public function testUsesOnlyCreateTableTopLevelParentheses(): void
+    {
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+            "CREATE TABLE child (id INT, note TEXT DEFAULT '(not structure)', "
+            . 'parent_id INT, FOREIGN KEY (parent_id) REFERENCES parent(id)) ENGINE = fn()',
+            SqlTokenDialect::MySql,
+        );
+
+        self::assertSame(['foreign_0'], array_keys($foreignKeys));
+        self::assertSame(['parent_id'], $foreignKeys['foreign_0']->columns);
+        self::assertSame('parent', $foreignKeys['foreign_0']->referencedTable);
+        self::assertSame(['id'], $foreignKeys['foreign_0']->referencedColumns);
+    }
+
+    public function testRejectsNonCreateAndMalformedForeignKeyStructures(): void
+    {
+        $parser = new ForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'WRAP (FOREIGN KEY (bad_id) REFERENCES wrong(id)) CREATE TABLE child '
+            . '(parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id) REFERENCES)',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id REFERENCES parent(id))',
+        ));
+    }
+
+    public function testDoesNotTreatOtherCreateStatementParenthesesAsTableBodies(): void
+    {
+        $parser = new ForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE VIEW child AS fn(parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TYPE child AS (parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT), fake_id INT REFERENCES fake_parent(id)',
+        ));
+    }
+
+    public function testMalformedActionsRemainNoActionWithoutTokenLookaheadFailures(): void
+    {
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child ('
+            . 'bare_id INT REFERENCES bare_parent, '
+            . 'on_id INT REFERENCES on_parent(id) ON, '
+            . 'delete_id INT REFERENCES delete_parent(id) ON DELETE, '
+            . 'set_id INT REFERENCES set_parent(id) ON DELETE SET, '
+            . 'unknown_id INT REFERENCES unknown_parent(id) ON DELETE UNKNOWN NULL'
+            . ')',
+        );
+
+        self::assertSame(
+            ['foreign_0', 'foreign_1', 'foreign_2', 'foreign_3', 'foreign_4'],
+            array_keys($foreignKeys),
+        );
+        self::assertSame('bare_parent', $foreignKeys['foreign_0']->referencedTable);
+        self::assertSame([], $foreignKeys['foreign_0']->referencedColumns);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_1']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_2']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_3']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_4']->onDelete);
+    }
+
+    public function testNestedActionTokensCannotOverrideTopLevelAction(): void
+    {
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child ('
+            . 'parent_id INT REFERENCES parent(id) CHECK (ON DELETE CASCADE) ON DELETE RESTRICT'
+            . ')',
+        );
+
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_0']->onDelete);
+    }
+
+    public function testForeignKeyClauseRequiresImmediateKeyAndColumnListTokens(): void
+    {
+        $parser = new ForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN WRONG KEY (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN WRONG (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY id REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY () REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, CONSTRAINT fk REFERENCES parent(id) FOREIGN KEY (id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, CONSTRAINT KEY (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id) REFERENCES parent.)',
+        ));
+    }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/ForeignKeyDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ForeignKeyDefinitionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
+
+#[CoversClass(ForeignKeyDefinition::class)]
+final class ForeignKeyDefinitionTest extends TestCase
+{
+    public function testCarriesCompositeReferenceAndActions(): void
+    {
+        $definition = new ForeignKeyDefinition(
+            ['tenant_id', 'department_id'],
+            'departments',
+            ['tenant_id', 'id'],
+            ReferentialAction::Cascade,
+            ReferentialAction::SetNull,
+        );
+
+        self::assertSame(['tenant_id', 'department_id'], $definition->columns);
+        self::assertSame('departments', $definition->referencedTable);
+        self::assertSame(['tenant_id', 'id'], $definition->referencedColumns);
+        self::assertSame(ReferentialAction::Cascade, $definition->onDelete);
+        self::assertSame(ReferentialAction::SetNull, $definition->onUpdate);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/ReferentialActionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ReferentialActionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\ReferentialAction;
+
+#[CoversClass(ReferentialAction::class)]
+final class ReferentialActionTest extends TestCase
+{
+    public function testActionsExposeSqlSpelling(): void
+    {
+        self::assertSame('NO ACTION', ReferentialAction::NoAction->value);
+        self::assertSame('RESTRICT', ReferentialAction::Restrict->value);
+        self::assertSame('CASCADE', ReferentialAction::Cascade->value);
+        self::assertSame('SET NULL', ReferentialAction::SetNull->value);
+        self::assertSame('SET DEFAULT', ReferentialAction::SetDefault->value);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
@@ -8,11 +8,13 @@ use PHPUnit\Framework\TestCase;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
+use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\TableDefinition;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[UsesClass(ColumnType::class)]
+#[UsesClass(ForeignKeyDefinition::class)]
 #[CoversClass(TableDefinition::class)]
 final class TableDefinitionTest extends TestCase
 {
@@ -30,6 +32,7 @@ final class TableDefinitionTest extends TestCase
             ['name' => "'anonymous'"],
             ['id' => IdentityGenerationStrategy::MaxValue],
             ['name' => "CONCAT('user-', id)"],
+            ['fk_parent' => new ForeignKeyDefinition(['id'], 'parents', ['id'])],
         );
 
         self::assertSame(['id', 'name'], $definition->columns);
@@ -41,6 +44,7 @@ final class TableDefinitionTest extends TestCase
         self::assertSame(['name' => "'anonymous'"], $definition->columnDefaults);
         self::assertSame(['id' => IdentityGenerationStrategy::MaxValue], $definition->identityStrategies);
         self::assertSame(['name' => "CONCAT('user-', id)"], $definition->generatedExpressions);
+        self::assertSame(['fk_parent'], array_keys($definition->foreignKeys));
     }
 
     public function testTypedColumnsDefaultsToEmpty(): void
@@ -57,5 +61,6 @@ final class TableDefinitionTest extends TestCase
         self::assertSame([], $definition->columnDefaults);
         self::assertSame([], $definition->identityStrategies);
         self::assertSame([], $definition->generatedExpressions);
+        self::assertSame([], $definition->foreignKeys);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -14,14 +14,19 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\Exception\MissingPrimaryKeyException;
+use ZtdQuery\Exception\ForeignKeyViolationException;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Session;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
+use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
+use ZtdQuery\Shadow\ReferentialIntegrityEnforcer;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTransactionManager;
 
@@ -31,12 +36,17 @@ use ZtdQuery\Shadow\ShadowTransactionManager;
 #[UsesClass(ShadowTransactionManager::class)]
 #[UsesClass(TableDefinitionRegistry::class)]
 #[UsesClass(TableDefinition::class)]
+#[UsesClass(CandidateKeySet::class)]
 #[UsesClass(ResultSelectRunner::class)]
 #[UsesClass(ResultSet::class)]
 #[UsesClass(DatabaseException::class)]
 #[UsesClass(RewritePlan::class)]
 #[UsesClass(UpdateMutation::class)]
+#[UsesClass(InsertMutation::class)]
 #[UsesClass(MutationRowIdentity::class)]
+#[UsesClass(ForeignKeyDefinition::class)]
+#[UsesClass(ForeignKeyViolationException::class)]
+#[UsesClass(ReferentialIntegrityEnforcer::class)]
 #[UsesClass(MissingPrimaryKeyException::class)]
 final class SessionTest extends TestCase
 {
@@ -109,6 +119,44 @@ final class SessionTest extends TestCase
         } catch (DatabaseException $exception) {
             self::assertSame(0, $exception->getCode());
             self::assertInstanceOf(MissingPrimaryKeyException::class, $exception->getPrevious());
+        }
+    }
+
+    public function testForeignKeyFailureRestoresShadowState(): void
+    {
+        $shadowStore = new ShadowStore();
+        $shadowStore->set('parents', []);
+        $shadowStore->set('children', []);
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['parent_id'], 'parents', ['id'])],
+        ));
+        $session = new Session(
+            new FakeSqlRewriter($shadowStore, $registry),
+            $shadowStore,
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            new FakeConnection(),
+            registry: $registry,
+        );
+        $plan = new RewritePlan(
+            'SELECT 1 AS id, 999 AS parent_id',
+            QueryKind::WRITE_SIMULATED,
+            new InsertMutation('children'),
+        );
+
+        try {
+            $session->processExecutedStatement($plan, new FakeStatement([['id' => 1, 'parent_id' => 999]]));
+            self::fail('Expected a database exception.');
+        } catch (DatabaseException $exception) {
+            self::assertInstanceOf(ForeignKeyViolationException::class, $exception->getPrevious());
+            self::assertSame([], $shadowStore->get('children'));
         }
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/DataMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/DataMutationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Shadow\Mutation\DataMutation;
+use ZtdQuery\Shadow\Mutation\DeleteMutation;
+use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\MultiDeleteMutation;
+use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
+use ZtdQuery\Shadow\Mutation\MultiUpdateMutation;
+use ZtdQuery\Shadow\Mutation\ReplaceMutation;
+use ZtdQuery\Shadow\Mutation\TruncateMutation;
+use ZtdQuery\Shadow\Mutation\UpdateMutation;
+use ZtdQuery\Shadow\Mutation\UpsertMutation;
+
+#[CoversNothing]
+final class DataMutationTest extends TestCase
+{
+    public function testRowChangingMutationsShareReferentialIntegrityMarker(): void
+    {
+        self::assertInstanceOf(DataMutation::class, new InsertMutation('items'));
+        self::assertInstanceOf(DataMutation::class, new UpdateMutation('items', ['id']));
+        self::assertInstanceOf(DataMutation::class, new DeleteMutation('items', ['id']));
+        self::assertInstanceOf(DataMutation::class, new ReplaceMutation('items'));
+        self::assertInstanceOf(DataMutation::class, new UpsertMutation('items', ['id']));
+        self::assertInstanceOf(DataMutation::class, new TruncateMutation('items'));
+        self::assertInstanceOf(DataMutation::class, new MultiUpdateMutation([]));
+        self::assertInstanceOf(DataMutation::class, new MultiDeleteMutation([]));
+        self::assertInstanceOf(DataMutation::class, new MultiTruncateMutation([]));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\ForeignKeyViolationException;
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
+use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Shadow\Mutation\DeleteMutation;
+use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\UpdateMutation;
+use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
+use ZtdQuery\Shadow\ReferentialIntegrityEnforcer;
+use ZtdQuery\Shadow\ShadowStore;
+
+#[CoversClass(ReferentialIntegrityEnforcer::class)]
+#[UsesClass(ForeignKeyDefinition::class)]
+#[UsesClass(TableDefinition::class)]
+#[UsesClass(TableDefinitionRegistry::class)]
+#[UsesClass(DeleteMutation::class)]
+#[UsesClass(InsertMutation::class)]
+#[UsesClass(UpdateMutation::class)]
+#[UsesClass(MutationRowIdentity::class)]
+#[UsesClass(ShadowStore::class)]
+final class ReferentialIntegrityEnforcerTest extends TestCase
+{
+    public function testRejectsInsertWhoseParentDoesNotExist(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['parent_id'], 'parents', ['id'])],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', []);
+        $store->set('children', []);
+        $before = $store->snapshot();
+        $mutation = new InsertMutation('children');
+        $mutation->apply($store, [['id' => 1, 'parent_id' => 99]]);
+
+        $this->expectException(ForeignKeyViolationException::class);
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $store,
+            $mutation,
+            [['id' => 1, 'parent_id' => 99]],
+            'INSERT',
+        );
+    }
+
+    public function testDeleteCascadePropagatesAcrossMultipleLevels(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('departments', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('employees', new TableDefinition(
+            ['id', 'department_id'],
+            ['id' => 'INT', 'department_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_department' => new ForeignKeyDefinition(
+                ['department_id'],
+                'departments',
+                ['id'],
+                ReferentialAction::Cascade,
+            )],
+        ));
+        $registry->register('tasks', new TableDefinition(
+            ['id', 'employee_id'],
+            ['id' => 'INT', 'employee_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_employee' => new ForeignKeyDefinition(
+                ['employee_id'],
+                'employees',
+                ['id'],
+                ReferentialAction::Cascade,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('departments', [['id' => 1]]);
+        $store->set('employees', [['id' => 10, 'department_id' => 1]]);
+        $store->set('tasks', [['id' => 100, 'employee_id' => 10]]);
+        $before = $store->snapshot();
+        $mutation = new DeleteMutation('departments', ['id']);
+        $mutation->apply($store, [['id' => 1]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $store,
+            $mutation,
+            [['id' => 1]],
+            'DELETE',
+        );
+
+        self::assertSame([], $store->get('departments'));
+        self::assertSame([], $store->get('employees'));
+        self::assertSame([], $store->get('tasks'));
+    }
+
+    public function testPrimaryKeyUpdateCascadesThroughOriginalRowIdentity(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 1]]);
+        $store->set('children', [['id' => 10, 'parent_id' => 1]]);
+        $before = $store->snapshot();
+        $mutation = new UpdateMutation('parents', ['id']);
+        $resultRows = [['id' => 2, '__ztd_original_id' => 1]];
+        $mutation->apply($store, $resultRows);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $store,
+            $mutation,
+            $resultRows,
+            'UPDATE',
+        );
+
+        self::assertSame([['id' => 2]], $store->get('parents'));
+        self::assertSame([['id' => 10, 'parent_id' => 2]], $store->get('children'));
+    }
+
+    public function testDeleteSetNullUpdatesChild(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                ReferentialAction::SetNull,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 1]]);
+        $store->set('children', [['id' => 10, 'parent_id' => 1]]);
+        $before = $store->snapshot();
+        $mutation = new DeleteMutation('parents', ['id']);
+        $mutation->apply($store, [['id' => 1]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $store,
+            $mutation,
+            [['id' => 1]],
+            'DELETE',
+        );
+
+        self::assertSame([['id' => 10, 'parent_id' => null]], $store->get('children'));
+    }
+
+    public function testDeleteRestrictRejectsParentRemoval(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                ReferentialAction::Restrict,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 2]]);
+        $store->set('children', [['id' => 20, 'parent_id' => 2]]);
+        $before = $store->snapshot();
+        $mutation = new DeleteMutation('parents', ['id']);
+        $mutation->apply($store, [['id' => 2]]);
+
+        $this->expectException(ForeignKeyViolationException::class);
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $store,
+            $mutation,
+            [['id' => 2]],
+            'DELETE',
+        );
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
@@ -14,7 +14,9 @@ use ZtdQuery\Schema\ReferentialAction;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
+use ZtdQuery\Shadow\Mutation\CreateTableMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\ReferentialIntegrityEnforcer;
@@ -27,7 +29,9 @@ use ZtdQuery\Shadow\ShadowStore;
 #[UsesClass(TableDefinition::class)]
 #[UsesClass(TableDefinitionRegistry::class)]
 #[UsesClass(DeleteMutation::class)]
+#[UsesClass(CreateTableMutation::class)]
 #[UsesClass(InsertMutation::class)]
+#[UsesClass(MultiTruncateMutation::class)]
 #[UsesClass(UpdateMutation::class)]
 #[UsesClass(MutationRowIdentity::class)]
 #[UsesClass(ShadowStore::class)]
@@ -217,5 +221,822 @@ final class ReferentialIntegrityEnforcerTest extends TestCase
             [['id' => 2]],
             'DELETE',
         );
+    }
+
+    public function testSchemaMutationDoesNotTriggerRowValidation(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['parent_id'], 'parents', ['id'])],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', []);
+        $store->set('children', [['id' => 1, 'parent_id' => 99]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $store->snapshot(),
+            $store,
+            new CreateTableMutation('archive', null, $registry),
+            [],
+            'CREATE TABLE archive',
+        );
+
+        self::assertSame([['id' => 1, 'parent_id' => 99]], $store->get('children'));
+    }
+
+    public function testMultiTruncateCascadesFromEveryChangedParentTable(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parent_a', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('parent_b', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('child_a', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_a' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parent_a',
+                ['id'],
+                ReferentialAction::Cascade,
+            )],
+        ));
+        $registry->register('child_b', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_b' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parent_b',
+                ['id'],
+                ReferentialAction::Cascade,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parent_a', [['id' => 1]]);
+        $store->set('parent_b', [['id' => 2]]);
+        $store->set('child_a', [['id' => 10, 'parent_id' => 1]]);
+        $store->set('child_b', [['id' => 20, 'parent_id' => 2]]);
+        $before = $store->snapshot();
+        $mutation = new MultiTruncateMutation(['parent_a', 'parent_b']);
+        $mutation->apply($store, []);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize($before, $store, $mutation, [], 'TRUNCATE');
+
+        self::assertSame([], $store->get('parent_a'));
+        self::assertSame([], $store->get('parent_b'));
+        self::assertSame([], $store->get('child_a'));
+        self::assertSame([], $store->get('child_b'));
+    }
+
+    public function testMatchingConstraintAfterUnrelatedConstraintStillCascades(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parent_a', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('parent_b', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'a_id', 'b_id'],
+            ['id' => 'INT', 'a_id' => 'INT', 'b_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: [
+                'fk_a' => new ForeignKeyDefinition(['a_id'], 'parent_a', ['id']),
+                'fk_b' => new ForeignKeyDefinition(['b_id'], 'parent_b', ['id'], ReferentialAction::Cascade),
+            ],
+        ));
+        $store = new ShadowStore();
+        $store->set('parent_a', [['id' => 1]]);
+        $store->set('parent_b', [['id' => 2]]);
+        $store->set('children', [['id' => 10, 'a_id' => 1, 'b_id' => 2]]);
+        $before = $store->snapshot();
+        $mutation = new DeleteMutation('parent_b', ['id']);
+        $mutation->apply($store, [['id' => 2]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize($before, $store, $mutation, [], 'DELETE');
+
+        self::assertSame([], $store->get('children'));
+    }
+
+    public function testCompositePrimaryKeyUpdateCascadesOnlyMatchingChildren(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['tenant_id', 'id'],
+            ['tenant_id' => 'INT', 'id' => 'INT'],
+            ['tenant_id', 'id'],
+            ['tenant_id', 'id'],
+            [],
+        ));
+        $registry->register('children', new TableDefinition(
+            ['id', 'tenant_id', 'parent_id'],
+            ['id' => 'INT', 'tenant_id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['tenant_id', 'parent_id'],
+                'parents',
+                ['tenant_id', 'id'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['tenant_id' => 7, 'id' => 1], ['tenant_id' => 7, 'id' => 2]]);
+        $store->set('children', [
+            ['id' => 10, 'tenant_id' => 7, 'parent_id' => 1],
+            ['id' => 20, 'tenant_id' => 7, 'parent_id' => 2],
+        ]);
+        $before = $store->snapshot();
+        $mutation = new UpdateMutation('parents', ['tenant_id', 'id']);
+        $resultRows = [[
+            'tenant_id' => 8,
+            'id' => 3,
+            '__ztd_original_tenant_id' => 7,
+            '__ztd_original_id' => 1,
+        ]];
+        $mutation->apply($store, $resultRows);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize($before, $store, $mutation, $resultRows, 'UPDATE');
+
+        self::assertSame([['tenant_id' => 8, 'id' => 3], ['tenant_id' => 7, 'id' => 2]], $store->get('parents'));
+        self::assertSame([
+            ['id' => 10, 'tenant_id' => 8, 'parent_id' => 3],
+            ['id' => 20, 'tenant_id' => 7, 'parent_id' => 2],
+        ], $store->get('children'));
+    }
+
+    public function testUpdateDoesNotCascadeWhileOldParentKeyStillExists(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [['id' => 1, 'name' => 'updated'], ['id' => 1, 'name' => 'retained']]);
+        $before->set('children', [['id' => 10, 'parent_id' => 1]]);
+        $after = $before->snapshot();
+        $after->set('parents', [['id' => 2, 'name' => 'updated'], ['id' => 1, 'name' => 'retained']]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new UpdateMutation('parents', ['id']),
+            [['id' => 2, 'name' => 'updated', '__ztd_original_id' => 1]],
+            'UPDATE',
+        );
+
+        self::assertSame([['id' => 10, 'parent_id' => 1]], $after->get('children'));
+    }
+
+    public function testExplicitReferencedColumnsAreNotReplacedByPrimaryKey(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['id', 'code'],
+            ['id' => 'TEXT', 'code' => 'TEXT'],
+            ['id'],
+            ['id', 'code'],
+            ['uq_code' => ['code']],
+        ));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_code'],
+            ['id' => 'INT', 'parent_code' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_code' => new ForeignKeyDefinition(['parent_code'], 'parents', ['code'])],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 'wrong-key', 'code' => 'expected-code']]);
+        $store->set('children', []);
+        $before = $store->snapshot();
+        $mutation = new InsertMutation('children');
+        $mutation->apply($store, [['id' => 1, 'parent_code' => 'expected-code']]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize($before, $store, $mutation, [], 'INSERT');
+
+        self::assertSame([['id' => 1, 'parent_code' => 'expected-code']], $store->get('children'));
+    }
+
+    public function testValidationContinuesPastMissingAndNullForeignKeys(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['parent_id'], 'parents', ['id'])],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 1]]);
+        $store->set('children', []);
+        $before = $store->snapshot();
+        $rows = [['id' => 10], ['id' => 20, 'parent_id' => null], ['id' => 30, 'parent_id' => 99]];
+        $mutation = new InsertMutation('children');
+        $mutation->apply($store, $rows);
+
+        $this->expectException(ForeignKeyViolationException::class);
+        (new ReferentialIntegrityEnforcer($registry))->synchronize($before, $store, $mutation, $rows, 'INSERT');
+    }
+
+    public function testCompositeDeleteSetNullNormalizesEveryForeignKeyColumn(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['tenant_id', 'id'],
+            ['tenant_id' => 'INT', 'id' => 'INT'],
+            ['tenant_id', 'id'],
+            ['tenant_id', 'id'],
+            [],
+        ));
+        $registry->register('children', new TableDefinition(
+            ['id', 'tenant_id', 'parent_id'],
+            ['id' => 'INT', 'tenant_id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['tenant_id', 'parent_id'],
+                'parents',
+                ['tenant_id', 'id'],
+                ReferentialAction::SetNull,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['tenant_id' => 7, 'id' => 1], ['tenant_id' => 7, 'id' => 2]]);
+        $store->set('children', [
+            ['id' => 10, 'tenant_id' => 7, 'parent_id' => 1],
+            ['id' => 20, 'tenant_id' => 7, 'parent_id' => 1],
+            ['id' => 30, 'tenant_id' => 7, 'parent_id' => 2],
+        ]);
+        $before = $store->snapshot();
+        $mutation = new DeleteMutation('parents', ['tenant_id', 'id']);
+        $mutation->apply($store, [['tenant_id' => 7, 'id' => 1]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize($before, $store, $mutation, [], 'DELETE');
+
+        self::assertSame([
+            ['id' => 10, 'tenant_id' => null, 'parent_id' => null],
+            ['id' => 20, 'tenant_id' => null, 'parent_id' => null],
+            ['id' => 30, 'tenant_id' => 7, 'parent_id' => 2],
+        ], $store->get('children'));
+    }
+
+    public function testDeleteCascadeRemovesAllMatchingChildrenAndKeepsOthers(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                ReferentialAction::Cascade,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 1], ['id' => 2]]);
+        $store->set('children', [
+            ['id' => 10, 'parent_id' => 1],
+            ['id' => 20, 'parent_id' => 1],
+            ['id' => 30, 'parent_id' => 2],
+        ]);
+        $before = $store->snapshot();
+        $mutation = new DeleteMutation('parents', ['id']);
+        $mutation->apply($store, [['id' => 1]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize($before, $store, $mutation, [], 'DELETE');
+
+        self::assertSame([['id' => 30, 'parent_id' => 2]], $store->get('children'));
+    }
+
+    public function testFallbackReferencedPrimaryKeyAppearsInUpdateViolation(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['parent_id'], 'parents', [])],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [['id' => 1]]);
+        $before->set('children', [['id' => 10, 'parent_id' => 1]]);
+        $after = $before->snapshot();
+        $after->set('parents', [['id' => 2]]);
+
+        $this->expectException(ForeignKeyViolationException::class);
+        $this->expectExceptionMessage("referenced row not found in 'parents.id'");
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new UpdateMutation('parents', ['id']),
+            [['id' => 2, '__ztd_original_id' => 1]],
+            'UPDATE',
+        );
+    }
+
+    public function testFallbackTransitionPropagatesUpdateAndDeleteFromOneTable(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['id', 'code'],
+            ['id' => 'INT', 'code' => 'TEXT'],
+            ['id'],
+            ['id', 'code'],
+            ['uq_code' => ['code']],
+        ));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_code'],
+            ['id' => 'INT', 'parent_code' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_code'],
+                'parents',
+                ['code'],
+                ReferentialAction::Cascade,
+                ReferentialAction::Cascade,
+            )],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [
+            ['id' => 2, 'code' => 'b'],
+            ['id' => 1, 'code' => 'a'],
+            ['id' => 3, 'code' => 'c'],
+        ]);
+        $before->set('children', [
+            ['id' => 30, 'parent_code' => 'c'],
+            ['id' => 10, 'parent_code' => 'a'],
+            ['id' => 20, 'parent_code' => 'b'],
+        ]);
+        $after = $before->snapshot();
+        $after->set('parents', [
+            ['id' => 1, 'code' => 'aa'],
+            ['id' => 3, 'code' => 'c'],
+        ]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new InsertMutation('unrelated'),
+            [],
+            'CHANGE',
+        );
+
+        self::assertSame([
+            ['id' => 30, 'parent_code' => 'c'],
+            ['id' => 10, 'parent_code' => 'aa'],
+        ], $after->get('children'));
+    }
+
+    public function testIdentityTransitionSkipsIncompleteChangeAndProcessesFollowingChange(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [['id' => 1], ['id' => 2]]);
+        $before->set('children', [['id' => 10, 'parent_id' => 1], ['id' => 20, 'parent_id' => 2]]);
+        $after = $before->snapshot();
+        $after->set('parents', [['id' => 1], ['id' => 20]]);
+        $resultRows = [
+            ['id' => 99, '__ztd_original_id' => 1],
+            ['id' => 20, '__ztd_original_id' => 2],
+        ];
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new UpdateMutation('parents', ['id']),
+            $resultRows,
+            'UPDATE',
+        );
+
+        self::assertSame([
+            ['id' => 10, 'parent_id' => 1],
+            ['id' => 20, 'parent_id' => 20],
+        ], $after->get('children'));
+    }
+
+    public function testRetainedOldKeyDoesNotStopFollowingUpdateCascade(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['id', 'code'],
+            ['id' => 'INT', 'code' => 'TEXT'],
+            ['id'],
+            ['id', 'code'],
+            [],
+        ));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_code'],
+            ['id' => 'INT', 'parent_code' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_code'],
+                'parents',
+                ['code'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [
+            ['id' => 1, 'code' => 'a'],
+            ['id' => 2, 'code' => 'a'],
+            ['id' => 3, 'code' => 'b'],
+        ]);
+        $before->set('children', [
+            ['id' => 10, 'parent_code' => 'a'],
+            ['id' => 20, 'parent_code' => 'b'],
+        ]);
+        $after = $before->snapshot();
+        $after->set('parents', [
+            ['id' => 1, 'code' => 'c'],
+            ['id' => 2, 'code' => 'a'],
+            ['id' => 3, 'code' => 'd'],
+        ]);
+        $resultRows = [
+            ['id' => 1, 'code' => 'c', '__ztd_original_id' => 1],
+            ['id' => 3, 'code' => 'd', '__ztd_original_id' => 3],
+        ];
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new UpdateMutation('parents', ['id']),
+            $resultRows,
+            'UPDATE',
+        );
+
+        self::assertSame([
+            ['id' => 10, 'parent_code' => 'a'],
+            ['id' => 20, 'parent_code' => 'd'],
+        ], $after->get('children'));
+    }
+
+    public function testMissingReferencedValuesDoNotStopLaterUpdateOrDeleteCascades(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['id', 'code'],
+            ['id' => 'INT', 'code' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+        ));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_code'],
+            ['id' => 'INT', 'parent_code' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_code'],
+                'parents',
+                ['code'],
+                ReferentialAction::Cascade,
+                ReferentialAction::Cascade,
+            )],
+        ));
+        $beforeUpdate = new ShadowStore();
+        $beforeUpdate->set('parents', [['id' => 1], ['id' => 2, 'code' => 'b']]);
+        $beforeUpdate->set('children', [['id' => 20, 'parent_code' => 'b']]);
+        $afterUpdate = $beforeUpdate->snapshot();
+        $afterUpdate->set('parents', [['id' => 1, 'code' => 'x'], ['id' => 2, 'code' => 'c']]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $beforeUpdate,
+            $afterUpdate,
+            new InsertMutation('unrelated'),
+            [],
+            'UPDATE',
+        );
+
+        self::assertSame([['id' => 20, 'parent_code' => 'c']], $afterUpdate->get('children'));
+
+        $beforeDelete = new ShadowStore();
+        $beforeDelete->set('parents', [['id' => 1], ['id' => 2, 'code' => 'b']]);
+        $beforeDelete->set('children', [['id' => 20, 'parent_code' => 'b']]);
+        $afterDelete = $beforeDelete->snapshot();
+        $afterDelete->set('parents', []);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $beforeDelete,
+            $afterDelete,
+            new InsertMutation('unrelated'),
+            [],
+            'DELETE',
+        );
+
+        self::assertSame([], $afterDelete->get('children'));
+    }
+
+    public function testUpdateCascadeCarriesOriginalRowIntoNextLevel(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $registry->register('grandchildren', new TableDefinition(
+            ['id', 'child_parent_id'],
+            ['id' => 'INT', 'child_parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_child' => new ForeignKeyDefinition(
+                ['child_parent_id'],
+                'children',
+                ['parent_id'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [['id' => 1]]);
+        $before->set('children', [['id' => 10, 'parent_id' => 1]]);
+        $before->set('grandchildren', [['id' => 100, 'child_parent_id' => 1]]);
+        $after = $before->snapshot();
+        $after->set('parents', [['id' => 2]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new UpdateMutation('parents', ['id']),
+            [['id' => 2, '__ztd_original_id' => 1]],
+            'UPDATE',
+        );
+
+        self::assertSame([['id' => 10, 'parent_id' => 2]], $after->get('children'));
+        self::assertSame([['id' => 100, 'child_parent_id' => 2]], $after->get('grandchildren'));
+    }
+
+    public function testDeleteSetNullCarriesOriginalRowIntoNextLevel(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                ReferentialAction::SetNull,
+            )],
+        ));
+        $registry->register('grandchildren', new TableDefinition(
+            ['id', 'child_parent_id'],
+            ['id' => 'INT', 'child_parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_child' => new ForeignKeyDefinition(
+                ['child_parent_id'],
+                'children',
+                ['parent_id'],
+                onUpdate: ReferentialAction::SetNull,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 1]]);
+        $store->set('children', [['id' => 10, 'parent_id' => 1]]);
+        $store->set('grandchildren', [['id' => 100, 'child_parent_id' => 1]]);
+        $before = $store->snapshot();
+        $store->set('parents', []);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $store,
+            new DeleteMutation('parents', ['id']),
+            [['id' => 1]],
+            'DELETE',
+        );
+
+        self::assertSame([['id' => 10, 'parent_id' => null]], $store->get('children'));
+        self::assertSame([['id' => 100, 'child_parent_id' => null]], $store->get('grandchildren'));
+    }
+
+    public function testEmptySelfReferentialCascadeTerminatesWithoutSyntheticEvents(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('nodes', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'nodes',
+                ['id'],
+                ReferentialAction::Cascade,
+            )],
+        ));
+        $before = new ShadowStore();
+        $before->set('nodes', [['id' => 1, 'parent_id' => null], ['id' => 2, 'parent_id' => null]]);
+        $after = $before->snapshot();
+        $after->set('nodes', [['id' => 1, 'parent_id' => null]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new DeleteMutation('nodes', ['id']),
+            [['id' => 2, 'parent_id' => null]],
+            'DELETE',
+        );
+
+        self::assertSame([['id' => 1, 'parent_id' => null]], $after->get('nodes'));
+    }
+
+    public function testSparsePrimaryKeyMetadataIsNormalizedForViolationDetails(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], [3 => 'id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['parent_id'], 'parents', [])],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', []);
+        $store->set('children', [['id' => 1, 'parent_id' => 99]]);
+
+        $this->expectException(ForeignKeyViolationException::class);
+        $this->expectExceptionMessage("referenced row not found in 'parents.id'");
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $store->snapshot(),
+            $store,
+            new InsertMutation('children'),
+            [],
+            'INSERT',
+        );
+    }
+
+    public function testCascadeNormalizesSparseChildRowIndexes(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [['id' => 1]]);
+        $before->set('children', [4 => ['id' => 10, 'parent_id' => 1]]);
+        $after = $before->snapshot();
+        $after->set('parents', [['id' => 2]]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new UpdateMutation('parents', ['id']),
+            [['id' => 2, '__ztd_original_id' => 1]],
+            'UPDATE',
+        );
+
+        self::assertSame([0], array_keys($after->get('children')));
+        self::assertSame([['id' => 10, 'parent_id' => 2]], $after->get('children'));
+    }
+
+    public function testRowsWithMissingPrimaryKeyCannotMatchRowsThatHaveTheKey(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['id', 'code'],
+            ['id' => 'INT', 'code' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [['code' => 'a']]);
+        $after = new ShadowStore();
+        $after->set('parents', [['id' => 1, 'code' => 'a']]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new InsertMutation('unrelated'),
+            [],
+            'CHANGE',
+        );
+
+        self::assertSame([['id' => 1, 'code' => 'a']], $after->get('parents'));
+    }
+
+    public function testFallbackContinuesAfterIdentityMatchedRow(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['id', 'code'],
+            ['id' => 'INT', 'code' => 'TEXT'],
+            ['id'],
+            ['id', 'code'],
+            [],
+        ));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_code'],
+            ['id' => 'INT', 'parent_code' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_code'],
+                'parents',
+                ['code'],
+                onUpdate: ReferentialAction::Cascade,
+            )],
+        ));
+        $before = new ShadowStore();
+        $before->set('parents', [['id' => 1, 'code' => 'a'], ['id' => 2, 'code' => 'b']]);
+        $before->set('children', [['id' => 10, 'parent_code' => 'a'], ['id' => 20, 'parent_code' => 'b']]);
+        $after = $before->snapshot();
+        $after->set('parents', [['id' => 1, 'code' => 'aa'], ['id' => 2, 'code' => 'bb']]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $after,
+            new UpdateMutation('parents', ['id']),
+            [['id' => 1, 'code' => 'aa', '__ztd_original_id' => 1]],
+            'UPDATE',
+        );
+
+        self::assertSame([
+            ['id' => 10, 'parent_code' => 'aa'],
+            ['id' => 20, 'parent_code' => 'bb'],
+        ], $after->get('children'));
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
@@ -20,6 +20,7 @@ use ZtdQuery\Shadow\ReferentialIntegrityEnforcer;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(ReferentialIntegrityEnforcer::class)]
+#[UsesClass(ForeignKeyViolationException::class)]
 #[UsesClass(ForeignKeyDefinition::class)]
 #[UsesClass(TableDefinition::class)]
 #[UsesClass(TableDefinitionRegistry::class)]

--- a/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\ForeignKeyViolationException;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\ReferentialAction;
 use ZtdQuery\Schema\TableDefinition;
@@ -21,6 +22,7 @@ use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(ReferentialIntegrityEnforcer::class)]
 #[UsesClass(ForeignKeyViolationException::class)]
+#[UsesClass(CandidateKeySet::class)]
 #[UsesClass(ForeignKeyDefinition::class)]
 #[UsesClass(TableDefinition::class)]
 #[UsesClass(TableDefinitionRegistry::class)]

--- a/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Simulator/StatementSimulatorTest.php
@@ -16,8 +16,10 @@ use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Schema\CandidateKeySet;
+use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MutationImpact;
+use ZtdQuery\Shadow\ReferentialIntegrityEnforcer;
 use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTransactionManager;
 use ZtdQuery\Simulator\StatementSimulator;
@@ -35,8 +37,10 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(MutationImpact::class)]
 #[UsesClass(CandidateKeySet::class)]
+#[UsesClass(TableDefinitionRegistry::class)]
 #[UsesClass(ShadowStore::class)]
 #[UsesClass(ShadowTransactionManager::class)]
+#[UsesClass(ReferentialIntegrityEnforcer::class)]
 #[UsesClass(Session::class)]
 #[CoversClass(StatementSimulator::class)]
 final class StatementSimulatorTest extends TestCase

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -150,6 +150,7 @@ final class RewriteTarget
             fn (): string => $this->provider->temporaryTableStatement(),
             fn (): string => $this->provider->viewStatement(),
             fn (): string => $this->provider->generatedColumnStatement(),
+            fn (): string => $this->provider->foreignKeyCascadeStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/Mutation/AlterTableMutation.php
+++ b/packages/ztd-query-mysql/src/Mutation/AlterTableMutation.php
@@ -111,6 +111,17 @@ final class AlterTableMutation implements ShadowMutation
             $columnDefs[] = "UNIQUE KEY `{$keyName}` (" . implode(', ', $ukCols) . ')';
         }
 
+        foreach ($definition->foreignKeys as $keyName => $foreignKey) {
+            $columns = array_map(fn (string $column) => "`{$column}`", $foreignKey->columns);
+            $referencedColumns = array_map(
+                fn (string $column) => "`{$column}`",
+                $foreignKey->referencedColumns,
+            );
+            $columnDefs[] = "CONSTRAINT `{$keyName}` FOREIGN KEY (" . implode(', ', $columns)
+                . ") REFERENCES `{$foreignKey->referencedTable}` (" . implode(', ', $referencedColumns) . ')'
+                . " ON DELETE {$foreignKey->onDelete->value} ON UPDATE {$foreignKey->onUpdate->value}";
+        }
+
         return "CREATE TABLE `{$this->tableName}` (" . implode(', ', $columnDefs) . ')';
     }
 

--- a/packages/ztd-query-mysql/src/MySqlForeignKeyDefinitionParser.php
+++ b/packages/ztd-query-mysql/src/MySqlForeignKeyDefinitionParser.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class MySqlForeignKeyDefinitionParser
+{
+    /** @return array<string, ForeignKeyDefinition> */
+    public function parseCreateTable(
+        string $sql,
+    ): array {
+        $dialect = SqlTokenDialect::MySql;
+        $body = $this->tableBody($sql, $dialect);
+        if ($body === null) {
+            return [];
+        }
+
+        $foreignKeys = [];
+        foreach (SqlTokenStream::tokenize($body, $dialect)->splitTopLevel() as $entry) {
+            $stream = SqlTokenStream::tokenize($entry, $dialect);
+            $first = $stream->identifierAt();
+            $firstKeyword = $stream->firstTopLevelKeyword();
+            $inlineColumn = $first !== null && !in_array(
+                $firstKeyword,
+                ['CONSTRAINT', 'FOREIGN', 'PRIMARY', 'UNIQUE', 'CHECK', 'EXCLUDE'],
+                true,
+            ) ? $first['name'] : null;
+            $name = sprintf('foreign_%d', count($foreignKeys));
+            $definition = $this->parseEntry($stream, $name, $inlineColumn);
+            if ($definition === null) {
+                continue;
+            }
+
+            $foreignKeys[$definition['name']] = $definition['foreignKey'];
+        }
+
+        return $foreignKeys;
+    }
+
+    private function tableBody(string $sql, SqlTokenDialect $dialect): ?string
+    {
+        $tokens = SqlTokenStream::tokenize($sql, $dialect)->significantTokens();
+        $first = $tokens[0] ?? null;
+        if ($first === null || !$first->isKeyword('CREATE')) {
+            return null;
+        }
+
+        $tableFound = false;
+        $opening = null;
+        foreach ($tokens as $token) {
+            if (!$token->isTopLevel()) {
+                continue;
+            }
+            if (!$tableFound) {
+                if ($token->isKeyword('TABLE')) {
+                    $tableFound = true;
+                }
+                continue;
+            }
+            if ($opening === null) {
+                if (self::isSymbol($token, '(')) {
+                    $opening = $token;
+                }
+                continue;
+            }
+            if (self::isSymbol($token, ')')) {
+                return substr($sql, $opening->endOffset(), $token->offset - $opening->endOffset());
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{name: string, foreignKey: ForeignKeyDefinition}|null
+     */
+    private function parseEntry(
+        SqlTokenStream $stream,
+        string $defaultName,
+        ?string $inlineColumn,
+    ): ?array {
+        $tokens = $stream->significantTokens();
+        $references = self::keywordIndex($tokens, 'REFERENCES');
+        if ($references === null) {
+            return null;
+        }
+
+        $columns = $inlineColumn !== null
+            ? [$inlineColumn]
+            : $this->foreignKeyColumns($stream, $tokens, $references);
+        if ($columns === []) {
+            return null;
+        }
+
+        $referenced = $this->referencedRelation($stream, $tokens, $references + 1);
+        if ($referenced === null) {
+            return null;
+        }
+
+        $name = $defaultName;
+        if ($tokens[0]->isKeyword('CONSTRAINT')) {
+            $constraint = $stream->identifierAt(1);
+            if ($constraint !== null) {
+                $name = $constraint['name'];
+            }
+        }
+
+        return [
+            'name' => $name,
+            'foreignKey' => new ForeignKeyDefinition(
+                $columns,
+                $referenced['table'],
+                $referenced['columns'],
+                $this->action($tokens, 'DELETE'),
+                $this->action($tokens, 'UPDATE'),
+            ),
+        ];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return list<string>
+     */
+    private function foreignKeyColumns(
+        SqlTokenStream $stream,
+        array $tokens,
+        int $references,
+    ): array {
+        $foreign = self::keywordIndex(array_slice($tokens, 0, $references), 'FOREIGN');
+        if ($foreign === null) {
+            return [];
+        }
+
+        $key = $tokens[$foreign + 1];
+        if (!$key->isKeyword('KEY')) {
+            return [];
+        }
+
+        $opening = $foreign + 2;
+        return $this->identifierList($stream, $tokens, $opening);
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{table: string, columns: list<string>}|null
+     */
+    private function referencedRelation(
+        SqlTokenStream $stream,
+        array $tokens,
+        int $start,
+    ): ?array {
+        $identifier = $stream->identifierAt($start);
+        if ($identifier === null) {
+            return null;
+        }
+
+        $table = $identifier['name'];
+        $next = $identifier['next'];
+        while (self::isSymbol($tokens[$next] ?? null, '.')) {
+            $component = $stream->identifierAt($next + 1);
+            if ($component === null) {
+                return null;
+            }
+            $table = $component['name'];
+            $next = $component['next'];
+        }
+
+        $opening = self::symbolIndex($tokens, '(', $next);
+        $columns = $opening !== null ? $this->identifierList($stream, $tokens, $opening) : [];
+
+        return ['table' => $table, 'columns' => $columns];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return list<string>
+     */
+    private function identifierList(SqlTokenStream $stream, array $tokens, int $opening): array
+    {
+        $depth = $tokens[$opening]->depth;
+        $candidates = array_slice($tokens, $opening);
+        array_shift($candidates);
+        $identifiers = [];
+        $index = $opening;
+        foreach ($candidates as $token) {
+            $index++;
+            if ($token->depth === $depth) {
+                if (self::isSymbol($token, ')')) {
+                    return $identifiers;
+                }
+
+                return [];
+            }
+            if ($token->depth !== $depth + 1) {
+                continue;
+            }
+
+            $identifier = $stream->identifierAt($index);
+            if ($identifier !== null) {
+                $identifiers[] = $identifier['name'];
+            }
+        }
+
+        return [];
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function action(array $tokens, string $event): ReferentialAction
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isTopLevel() || !$token->isKeyword('ON')) {
+                continue;
+            }
+            $eventToken = $tokens[$index + 1] ?? null;
+            if ($eventToken === null || !$eventToken->isKeyword($event)) {
+                continue;
+            }
+
+            $action = $tokens[$index + 2] ?? null;
+            if ($action === null) {
+                return ReferentialAction::NoAction;
+            }
+            if ($action->isKeyword('CASCADE')) {
+                return ReferentialAction::Cascade;
+            }
+            if ($action->isKeyword('RESTRICT')) {
+                return ReferentialAction::Restrict;
+            }
+            if (!$action->isKeyword('SET')) {
+                return ReferentialAction::NoAction;
+            }
+
+            $qualifier = $tokens[$index + 3] ?? null;
+            if ($qualifier === null) {
+                return ReferentialAction::NoAction;
+            }
+            if ($qualifier->isKeyword('NULL')) {
+                return ReferentialAction::SetNull;
+            }
+            if ($qualifier->isKeyword('DEFAULT')) {
+                return ReferentialAction::SetDefault;
+            }
+
+            return ReferentialAction::NoAction;
+        }
+
+        return ReferentialAction::NoAction;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private static function keywordIndex(array $tokens, string $keyword): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isTopLevel() && $token->isKeyword($keyword)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private static function symbolIndex(array $tokens, string $symbol, int $start): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($index >= $start && $token->isTopLevel() && self::isSymbol($token, $symbol)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private static function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        if ($token === null) {
+            return false;
+        }
+
+        return $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlSchemaParser.php
+++ b/packages/ztd-query-mysql/src/MySqlSchemaParser.php
@@ -7,9 +7,11 @@ namespace ZtdQuery\Platform\MySql;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Schema\ForeignKeyDefinitionParser;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Sql\SqlTokenDialect;
 
 /**
  * MySQL implementation of SchemaParser using phpMyAdmin SQL parser.
@@ -53,6 +55,10 @@ final class MySqlSchemaParser implements SchemaParser
         $notNullColumns = [];
         $uniqueConstraints = [];
         $uniqueIndex = 0;
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+            $createTableSql,
+            SqlTokenDialect::MySql,
+        );
 
         foreach ($stmt->fields as $field) {
             $name = $field->name ?? null;
@@ -144,6 +150,7 @@ final class MySqlSchemaParser implements SchemaParser
             $columnDefaults,
             $identityStrategies,
             $generatedExpressions,
+            $foreignKeys,
         );
     }
 

--- a/packages/ztd-query-mysql/src/MySqlSchemaParser.php
+++ b/packages/ztd-query-mysql/src/MySqlSchemaParser.php
@@ -7,11 +7,9 @@ namespace ZtdQuery\Platform\MySql;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
-use ZtdQuery\Schema\ForeignKeyDefinitionParser;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\TableDefinition;
-use ZtdQuery\Sql\SqlTokenDialect;
 
 /**
  * MySQL implementation of SchemaParser using phpMyAdmin SQL parser.
@@ -55,10 +53,7 @@ final class MySqlSchemaParser implements SchemaParser
         $notNullColumns = [];
         $uniqueConstraints = [];
         $uniqueIndex = 0;
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
-            $createTableSql,
-            SqlTokenDialect::MySql,
-        );
+        $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable($createTableSql);
 
         foreach ($stmt->fields as $field) {
             $name = $field->name ?? null;

--- a/packages/ztd-query-mysql/tests/Unit/Mutation/AlterTableMutationTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Mutation/AlterTableMutationTest.php
@@ -47,6 +47,55 @@ final class AlterTableMutationTest extends TestCase
         self::assertContains('email', $newDef->columns);
     }
 
+    public function testApplyAddColumnPreservesForeignKeyMetadata(): void
+    {
+        $schemaParser = new MySqlSchemaParser(new MySqlParser());
+        $registry = new TableDefinitionRegistry();
+        $definition = $schemaParser->parse(
+            'CREATE TABLE children (id INT PRIMARY KEY, parent_id INT, CONSTRAINT fk_parent '
+            . 'FOREIGN KEY (parent_id) REFERENCES parents (id) ON DELETE CASCADE ON UPDATE CASCADE)'
+        );
+        self::assertNotNull($definition);
+        $registry->register('children', $definition);
+        $store = new ShadowStore();
+
+        $parser = new Parser('ALTER TABLE children ADD COLUMN label VARCHAR(255)');
+        $alterStmt = $parser->statements[0];
+        self::assertInstanceOf(AlterStatement::class, $alterStmt);
+        (new AlterTableMutation('children', $alterStmt, $registry, $schemaParser))->apply($store, []);
+
+        $foreignKey = $registry->get('children')?->foreignKeys['fk_parent'] ?? null;
+        self::assertNotNull($foreignKey);
+        self::assertSame(['parent_id'], $foreignKey->columns);
+        self::assertSame(['id'], $foreignKey->referencedColumns);
+        self::assertSame('CASCADE', $foreignKey->onDelete->value);
+        self::assertSame('CASCADE', $foreignKey->onUpdate->value);
+    }
+
+    public function testApplyAddColumnPreservesQuotedForeignKeyIdentifiers(): void
+    {
+        $schemaParser = new MySqlSchemaParser(new MySqlParser());
+        $registry = new TableDefinitionRegistry();
+        $definition = $schemaParser->parse(
+            'CREATE TABLE children (`child id` INT PRIMARY KEY, `parent id` INT, CONSTRAINT `fk parent` '
+            . 'FOREIGN KEY (`parent id`) REFERENCES `parent table` (`parent key`) '
+            . 'ON DELETE CASCADE ON UPDATE CASCADE)'
+        );
+        self::assertNotNull($definition);
+        $registry->register('children', $definition);
+
+        $parser = new Parser('ALTER TABLE children ADD COLUMN label VARCHAR(255)');
+        $alterStmt = $parser->statements[0];
+        self::assertInstanceOf(AlterStatement::class, $alterStmt);
+        (new AlterTableMutation('children', $alterStmt, $registry, $schemaParser))->apply(new ShadowStore(), []);
+
+        $foreignKey = $registry->get('children')?->foreignKeys['fk parent'] ?? null;
+        self::assertNotNull($foreignKey);
+        self::assertSame(['parent id'], $foreignKey->columns);
+        self::assertSame('parent table', $foreignKey->referencedTable);
+        self::assertSame(['parent key'], $foreignKey->referencedColumns);
+    }
+
     public function testApplyAddColumnWithoutColumnKeyword(): void
     {
         $schemaParser = new MySqlSchemaParser(new MySqlParser());

--- a/packages/ztd-query-mysql/tests/Unit/Mutation/AlterTableMutationTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Mutation/AlterTableMutationTest.php
@@ -23,6 +23,7 @@ use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(AlterTableMutation::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 final class AlterTableMutationTest extends TestCase

--- a/packages/ztd-query-mysql/tests/Unit/MySqlForeignKeyDefinitionParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlForeignKeyDefinitionParserTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser;
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(MySqlForeignKeyDefinitionParser::class)]
+#[UsesClass(ForeignKeyDefinition::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class MySqlForeignKeyDefinitionParserTest extends TestCase
+{
+    public function testParsesNamedCompositeConstraintWithoutRegexSubstitution(): void
+    {
+        $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child (id INT, tenant_id INT, parent_id INT, '
+            . 'CONSTRAINT `fk child parent` FOREIGN KEY (tenant_id, parent_id) '
+            . 'REFERENCES app.parents (tenant_id, id) ON UPDATE CASCADE ON DELETE SET NULL)',
+        );
+
+        self::assertSame(['fk child parent'], array_keys($foreignKeys));
+        self::assertSame(['tenant_id', 'parent_id'], $foreignKeys['fk child parent']->columns);
+        self::assertSame('parents', $foreignKeys['fk child parent']->referencedTable);
+        self::assertSame(['tenant_id', 'id'], $foreignKeys['fk child parent']->referencedColumns);
+        self::assertSame(ReferentialAction::SetNull, $foreignKeys['fk child parent']->onDelete);
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['fk child parent']->onUpdate);
+    }
+
+    public function testParsesInlineAndMySqlQuotedReferences(): void
+    {
+        $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE `child` (`id` INT, `parent_id` INT REFERENCES `app`.`parents` (`id`) ON DELETE RESTRICT)',
+        );
+
+        self::assertCount(1, $foreignKeys);
+        $foreignKey = array_values($foreignKeys)[0];
+        self::assertSame(['parent_id'], $foreignKey->columns);
+        self::assertSame('parents', $foreignKey->referencedTable);
+        self::assertSame(['id'], $foreignKey->referencedColumns);
+        self::assertSame(ReferentialAction::Restrict, $foreignKey->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKey->onUpdate);
+    }
+
+    public function testUsesReferencedPrimaryKeyWhenColumnListIsOmitted(): void
+    {
+        $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child (parent_id INTEGER REFERENCES parent ON DELETE CASCADE)',
+        );
+
+        self::assertSame([], array_values($foreignKeys)[0]->referencedColumns);
+        self::assertSame(ReferentialAction::Cascade, array_values($foreignKeys)[0]->onDelete);
+    }
+
+    public function testRejectsStatementsAndMalformedReferencesWithoutTableBody(): void
+    {
+        $parser = new MySqlForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable('CREATE TABLE child AS SELECT 1'));
+        self::assertSame([], $parser->parseCreateTable('CREATE TABLE child (id INT, FOREIGN KEY REFERENCES parent(id))'));
+    }
+
+    public function testParsesEveryActionAndAssignsSequentialSyntheticNames(): void
+    {
+        $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable(
+            'create table child ('
+            . 'id int, '
+            . 'cascade_id int references cascade_parent(id) on delete cascade on update restrict, '
+            . 'default_id int references default_parent(id) on delete set default on update no action, '
+            . 'null_id int references null_parent(id) on delete set null, '
+            . 'foreign key (id, cascade_id) references composite_parent(tenant_id, id) '
+            . 'on delete restrict on update cascade'
+            . ')',
+        );
+
+        self::assertSame(['foreign_0', 'foreign_1', 'foreign_2', 'foreign_3'], array_keys($foreignKeys));
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['foreign_0']->onDelete);
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_0']->onUpdate);
+        self::assertSame(ReferentialAction::SetDefault, $foreignKeys['foreign_1']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_1']->onUpdate);
+        self::assertSame(ReferentialAction::SetNull, $foreignKeys['foreign_2']->onDelete);
+        self::assertSame(['id', 'cascade_id'], $foreignKeys['foreign_3']->columns);
+        self::assertSame(['tenant_id', 'id'], $foreignKeys['foreign_3']->referencedColumns);
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_3']->onDelete);
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['foreign_3']->onUpdate);
+    }
+
+    public function testUsesOnlyCreateTableTopLevelParentheses(): void
+    {
+        $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable(
+            "CREATE TABLE child (id INT, note TEXT DEFAULT '(not structure)', "
+            . 'parent_id INT, FOREIGN KEY (parent_id) REFERENCES parent(id)) ENGINE = fn()',
+        );
+
+        self::assertSame(['foreign_0'], array_keys($foreignKeys));
+        self::assertSame(['parent_id'], $foreignKeys['foreign_0']->columns);
+        self::assertSame('parent', $foreignKeys['foreign_0']->referencedTable);
+        self::assertSame(['id'], $foreignKeys['foreign_0']->referencedColumns);
+    }
+
+    public function testRejectsNonCreateAndMalformedForeignKeyStructures(): void
+    {
+        $parser = new MySqlForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'WRAP (FOREIGN KEY (bad_id) REFERENCES wrong(id)) CREATE TABLE child '
+            . '(parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id) REFERENCES)',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id REFERENCES parent(id))',
+        ));
+    }
+
+    public function testDoesNotTreatOtherCreateStatementParenthesesAsTableBodies(): void
+    {
+        $parser = new MySqlForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE VIEW child AS fn(parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TYPE child AS (parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT), fake_id INT REFERENCES fake_parent(id)',
+        ));
+    }
+
+    public function testMalformedActionsRemainNoActionWithoutTokenLookaheadFailures(): void
+    {
+        $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child ('
+            . 'bare_id INT REFERENCES bare_parent, '
+            . 'on_id INT REFERENCES on_parent(id) ON, '
+            . 'delete_id INT REFERENCES delete_parent(id) ON DELETE, '
+            . 'set_id INT REFERENCES set_parent(id) ON DELETE SET, '
+            . 'unknown_id INT REFERENCES unknown_parent(id) ON DELETE UNKNOWN NULL'
+            . ')',
+        );
+
+        self::assertSame(
+            ['foreign_0', 'foreign_1', 'foreign_2', 'foreign_3', 'foreign_4'],
+            array_keys($foreignKeys),
+        );
+        self::assertSame('bare_parent', $foreignKeys['foreign_0']->referencedTable);
+        self::assertSame([], $foreignKeys['foreign_0']->referencedColumns);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_1']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_2']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_3']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_4']->onDelete);
+    }
+
+    public function testNestedActionTokensCannotOverrideTopLevelAction(): void
+    {
+        $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child ('
+            . 'parent_id INT REFERENCES parent(id) CHECK (ON DELETE CASCADE) ON DELETE RESTRICT'
+            . ')',
+        );
+
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_0']->onDelete);
+    }
+
+    public function testForeignKeyClauseRequiresImmediateKeyAndColumnListTokens(): void
+    {
+        $parser = new MySqlForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN WRONG KEY (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN WRONG (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY id REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY () REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, CONSTRAINT fk REFERENCES parent(id) FOREIGN KEY (id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, CONSTRAINT KEY (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id) REFERENCES parent.)',
+        ));
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlForeignKeyDefinitionParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlForeignKeyDefinitionParserTest.php
@@ -5,18 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser;
-use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\ReferentialAction;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(MySqlForeignKeyDefinitionParser::class)]
-#[UsesClass(ForeignKeyDefinition::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class MySqlForeignKeyDefinitionParserTest extends TestCase
 {
     public function testParsesNamedCompositeConstraintWithoutRegexSubstitution(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlMutationResolverTest.php
@@ -39,6 +39,7 @@ use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(MySqlMutationResolver::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser::class)]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -46,6 +46,7 @@ use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(MySqlRewriter::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlMutationResolver::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser::class)]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
@@ -625,4 +625,20 @@ final class MySqlSchemaParserTest extends SchemaParserContractTest
         self::assertNotNull($definition);
         self::assertSame(['id' => IdentityGenerationStrategy::MaxValue], $definition->identityStrategies);
     }
+
+    public function testParsePreservesCompositeForeignKeyActions(): void
+    {
+        $definition = (new MySqlSchemaParser(new MySqlParser()))->parse(
+            'CREATE TABLE child (tenant_id INT, parent_id INT, CONSTRAINT `fk_parent` '
+            . 'FOREIGN KEY (tenant_id, parent_id) REFERENCES `parents` (tenant_id, id) '
+            . 'ON DELETE CASCADE ON UPDATE CASCADE)'
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame(['fk_parent'], array_keys($definition->foreignKeys));
+        self::assertSame(['tenant_id', 'parent_id'], $definition->foreignKeys['fk_parent']->columns);
+        self::assertSame(['tenant_id', 'id'], $definition->foreignKeys['fk_parent']->referencedColumns);
+        self::assertSame('CASCADE', $definition->foreignKeys['fk_parent']->onDelete->value);
+        self::assertSame('CASCADE', $definition->foreignKeys['fk_parent']->onUpdate->value);
+    }
 }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 
 #[CoversClass(MySqlSchemaParser::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser::class)]
 #[UsesClass(MySqlParser::class)]
 final class MySqlSchemaParserTest extends SchemaParserContractTest
 {

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliForeignKeyCascadeTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliForeignKeyCascadeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
+use ZtdQuery\Adapter\Mysqli\ZtdMysqliException;
+
+#[CoversNothing]
+#[Large]
+final class MysqliForeignKeyCascadeTest extends TestCase
+{
+    public function testForeignKeysValidateAndCascadeUpdatesAndDeletes(): void
+    {
+        [$databaseName, $mysqli] = MySqlContainer::createTestDatabase();
+
+        try {
+            $mysqli->query('CREATE TABLE departments (id INT PRIMARY KEY, name VARCHAR(50)) ENGINE=InnoDB');
+            $mysqli->query('CREATE TABLE employees (id INT PRIMARY KEY, department_id INT, '
+                . 'CONSTRAINT fk_department FOREIGN KEY (department_id) REFERENCES departments (id) '
+                . 'ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB');
+            $mysqli->query('CREATE TABLE tasks (id INT PRIMARY KEY, employee_id INT, '
+                . 'CONSTRAINT fk_employee FOREIGN KEY (employee_id) REFERENCES employees (id) '
+                . 'ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB');
+            $ztdMysqli = ZtdMysqli::fromMysqli($mysqli, null);
+
+            self::assertNotFalse($ztdMysqli->query("INSERT INTO departments VALUES (1, 'Engineering')"));
+            self::assertNotFalse($ztdMysqli->query('INSERT INTO employees VALUES (10, 1)'));
+            self::assertNotFalse($ztdMysqli->query('INSERT INTO tasks VALUES (100, 10)'));
+
+            try {
+                $ztdMysqli->query('INSERT INTO employees VALUES (11, 999)');
+                self::fail('Expected foreign-key validation to reject the orphan row.');
+            } catch (ZtdMysqliException $exception) {
+                self::assertStringContainsString("Foreign key constraint 'fk_department' violated", $exception->getMessage());
+            }
+            $employees = $ztdMysqli->query('SELECT id, department_id FROM employees ORDER BY id');
+            self::assertInstanceOf(\mysqli_result::class, $employees);
+            self::assertSame([['id' => 10, 'department_id' => 1]], $employees->fetch_all(MYSQLI_ASSOC));
+
+            self::assertNotFalse($ztdMysqli->query('UPDATE departments SET id = 2 WHERE id = 1'));
+            self::assertNotFalse($ztdMysqli->query('UPDATE employees SET id = 20 WHERE id = 10'));
+            $task = $ztdMysqli->query('SELECT employee_id FROM tasks WHERE id = 100');
+            self::assertInstanceOf(\mysqli_result::class, $task);
+            self::assertSame([['employee_id' => 20]], $task->fetch_all(MYSQLI_ASSOC));
+
+            self::assertNotFalse($ztdMysqli->query('DELETE FROM departments WHERE id = 2'));
+            $employees = $ztdMysqli->query('SELECT id FROM employees');
+            $tasks = $ztdMysqli->query('SELECT id FROM tasks');
+            self::assertInstanceOf(\mysqli_result::class, $employees);
+            self::assertInstanceOf(\mysqli_result::class, $tasks);
+            self::assertSame([], $employees->fetch_all(MYSQLI_ASSOC));
+            self::assertSame([], $tasks->fetch_all(MYSQLI_ASSOC));
+
+            $physical = $mysqli->query('SELECT '
+                . '(SELECT COUNT(*) FROM departments) + '
+                . '(SELECT COUNT(*) FROM employees) + '
+                . '(SELECT COUNT(*) FROM tasks) AS row_count');
+            self::assertInstanceOf(\mysqli_result::class, $physical);
+            self::assertSame([['row_count' => '0']], $physical->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $mysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/ForeignKeyCascadeTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/ForeignKeyCascadeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+use ZtdQuery\Adapter\Pdo\ZtdPdoException;
+
+/**
+ * @requires extension pdo_mysql
+ * @group integration
+ * @group mysql
+ */
+#[CoversNothing]
+#[Large]
+final class ForeignKeyCascadeTest extends TestCase
+{
+    public function testForeignKeysValidateAndCascadeUpdatesAndDeletes(): void
+    {
+        [$databaseName, $pdo] = MySqlContainer::createTestDatabase();
+
+        try {
+            $pdo->exec('CREATE TABLE departments (id INT PRIMARY KEY, name VARCHAR(50)) ENGINE=InnoDB');
+            $pdo->exec('CREATE TABLE employees (id INT PRIMARY KEY, department_id INT, '
+                . 'CONSTRAINT fk_department FOREIGN KEY (department_id) REFERENCES departments (id) '
+                . 'ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB');
+            $pdo->exec('CREATE TABLE tasks (id INT PRIMARY KEY, employee_id INT, '
+                . 'CONSTRAINT fk_employee FOREIGN KEY (employee_id) REFERENCES employees (id) '
+                . 'ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO departments VALUES (1, 'Engineering')"));
+            self::assertSame(1, $ztdPdo->exec('INSERT INTO employees VALUES (10, 1)'));
+            self::assertSame(1, $ztdPdo->exec('INSERT INTO tasks VALUES (100, 10)'));
+
+            try {
+                $ztdPdo->exec('INSERT INTO employees VALUES (11, 999)');
+                self::fail('Expected foreign-key validation to reject the orphan row.');
+            } catch (ZtdPdoException $exception) {
+                self::assertStringContainsString("Foreign key constraint 'fk_department' violated", $exception->getMessage());
+            }
+            $employees = $ztdPdo->query('SELECT id, department_id FROM employees ORDER BY id');
+            self::assertNotFalse($employees);
+            self::assertSame([['id' => 10, 'department_id' => 1]], $employees->fetchAll());
+
+            self::assertSame(1, $ztdPdo->exec('UPDATE departments SET id = 2 WHERE id = 1'));
+            self::assertSame(1, $ztdPdo->exec('UPDATE employees SET id = 20 WHERE id = 10'));
+            $task = $ztdPdo->query('SELECT employee_id FROM tasks WHERE id = 100');
+            self::assertNotFalse($task);
+            self::assertSame(20, $task->fetchColumn());
+
+            self::assertSame(1, $ztdPdo->exec('DELETE FROM departments WHERE id = 2'));
+            $orphans = $ztdPdo->query('SELECT employees.id FROM employees LEFT JOIN departments '
+                . 'ON employees.department_id = departments.id WHERE departments.id IS NULL');
+            self::assertNotFalse($orphans);
+            self::assertSame([], $orphans->fetchAll());
+            $tasks = $ztdPdo->query('SELECT id FROM tasks');
+            self::assertNotFalse($tasks);
+            self::assertSame([], $tasks->fetchAll());
+
+            $physical = $pdo->query('SELECT (SELECT COUNT(*) FROM departments) '
+                . '+ (SELECT COUNT(*) FROM employees) + (SELECT COUNT(*) FROM tasks)');
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/ForeignKeyCascadeTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/ForeignKeyCascadeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+use ZtdQuery\Adapter\Pdo\ZtdPdoException;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class ForeignKeyCascadeTest extends TestCase
+{
+    public function testForeignKeysValidateAndCascadeUpdatesAndDeletes(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $pdo->exec('CREATE TABLE departments (id INTEGER PRIMARY KEY, name TEXT)');
+            $pdo->exec('CREATE TABLE employees (id INTEGER PRIMARY KEY, department_id INTEGER, '
+                . 'CONSTRAINT fk_department FOREIGN KEY (department_id) REFERENCES departments (id) '
+                . 'ON DELETE CASCADE ON UPDATE CASCADE)');
+            $pdo->exec('CREATE TABLE tasks (id INTEGER PRIMARY KEY, employee_id INTEGER, '
+                . 'CONSTRAINT fk_employee FOREIGN KEY (employee_id) REFERENCES employees (id) '
+                . 'ON DELETE CASCADE ON UPDATE CASCADE)');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO departments VALUES (1, 'Engineering')"));
+            self::assertSame(1, $ztdPdo->exec('INSERT INTO employees VALUES (10, 1)'));
+            self::assertSame(1, $ztdPdo->exec('INSERT INTO tasks VALUES (100, 10)'));
+
+            try {
+                $ztdPdo->exec('INSERT INTO employees VALUES (11, 999)');
+                self::fail('Expected foreign-key validation to reject the orphan row.');
+            } catch (ZtdPdoException $exception) {
+                self::assertStringContainsString("Foreign key constraint 'fk_department' violated", $exception->getMessage());
+            }
+            $employees = $ztdPdo->query('SELECT id, department_id FROM employees ORDER BY id');
+            self::assertNotFalse($employees);
+            self::assertSame([['id' => 10, 'department_id' => 1]], $employees->fetchAll());
+
+            self::assertSame(1, $ztdPdo->exec('UPDATE departments SET id = 2 WHERE id = 1'));
+            self::assertSame(1, $ztdPdo->exec('UPDATE employees SET id = 20 WHERE id = 10'));
+            $task = $ztdPdo->query('SELECT employee_id FROM tasks WHERE id = 100');
+            self::assertNotFalse($task);
+            self::assertSame(20, $task->fetchColumn());
+
+            self::assertSame(1, $ztdPdo->exec('DELETE FROM departments WHERE id = 2'));
+            $orphans = $ztdPdo->query('SELECT employees.id FROM employees LEFT JOIN departments '
+                . 'ON employees.department_id = departments.id WHERE departments.id IS NULL');
+            self::assertNotFalse($orphans);
+            self::assertSame([], $orphans->fetchAll());
+            $tasks = $ztdPdo->query('SELECT id FROM tasks');
+            self::assertNotFalse($tasks);
+            self::assertSame([], $tasks->fetchAll());
+
+            $physical = $pdo->query('SELECT (SELECT COUNT(*) FROM departments) '
+                . '+ (SELECT COUNT(*) FROM employees) + (SELECT COUNT(*) FROM tasks)');
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/ForeignKeyCascadeTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/ForeignKeyCascadeTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+use ZtdQuery\Adapter\Pdo\ZtdPdoException;
+
+/** @requires extension pdo_sqlite */
+#[CoversNothing]
+#[Large]
+final class ForeignKeyCascadeTest extends TestCase
+{
+    public function testForeignKeysValidateAndCascadeUpdatesAndDeletes(): void
+    {
+        $pdo = new \PDO('sqlite::memory:', null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+        $pdo->exec('PRAGMA foreign_keys = ON');
+        $pdo->exec('CREATE TABLE departments (id INTEGER PRIMARY KEY, name TEXT)');
+        $pdo->exec('CREATE TABLE employees (id INTEGER PRIMARY KEY, department_id INTEGER, '
+            . 'CONSTRAINT fk_department FOREIGN KEY (department_id) REFERENCES departments (id) '
+            . 'ON DELETE CASCADE ON UPDATE CASCADE)');
+        $pdo->exec('CREATE TABLE tasks (id INTEGER PRIMARY KEY, employee_id INTEGER, '
+            . 'CONSTRAINT fk_employee FOREIGN KEY (employee_id) REFERENCES employees (id) '
+            . 'ON DELETE CASCADE ON UPDATE CASCADE)');
+        $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+        self::assertSame(1, $ztdPdo->exec("INSERT INTO departments VALUES (1, 'Engineering')"));
+        self::assertSame(1, $ztdPdo->exec('INSERT INTO employees VALUES (10, 1)'));
+        self::assertSame(1, $ztdPdo->exec('INSERT INTO tasks VALUES (100, 10)'));
+
+        try {
+            $ztdPdo->exec('INSERT INTO employees VALUES (11, 999)');
+            self::fail('Expected foreign-key validation to reject the orphan row.');
+        } catch (ZtdPdoException $exception) {
+            self::assertStringContainsString("Foreign key constraint 'fk_department' violated", $exception->getMessage());
+        }
+        $employees = $ztdPdo->query('SELECT id, department_id FROM employees ORDER BY id');
+        self::assertNotFalse($employees);
+        self::assertSame([['id' => 10, 'department_id' => 1]], $employees->fetchAll());
+
+        self::assertSame(1, $ztdPdo->exec('UPDATE departments SET id = 2 WHERE id = 1'));
+        self::assertSame(1, $ztdPdo->exec('UPDATE employees SET id = 20 WHERE id = 10'));
+        $task = $ztdPdo->query('SELECT employee_id FROM tasks WHERE id = 100');
+        self::assertNotFalse($task);
+        self::assertSame(20, $task->fetchColumn());
+
+        self::assertSame(1, $ztdPdo->exec('DELETE FROM departments WHERE id = 2'));
+        $orphans = $ztdPdo->query('SELECT employees.id FROM employees LEFT JOIN departments '
+            . 'ON employees.department_id = departments.id WHERE departments.id IS NULL');
+        self::assertNotFalse($orphans);
+        self::assertSame([], $orphans->fetchAll());
+        $tasks = $ztdPdo->query('SELECT id FROM tasks');
+        self::assertNotFalse($tasks);
+        self::assertSame([], $tasks->fetchAll());
+
+        $physical = $pdo->query('SELECT (SELECT COUNT(*) FROM departments) '
+            . '+ (SELECT COUNT(*) FROM employees) + (SELECT COUNT(*) FROM tasks)');
+        self::assertNotFalse($physical);
+        self::assertSame(0, (int) $physical->fetchColumn());
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -138,6 +138,7 @@ final class RewriteTarget
             fn (): string => $this->provider->temporaryTableStatement(),
             fn (): string => $this->provider->viewStatement(),
             fn (): string => $this->provider->generatedColumnStatement(),
+            fn (): string => $this->provider->foreignKeyCascadeStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlForeignKeyDefinitionParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlForeignKeyDefinitionParser.php
@@ -2,20 +2,22 @@
 
 declare(strict_types=1);
 
-namespace ZtdQuery\Schema;
+namespace ZtdQuery\Platform\Postgres;
 
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
 use ZtdQuery\Sql\SqlToken;
 use ZtdQuery\Sql\SqlTokenDialect;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
-final class ForeignKeyDefinitionParser
+final class PgSqlForeignKeyDefinitionParser
 {
     /** @return array<string, ForeignKeyDefinition> */
     public function parseCreateTable(
         string $sql,
-        SqlTokenDialect $dialect = SqlTokenDialect::Standard,
     ): array {
+        $dialect = SqlTokenDialect::Standard;
         $body = $this->tableBody($sql, $dialect);
         if ($body === null) {
             return [];

--- a/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
@@ -6,7 +6,6 @@ namespace ZtdQuery\Platform\Postgres;
 
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
-use ZtdQuery\Schema\ForeignKeyDefinitionParser;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\TableDefinition;
@@ -43,7 +42,7 @@ final class PgSqlSchemaParser implements SchemaParser
         /** @var array<string, list<string>> $uniqueConstraints */
         $uniqueConstraints = [];
         $uniqueIndex = 0;
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable($createTableSql);
+        $foreignKeys = (new PgSqlForeignKeyDefinitionParser())->parseCreateTable($createTableSql);
 
         $entries = $this->splitTableBody($body);
 

--- a/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Postgres;
 
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Schema\ForeignKeyDefinitionParser;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\TableDefinition;
@@ -42,6 +43,7 @@ final class PgSqlSchemaParser implements SchemaParser
         /** @var array<string, list<string>> $uniqueConstraints */
         $uniqueConstraints = [];
         $uniqueIndex = 0;
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable($createTableSql);
 
         $entries = $this->splitTableBody($body);
 
@@ -114,6 +116,7 @@ final class PgSqlSchemaParser implements SchemaParser
             $columnDefaults,
             $identityStrategies,
             $generatedExpressions,
+            $foreignKeys,
         );
     }
 

--- a/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
@@ -159,6 +159,60 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
             }
         }
 
+        $foreignKeyStmt = $this->connection->query(
+            "SELECT fk.constraint_name, fk.column_name, "
+            . "pk.table_name AS foreign_table_name, pk.column_name AS foreign_column_name, "
+            . "rc.update_rule, rc.delete_rule "
+            . "FROM information_schema.referential_constraints rc "
+            . "JOIN information_schema.key_column_usage fk "
+            . "  ON fk.constraint_catalog = rc.constraint_catalog "
+            . "  AND fk.constraint_schema = rc.constraint_schema "
+            . "  AND fk.constraint_name = rc.constraint_name "
+            . "JOIN information_schema.key_column_usage pk "
+            . "  ON pk.constraint_catalog = rc.unique_constraint_catalog "
+            . "  AND pk.constraint_schema = rc.unique_constraint_schema "
+            . "  AND pk.constraint_name = rc.unique_constraint_name "
+            . "  AND pk.ordinal_position = fk.position_in_unique_constraint "
+            . "WHERE fk.table_schema = current_schema() "
+            . "  AND fk.table_name = '" . str_replace("'", "''", $tableName) . "' "
+            . "ORDER BY fk.constraint_name, fk.ordinal_position"
+        );
+
+        /** @var array<string, array{columns: list<string>, table: string, referencedColumns: list<string>, onUpdate: string, onDelete: string}> $foreignKeys */
+        $foreignKeys = [];
+        if ($foreignKeyStmt !== false) {
+            foreach ($foreignKeyStmt->fetchAll() as $foreignKeyRow) {
+                $constraintName = $foreignKeyRow['constraint_name'] ?? null;
+                $columnName = $foreignKeyRow['column_name'] ?? null;
+                $foreignTable = $foreignKeyRow['foreign_table_name'] ?? null;
+                $foreignColumn = $foreignKeyRow['foreign_column_name'] ?? null;
+                $onUpdate = $foreignKeyRow['update_rule'] ?? null;
+                $onDelete = $foreignKeyRow['delete_rule'] ?? null;
+                if (!is_string($constraintName)
+                    || !is_string($columnName)
+                    || !is_string($foreignTable)
+                    || !is_string($foreignColumn)
+                    || !is_string($onUpdate)
+                    || !is_string($onDelete)
+                ) {
+                    continue;
+                }
+                if (!isset($foreignKeys[$constraintName])) {
+                    $foreignKeys[$constraintName] = [
+                        'columns' => ['"' . $columnName . '"'],
+                        'table' => $foreignTable,
+                        'referencedColumns' => ['"' . $foreignColumn . '"'],
+                        'onUpdate' => $onUpdate,
+                        'onDelete' => $onDelete,
+                    ];
+
+                    continue;
+                }
+                $foreignKeys[$constraintName]['columns'][] = '"' . $columnName . '"';
+                $foreignKeys[$constraintName]['referencedColumns'][] = '"' . $foreignColumn . '"';
+            }
+        }
+
         $parts = $columnDefs;
 
         if ($primaryKeyCols !== []) {
@@ -167,6 +221,14 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
 
         foreach ($uniqueConstraints as $constraintName => $constraintCols) {
             $parts[] = 'CONSTRAINT "' . $constraintName . '" UNIQUE (' . implode(', ', $constraintCols) . ')';
+        }
+
+        foreach ($foreignKeys as $constraintName => $foreignKey) {
+            $parts[] = 'CONSTRAINT "' . $constraintName . '" FOREIGN KEY ('
+                . implode(', ', $foreignKey['columns']) . ') REFERENCES "'
+                . $foreignKey['table'] . '" (' . implode(', ', $foreignKey['referencedColumns']) . ')'
+                . ' ON UPDATE ' . $foreignKey['onUpdate']
+                . ' ON DELETE ' . $foreignKey['onDelete'];
         }
 
         return 'CREATE TABLE "' . $tableName . '" (' . "\n  " . implode(",\n  ", $parts) . "\n)";

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlForeignKeyDefinitionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlForeignKeyDefinitionParserTest.php
@@ -5,18 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser;
-use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\ReferentialAction;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(PgSqlForeignKeyDefinitionParser::class)]
-#[UsesClass(ForeignKeyDefinition::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class PgSqlForeignKeyDefinitionParserTest extends TestCase
 {
     public function testParsesNamedCompositeConstraintWithoutRegexSubstitution(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlForeignKeyDefinitionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlForeignKeyDefinitionParserTest.php
@@ -2,27 +2,26 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Schema;
+namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
-use ZtdQuery\Schema\ForeignKeyDefinitionParser;
+use ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser;
 use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\ReferentialAction;
-use ZtdQuery\Sql\SqlTokenDialect;
 use ZtdQuery\Sql\SqlToken;
 use ZtdQuery\Sql\SqlTokenStream;
 
-#[CoversClass(ForeignKeyDefinitionParser::class)]
+#[CoversClass(PgSqlForeignKeyDefinitionParser::class)]
 #[UsesClass(ForeignKeyDefinition::class)]
 #[UsesClass(SqlToken::class)]
 #[UsesClass(SqlTokenStream::class)]
-final class ForeignKeyDefinitionParserTest extends TestCase
+final class PgSqlForeignKeyDefinitionParserTest extends TestCase
 {
     public function testParsesNamedCompositeConstraintWithoutRegexSubstitution(): void
     {
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+        $foreignKeys = (new PgSqlForeignKeyDefinitionParser())->parseCreateTable(
             'CREATE TABLE child (id INT, tenant_id INT, parent_id INT, '
             . 'CONSTRAINT "fk child parent" FOREIGN KEY (tenant_id, parent_id) '
             . 'REFERENCES app.parents (tenant_id, id) ON UPDATE CASCADE ON DELETE SET NULL)',
@@ -36,11 +35,10 @@ final class ForeignKeyDefinitionParserTest extends TestCase
         self::assertSame(ReferentialAction::Cascade, $foreignKeys['fk child parent']->onUpdate);
     }
 
-    public function testParsesInlineAndMySqlQuotedReferences(): void
+    public function testParsesInlineAndPostgreSqlQuotedReferences(): void
     {
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
-            'CREATE TABLE `child` (`id` INT, `parent_id` INT REFERENCES `app`.`parents` (`id`) ON DELETE RESTRICT)',
-            SqlTokenDialect::MySql,
+        $foreignKeys = (new PgSqlForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE "child" ("id" INT, "parent_id" INT REFERENCES "app"."parents" ("id") ON DELETE RESTRICT)',
         );
 
         self::assertCount(1, $foreignKeys);
@@ -54,7 +52,7 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testUsesReferencedPrimaryKeyWhenColumnListIsOmitted(): void
     {
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+        $foreignKeys = (new PgSqlForeignKeyDefinitionParser())->parseCreateTable(
             'CREATE TABLE child (parent_id INTEGER REFERENCES parent ON DELETE CASCADE)',
         );
 
@@ -64,7 +62,7 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testRejectsStatementsAndMalformedReferencesWithoutTableBody(): void
     {
-        $parser = new ForeignKeyDefinitionParser();
+        $parser = new PgSqlForeignKeyDefinitionParser();
 
         self::assertSame([], $parser->parseCreateTable('CREATE TABLE child AS SELECT 1'));
         self::assertSame([], $parser->parseCreateTable('CREATE TABLE child (id INT, FOREIGN KEY REFERENCES parent(id))'));
@@ -72,7 +70,7 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testParsesEveryActionAndAssignsSequentialSyntheticNames(): void
     {
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+        $foreignKeys = (new PgSqlForeignKeyDefinitionParser())->parseCreateTable(
             'create table child ('
             . 'id int, '
             . 'cascade_id int references cascade_parent(id) on delete cascade on update restrict, '
@@ -97,10 +95,9 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testUsesOnlyCreateTableTopLevelParentheses(): void
     {
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+        $foreignKeys = (new PgSqlForeignKeyDefinitionParser())->parseCreateTable(
             "CREATE TABLE child (id INT, note TEXT DEFAULT '(not structure)', "
-            . 'parent_id INT, FOREIGN KEY (parent_id) REFERENCES parent(id)) ENGINE = fn()',
-            SqlTokenDialect::MySql,
+            . 'parent_id INT, FOREIGN KEY (parent_id) REFERENCES parent(id)) WITH (fillfactor = 80)',
         );
 
         self::assertSame(['foreign_0'], array_keys($foreignKeys));
@@ -111,7 +108,7 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testRejectsNonCreateAndMalformedForeignKeyStructures(): void
     {
-        $parser = new ForeignKeyDefinitionParser();
+        $parser = new PgSqlForeignKeyDefinitionParser();
 
         self::assertSame([], $parser->parseCreateTable(
             'WRAP (FOREIGN KEY (bad_id) REFERENCES wrong(id)) CREATE TABLE child '
@@ -130,7 +127,7 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testDoesNotTreatOtherCreateStatementParenthesesAsTableBodies(): void
     {
-        $parser = new ForeignKeyDefinitionParser();
+        $parser = new PgSqlForeignKeyDefinitionParser();
 
         self::assertSame([], $parser->parseCreateTable(
             'CREATE VIEW child AS fn(parent_id INT REFERENCES parent(id))',
@@ -145,7 +142,7 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testMalformedActionsRemainNoActionWithoutTokenLookaheadFailures(): void
     {
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+        $foreignKeys = (new PgSqlForeignKeyDefinitionParser())->parseCreateTable(
             'CREATE TABLE child ('
             . 'bare_id INT REFERENCES bare_parent, '
             . 'on_id INT REFERENCES on_parent(id) ON, '
@@ -169,7 +166,7 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testNestedActionTokensCannotOverrideTopLevelAction(): void
     {
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable(
+        $foreignKeys = (new PgSqlForeignKeyDefinitionParser())->parseCreateTable(
             'CREATE TABLE child ('
             . 'parent_id INT REFERENCES parent(id) CHECK (ON DELETE CASCADE) ON DELETE RESTRICT'
             . ')',
@@ -180,7 +177,7 @@ final class ForeignKeyDefinitionParserTest extends TestCase
 
     public function testForeignKeyClauseRequiresImmediateKeyAndColumnListTokens(): void
     {
-        $parser = new ForeignKeyDefinitionParser();
+        $parser = new PgSqlForeignKeyDefinitionParser();
 
         self::assertSame([], $parser->parseCreateTable(
             'CREATE TABLE child (id INT, FOREIGN WRONG KEY (id) REFERENCES parent(id))',

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlMutationResolver::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -42,6 +42,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlRewriter::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
@@ -1673,6 +1673,9 @@ final class PgSqlSchemaParserTest extends SchemaParserContractTest
         $def = $parser->parse('CREATE TABLE t (id INTEGER, foreign key (id) REFERENCES other(id))');
         self::assertNotNull($def);
         self::assertSame(['id'], $def->columns);
+        self::assertCount(1, $def->foreignKeys);
+        self::assertSame('other', array_values($def->foreignKeys)[0]->referencedTable);
+        self::assertSame(['id'], array_values($def->foreignKeys)[0]->columns);
     }
 
     public function testParseColumnWithDefaultContainingParenthesis(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
@@ -10,8 +10,10 @@ use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlSchemaParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser::class)]
 final class PgSqlSchemaParserTest extends SchemaParserContractTest
 {
     protected function createParser(): SchemaParser

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
@@ -1056,9 +1056,11 @@ final class PgSqlSchemaReflectorTest extends TestCase
                     2 => $colStmtA,
                     3 => $emptyStmt,
                     4 => $emptyStmt,
-                    5 => $colStmtB,
-                    6 => $emptyStmt,
+                    5 => $emptyStmt,
+                    6 => $colStmtB,
                     7 => $emptyStmt,
+                    8 => $emptyStmt,
+                    9 => $emptyStmt,
                     default => false,
                 };
             }
@@ -1104,7 +1106,8 @@ final class PgSqlSchemaReflectorTest extends TestCase
                     2 => $colStmtGood,
                     3 => $emptyStmt,
                     4 => $emptyStmt,
-                    5 => $colStmtEmpty,
+                    5 => $emptyStmt,
+                    6 => $colStmtEmpty,
                     default => false,
                 };
             }
@@ -1234,5 +1237,111 @@ final class PgSqlSchemaReflectorTest extends TestCase
         ]));
 
         self::assertSame("CREATE TABLE \"t\" (\n  \"id\" INTEGER\n)", $r->getCreateStatement('t'));
+    }
+
+    public function testForeignKeysAreReconstructedWithCompositeColumnsAndActions(): void
+    {
+        $r = new PgSqlSchemaReflector(new FakeSequentialConnection([
+            new FakeStatement([
+                ['column_name' => 'tenant_id', 'data_type' => 'integer', 'is_nullable' => 'NO', 'udt_name' => 'int4'],
+                ['column_name' => 'parent_id', 'data_type' => 'integer', 'is_nullable' => 'NO', 'udt_name' => 'int4'],
+            ]),
+            new FakeStatement([]),
+            new FakeStatement([]),
+            new FakeStatement([
+                ['constraint_name' => 'fk_parent', 'column_name' => 'tenant_id', 'foreign_table_name' => 'parents', 'foreign_column_name' => 'tenant_id', 'update_rule' => 'CASCADE', 'delete_rule' => 'CASCADE'],
+                ['constraint_name' => 'fk_parent', 'column_name' => 'parent_id', 'foreign_table_name' => 'parents', 'foreign_column_name' => 'id', 'update_rule' => 'CASCADE', 'delete_rule' => 'CASCADE'],
+            ]),
+        ]));
+
+        self::assertSame(
+            "CREATE TABLE \"children\" (\n"
+            . "  \"tenant_id\" INTEGER NOT NULL,\n"
+            . "  \"parent_id\" INTEGER NOT NULL,\n"
+            . "  CONSTRAINT \"fk_parent\" FOREIGN KEY (\"tenant_id\", \"parent_id\") "
+            . "REFERENCES \"parents\" (\"tenant_id\", \"id\") ON UPDATE CASCADE ON DELETE CASCADE\n)",
+            $r->getCreateStatement('children'),
+        );
+    }
+
+    public function testForeignKeyQueryIsExactAndEscapesTableName(): void
+    {
+        $queries = [];
+        $columnStatement = static::createStub(StatementInterface::class);
+        $columnStatement->method('fetchAll')->willReturn([
+            ['column_name' => 'id', 'data_type' => 'integer', 'is_nullable' => 'NO', 'udt_name' => 'int4'],
+        ]);
+        $emptyStatement = static::createStub(StatementInterface::class);
+        $emptyStatement->method('fetchAll')->willReturn([]);
+        $connection = static::createStub(ConnectionInterface::class);
+        $callCount = 0;
+        $connection->method('query')->willReturnCallback(
+            function (string $query) use (&$callCount, &$queries, $columnStatement, $emptyStatement) {
+                $queries[] = $query;
+                $callCount++;
+
+                return $callCount === 1 ? $columnStatement : $emptyStatement;
+            }
+        );
+
+        (new PgSqlSchemaReflector($connection))->getCreateStatement("child'ren");
+
+        self::assertSame(
+            "SELECT fk.constraint_name, fk.column_name, "
+            . "pk.table_name AS foreign_table_name, pk.column_name AS foreign_column_name, "
+            . "rc.update_rule, rc.delete_rule "
+            . "FROM information_schema.referential_constraints rc "
+            . "JOIN information_schema.key_column_usage fk "
+            . "  ON fk.constraint_catalog = rc.constraint_catalog "
+            . "  AND fk.constraint_schema = rc.constraint_schema "
+            . "  AND fk.constraint_name = rc.constraint_name "
+            . "JOIN information_schema.key_column_usage pk "
+            . "  ON pk.constraint_catalog = rc.unique_constraint_catalog "
+            . "  AND pk.constraint_schema = rc.unique_constraint_schema "
+            . "  AND pk.constraint_name = rc.unique_constraint_name "
+            . "  AND pk.ordinal_position = fk.position_in_unique_constraint "
+            . "WHERE fk.table_schema = current_schema() "
+            . "  AND fk.table_name = 'child''ren' "
+            . "ORDER BY fk.constraint_name, fk.ordinal_position",
+            $queries[3],
+        );
+    }
+
+    public function testMalformedForeignKeyRowsAreSkippedIndependently(): void
+    {
+        $valid = [
+            'constraint_name' => 'fk_parent',
+            'column_name' => 'parent_id',
+            'foreign_table_name' => 'parents',
+            'foreign_column_name' => 'id',
+            'update_rule' => 'CASCADE',
+            'delete_rule' => 'CASCADE',
+        ];
+        $rows = [
+            array_replace($valid, ['constraint_name' => null]),
+            array_replace($valid, ['column_name' => null]),
+            array_replace($valid, ['foreign_table_name' => null]),
+            array_replace($valid, ['foreign_column_name' => null]),
+            array_replace($valid, ['update_rule' => null]),
+            array_replace($valid, ['delete_rule' => null]),
+            $valid,
+        ];
+
+        $r = new PgSqlSchemaReflector(new FakeSequentialConnection([
+            new FakeStatement([
+                ['column_name' => 'parent_id', 'data_type' => 'integer', 'is_nullable' => 'NO', 'udt_name' => 'int4'],
+            ]),
+            new FakeStatement([]),
+            new FakeStatement([]),
+            new FakeStatement($rows),
+        ]));
+
+        self::assertSame(
+            "CREATE TABLE \"children\" (\n"
+            . "  \"parent_id\" INTEGER NOT NULL,\n"
+            . "  CONSTRAINT \"fk_parent\" FOREIGN KEY (\"parent_id\") "
+            . "REFERENCES \"parents\" (\"id\") ON UPDATE CASCADE ON DELETE CASCADE\n)",
+            $r->getCreateStatement('children'),
+        );
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -27,6 +27,7 @@ use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 
 #[CoversClass(PgSqlSessionFactory::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
@@ -135,6 +135,7 @@ final class RewriteTarget
             fn (): string => $this->provider->temporaryTableStatement(),
             fn (): string => $this->provider->viewStatement(),
             fn (): string => $this->provider->generatedColumnStatement(),
+            fn (): string => $this->provider->foreignKeyCascadeStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-sqlite/src/SqliteForeignKeyDefinitionParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteForeignKeyDefinitionParser.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class SqliteForeignKeyDefinitionParser
+{
+    /** @return array<string, ForeignKeyDefinition> */
+    public function parseCreateTable(
+        string $sql,
+    ): array {
+        $dialect = SqlTokenDialect::Standard;
+        $body = $this->tableBody($sql, $dialect);
+        if ($body === null) {
+            return [];
+        }
+
+        $foreignKeys = [];
+        foreach (SqlTokenStream::tokenize($body, $dialect)->splitTopLevel() as $entry) {
+            $stream = SqlTokenStream::tokenize($entry, $dialect);
+            $first = $stream->identifierAt();
+            $firstKeyword = $stream->firstTopLevelKeyword();
+            $inlineColumn = $first !== null && !in_array(
+                $firstKeyword,
+                ['CONSTRAINT', 'FOREIGN', 'PRIMARY', 'UNIQUE', 'CHECK', 'EXCLUDE'],
+                true,
+            ) ? $first['name'] : null;
+            $name = sprintf('foreign_%d', count($foreignKeys));
+            $definition = $this->parseEntry($stream, $name, $inlineColumn);
+            if ($definition === null) {
+                continue;
+            }
+
+            $foreignKeys[$definition['name']] = $definition['foreignKey'];
+        }
+
+        return $foreignKeys;
+    }
+
+    private function tableBody(string $sql, SqlTokenDialect $dialect): ?string
+    {
+        $tokens = SqlTokenStream::tokenize($sql, $dialect)->significantTokens();
+        $first = $tokens[0] ?? null;
+        if ($first === null || !$first->isKeyword('CREATE')) {
+            return null;
+        }
+
+        $tableFound = false;
+        $opening = null;
+        foreach ($tokens as $token) {
+            if (!$token->isTopLevel()) {
+                continue;
+            }
+            if (!$tableFound) {
+                if ($token->isKeyword('TABLE')) {
+                    $tableFound = true;
+                }
+                continue;
+            }
+            if ($opening === null) {
+                if (self::isSymbol($token, '(')) {
+                    $opening = $token;
+                }
+                continue;
+            }
+            if (self::isSymbol($token, ')')) {
+                return substr($sql, $opening->endOffset(), $token->offset - $opening->endOffset());
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{name: string, foreignKey: ForeignKeyDefinition}|null
+     */
+    private function parseEntry(
+        SqlTokenStream $stream,
+        string $defaultName,
+        ?string $inlineColumn,
+    ): ?array {
+        $tokens = $stream->significantTokens();
+        $references = self::keywordIndex($tokens, 'REFERENCES');
+        if ($references === null) {
+            return null;
+        }
+
+        $columns = $inlineColumn !== null
+            ? [$inlineColumn]
+            : $this->foreignKeyColumns($stream, $tokens, $references);
+        if ($columns === []) {
+            return null;
+        }
+
+        $referenced = $this->referencedRelation($stream, $tokens, $references + 1);
+        if ($referenced === null) {
+            return null;
+        }
+
+        $name = $defaultName;
+        if ($tokens[0]->isKeyword('CONSTRAINT')) {
+            $constraint = $stream->identifierAt(1);
+            if ($constraint !== null) {
+                $name = $constraint['name'];
+            }
+        }
+
+        return [
+            'name' => $name,
+            'foreignKey' => new ForeignKeyDefinition(
+                $columns,
+                $referenced['table'],
+                $referenced['columns'],
+                $this->action($tokens, 'DELETE'),
+                $this->action($tokens, 'UPDATE'),
+            ),
+        ];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return list<string>
+     */
+    private function foreignKeyColumns(
+        SqlTokenStream $stream,
+        array $tokens,
+        int $references,
+    ): array {
+        $foreign = self::keywordIndex(array_slice($tokens, 0, $references), 'FOREIGN');
+        if ($foreign === null) {
+            return [];
+        }
+
+        $key = $tokens[$foreign + 1];
+        if (!$key->isKeyword('KEY')) {
+            return [];
+        }
+
+        $opening = $foreign + 2;
+        return $this->identifierList($stream, $tokens, $opening);
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{table: string, columns: list<string>}|null
+     */
+    private function referencedRelation(
+        SqlTokenStream $stream,
+        array $tokens,
+        int $start,
+    ): ?array {
+        $identifier = $stream->identifierAt($start);
+        if ($identifier === null) {
+            return null;
+        }
+
+        $table = $identifier['name'];
+        $next = $identifier['next'];
+        while (self::isSymbol($tokens[$next] ?? null, '.')) {
+            $component = $stream->identifierAt($next + 1);
+            if ($component === null) {
+                return null;
+            }
+            $table = $component['name'];
+            $next = $component['next'];
+        }
+
+        $opening = self::symbolIndex($tokens, '(', $next);
+        $columns = $opening !== null ? $this->identifierList($stream, $tokens, $opening) : [];
+
+        return ['table' => $table, 'columns' => $columns];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return list<string>
+     */
+    private function identifierList(SqlTokenStream $stream, array $tokens, int $opening): array
+    {
+        $depth = $tokens[$opening]->depth;
+        $candidates = array_slice($tokens, $opening);
+        array_shift($candidates);
+        $identifiers = [];
+        $index = $opening;
+        foreach ($candidates as $token) {
+            $index++;
+            if ($token->depth === $depth) {
+                if (self::isSymbol($token, ')')) {
+                    return $identifiers;
+                }
+
+                return [];
+            }
+            if ($token->depth !== $depth + 1) {
+                continue;
+            }
+
+            $identifier = $stream->identifierAt($index);
+            if ($identifier !== null) {
+                $identifiers[] = $identifier['name'];
+            }
+        }
+
+        return [];
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function action(array $tokens, string $event): ReferentialAction
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isTopLevel() || !$token->isKeyword('ON')) {
+                continue;
+            }
+            $eventToken = $tokens[$index + 1] ?? null;
+            if ($eventToken === null || !$eventToken->isKeyword($event)) {
+                continue;
+            }
+
+            $action = $tokens[$index + 2] ?? null;
+            if ($action === null) {
+                return ReferentialAction::NoAction;
+            }
+            if ($action->isKeyword('CASCADE')) {
+                return ReferentialAction::Cascade;
+            }
+            if ($action->isKeyword('RESTRICT')) {
+                return ReferentialAction::Restrict;
+            }
+            if (!$action->isKeyword('SET')) {
+                return ReferentialAction::NoAction;
+            }
+
+            $qualifier = $tokens[$index + 3] ?? null;
+            if ($qualifier === null) {
+                return ReferentialAction::NoAction;
+            }
+            if ($qualifier->isKeyword('NULL')) {
+                return ReferentialAction::SetNull;
+            }
+            if ($qualifier->isKeyword('DEFAULT')) {
+                return ReferentialAction::SetDefault;
+            }
+
+            return ReferentialAction::NoAction;
+        }
+
+        return ReferentialAction::NoAction;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private static function keywordIndex(array $tokens, string $keyword): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isTopLevel() && $token->isKeyword($keyword)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private static function symbolIndex(array $tokens, string $symbol, int $start): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($index >= $start && $token->isTopLevel() && self::isSymbol($token, $symbol)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private static function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        if ($token === null) {
+            return false;
+        }
+
+        return $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
+++ b/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
@@ -11,6 +11,7 @@ use ZtdQuery\Exception\ColumnNotFoundException;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Platform\Sqlite\Mutation\AlterTableMutation;
+use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
@@ -279,6 +280,14 @@ final class SqliteMutationResolver
             throw new ColumnAlreadyExistsException($sql, $tableName, $columnName);
         }
 
+        $foreignKeys = $existing->foreignKeys;
+        foreach ($added->foreignKeys as $name => $foreignKey) {
+            while (isset($foreignKeys[$name])) {
+                $name .= '_added';
+            }
+            $foreignKeys[$name] = $foreignKey;
+        }
+
         $definition = new TableDefinition(
             [...$existing->columns, $columnName],
             array_merge($existing->columnTypes, $added->columnTypes),
@@ -289,6 +298,7 @@ final class SqliteMutationResolver
             array_merge($existing->columnDefaults, $added->columnDefaults),
             $existing->identityStrategies,
             array_merge($existing->generatedExpressions, $added->generatedExpressions),
+            $foreignKeys,
         );
         $projection = $this->quotedColumns($existing->columns);
         $projection[] = ($added->columnDefaults[$columnName] ?? 'NULL')
@@ -316,6 +326,14 @@ final class SqliteMutationResolver
         $newDefaults = self::withoutMapKey($existing->columnDefaults, $columnName);
         $newIdentityStrategies = self::withoutMapKey($existing->identityStrategies, $columnName);
         $newGeneratedExpressions = self::withoutMapKey($existing->generatedExpressions, $columnName);
+        $newForeignKeys = array_filter(
+            $existing->foreignKeys,
+            static fn (\ZtdQuery\Schema\ForeignKeyDefinition $foreignKey): bool => !in_array(
+                $columnName,
+                $foreignKey->columns,
+                true,
+            ),
+        );
         $newNotNull = self::withoutColumn($existing->notNullColumns, $columnName);
         $newPrimaryKeys = self::withoutColumn($existing->primaryKeys, $columnName);
         $newUniqueConstraints = [];
@@ -336,6 +354,7 @@ final class SqliteMutationResolver
             $newDefaults,
             $newIdentityStrategies,
             $newGeneratedExpressions,
+            $newForeignKeys,
         );
 
         return $this->alterMutation(
@@ -399,6 +418,14 @@ final class SqliteMutationResolver
             self::renamedMapKey($existing->columnDefaults, $oldName, $newName),
             self::renamedMapKey($existing->identityStrategies, $oldName, $newName),
             self::renamedMapKey($existing->generatedExpressions, $oldName, $newName),
+            array_map(
+                static fn (ForeignKeyDefinition $foreignKey): ForeignKeyDefinition => self::renamedForeignKey(
+                    $foreignKey,
+                    $oldName,
+                    $newName,
+                ),
+                $existing->foreignKeys,
+            ),
         );
         $projection = [];
         foreach ($existing->columns as $column) {
@@ -623,6 +650,25 @@ final class SqliteMutationResolver
         }
 
         return $renamed;
+    }
+
+    private static function renamedForeignKey(
+        ForeignKeyDefinition $foreignKey,
+        string $old,
+        string $new,
+    ): ForeignKeyDefinition {
+        $columns = self::renamedColumns($foreignKey->columns, $old, $new);
+        if ($columns === []) {
+            return $foreignKey;
+        }
+
+        return new ForeignKeyDefinition(
+            $columns,
+            $foreignKey->referencedTable,
+            $foreignKey->referencedColumns,
+            $foreignKey->onDelete,
+            $foreignKey->onUpdate,
+        );
     }
 
     /**

--- a/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
@@ -6,7 +6,6 @@ namespace ZtdQuery\Platform\Sqlite;
 
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
-use ZtdQuery\Schema\ForeignKeyDefinitionParser;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\TableDefinition;
@@ -41,7 +40,7 @@ final class SqliteSchemaParser implements SchemaParser
         $columnDefaults = [];
         $generatedExpressions = [];
         $uniqueIndex = 0;
-        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable($createTableSql);
+        $foreignKeys = (new SqliteForeignKeyDefinitionParser())->parseCreateTable($createTableSql);
 
         $definitions = $this->splitColumnDefinitions($body);
 

--- a/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Sqlite;
 
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Schema\ForeignKeyDefinitionParser;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\TableDefinition;
@@ -40,6 +41,7 @@ final class SqliteSchemaParser implements SchemaParser
         $columnDefaults = [];
         $generatedExpressions = [];
         $uniqueIndex = 0;
+        $foreignKeys = (new ForeignKeyDefinitionParser())->parseCreateTable($createTableSql);
 
         $definitions = $this->splitColumnDefinitions($body);
 
@@ -168,6 +170,7 @@ final class SqliteSchemaParser implements SchemaParser
             $columnDefaults,
             $identityStrategies,
             $generatedExpressions,
+            $foreignKeys,
         );
     }
 

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteForeignKeyDefinitionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteForeignKeyDefinitionParserTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteForeignKeyDefinitionParser;
+use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\ReferentialAction;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(SqliteForeignKeyDefinitionParser::class)]
+#[UsesClass(ForeignKeyDefinition::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class SqliteForeignKeyDefinitionParserTest extends TestCase
+{
+    public function testParsesNamedCompositeConstraintWithoutRegexSubstitution(): void
+    {
+        $foreignKeys = (new SqliteForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child (id INT, tenant_id INT, parent_id INT, '
+            . 'CONSTRAINT "fk child parent" FOREIGN KEY (tenant_id, parent_id) '
+            . 'REFERENCES app.parents (tenant_id, id) ON UPDATE CASCADE ON DELETE SET NULL)',
+        );
+
+        self::assertSame(['fk child parent'], array_keys($foreignKeys));
+        self::assertSame(['tenant_id', 'parent_id'], $foreignKeys['fk child parent']->columns);
+        self::assertSame('parents', $foreignKeys['fk child parent']->referencedTable);
+        self::assertSame(['tenant_id', 'id'], $foreignKeys['fk child parent']->referencedColumns);
+        self::assertSame(ReferentialAction::SetNull, $foreignKeys['fk child parent']->onDelete);
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['fk child parent']->onUpdate);
+    }
+
+    public function testParsesInlineAndSqliteQuotedReferences(): void
+    {
+        $foreignKeys = (new SqliteForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE [child] ([id] INT, [parent_id] INT REFERENCES [app].[parents] ([id]) ON DELETE RESTRICT)',
+        );
+
+        self::assertCount(1, $foreignKeys);
+        $foreignKey = array_values($foreignKeys)[0];
+        self::assertSame(['parent_id'], $foreignKey->columns);
+        self::assertSame('parents', $foreignKey->referencedTable);
+        self::assertSame(['id'], $foreignKey->referencedColumns);
+        self::assertSame(ReferentialAction::Restrict, $foreignKey->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKey->onUpdate);
+    }
+
+    public function testUsesReferencedPrimaryKeyWhenColumnListIsOmitted(): void
+    {
+        $foreignKeys = (new SqliteForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child (parent_id INTEGER REFERENCES parent ON DELETE CASCADE)',
+        );
+
+        self::assertSame([], array_values($foreignKeys)[0]->referencedColumns);
+        self::assertSame(ReferentialAction::Cascade, array_values($foreignKeys)[0]->onDelete);
+    }
+
+    public function testRejectsStatementsAndMalformedReferencesWithoutTableBody(): void
+    {
+        $parser = new SqliteForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable('CREATE TABLE child AS SELECT 1'));
+        self::assertSame([], $parser->parseCreateTable('CREATE TABLE child (id INT, FOREIGN KEY REFERENCES parent(id))'));
+    }
+
+    public function testParsesEveryActionAndAssignsSequentialSyntheticNames(): void
+    {
+        $foreignKeys = (new SqliteForeignKeyDefinitionParser())->parseCreateTable(
+            'create table child ('
+            . 'id int, '
+            . 'cascade_id int references cascade_parent(id) on delete cascade on update restrict, '
+            . 'default_id int references default_parent(id) on delete set default on update no action, '
+            . 'null_id int references null_parent(id) on delete set null, '
+            . 'foreign key (id, cascade_id) references composite_parent(tenant_id, id) '
+            . 'on delete restrict on update cascade'
+            . ')',
+        );
+
+        self::assertSame(['foreign_0', 'foreign_1', 'foreign_2', 'foreign_3'], array_keys($foreignKeys));
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['foreign_0']->onDelete);
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_0']->onUpdate);
+        self::assertSame(ReferentialAction::SetDefault, $foreignKeys['foreign_1']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_1']->onUpdate);
+        self::assertSame(ReferentialAction::SetNull, $foreignKeys['foreign_2']->onDelete);
+        self::assertSame(['id', 'cascade_id'], $foreignKeys['foreign_3']->columns);
+        self::assertSame(['tenant_id', 'id'], $foreignKeys['foreign_3']->referencedColumns);
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_3']->onDelete);
+        self::assertSame(ReferentialAction::Cascade, $foreignKeys['foreign_3']->onUpdate);
+    }
+
+    public function testUsesOnlyCreateTableTopLevelParentheses(): void
+    {
+        $foreignKeys = (new SqliteForeignKeyDefinitionParser())->parseCreateTable(
+            "CREATE TABLE child (id INT, note TEXT DEFAULT '(not structure)', "
+            . 'parent_id INT, FOREIGN KEY (parent_id) REFERENCES parent(id)) WITHOUT ROWID',
+        );
+
+        self::assertSame(['foreign_0'], array_keys($foreignKeys));
+        self::assertSame(['parent_id'], $foreignKeys['foreign_0']->columns);
+        self::assertSame('parent', $foreignKeys['foreign_0']->referencedTable);
+        self::assertSame(['id'], $foreignKeys['foreign_0']->referencedColumns);
+    }
+
+    public function testRejectsNonCreateAndMalformedForeignKeyStructures(): void
+    {
+        $parser = new SqliteForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'WRAP (FOREIGN KEY (bad_id) REFERENCES wrong(id)) CREATE TABLE child '
+            . '(parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id) REFERENCES)',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id REFERENCES parent(id))',
+        ));
+    }
+
+    public function testDoesNotTreatOtherCreateStatementParenthesesAsTableBodies(): void
+    {
+        $parser = new SqliteForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE VIEW child AS fn(parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TYPE child AS (parent_id INT REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT), fake_id INT REFERENCES fake_parent(id)',
+        ));
+    }
+
+    public function testMalformedActionsRemainNoActionWithoutTokenLookaheadFailures(): void
+    {
+        $foreignKeys = (new SqliteForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child ('
+            . 'bare_id INT REFERENCES bare_parent, '
+            . 'on_id INT REFERENCES on_parent(id) ON, '
+            . 'delete_id INT REFERENCES delete_parent(id) ON DELETE, '
+            . 'set_id INT REFERENCES set_parent(id) ON DELETE SET, '
+            . 'unknown_id INT REFERENCES unknown_parent(id) ON DELETE UNKNOWN NULL'
+            . ')',
+        );
+
+        self::assertSame(
+            ['foreign_0', 'foreign_1', 'foreign_2', 'foreign_3', 'foreign_4'],
+            array_keys($foreignKeys),
+        );
+        self::assertSame('bare_parent', $foreignKeys['foreign_0']->referencedTable);
+        self::assertSame([], $foreignKeys['foreign_0']->referencedColumns);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_1']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_2']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_3']->onDelete);
+        self::assertSame(ReferentialAction::NoAction, $foreignKeys['foreign_4']->onDelete);
+    }
+
+    public function testNestedActionTokensCannotOverrideTopLevelAction(): void
+    {
+        $foreignKeys = (new SqliteForeignKeyDefinitionParser())->parseCreateTable(
+            'CREATE TABLE child ('
+            . 'parent_id INT REFERENCES parent(id) CHECK (ON DELETE CASCADE) ON DELETE RESTRICT'
+            . ')',
+        );
+
+        self::assertSame(ReferentialAction::Restrict, $foreignKeys['foreign_0']->onDelete);
+    }
+
+    public function testForeignKeyClauseRequiresImmediateKeyAndColumnListTokens(): void
+    {
+        $parser = new SqliteForeignKeyDefinitionParser();
+
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN WRONG KEY (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN WRONG (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY id REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY () REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, CONSTRAINT fk REFERENCES parent(id) FOREIGN KEY (id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, CONSTRAINT KEY (id) REFERENCES parent(id))',
+        ));
+        self::assertSame([], $parser->parseCreateTable(
+            'CREATE TABLE child (id INT, FOREIGN KEY (id) REFERENCES parent.)',
+        ));
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteForeignKeyDefinitionParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteForeignKeyDefinitionParserTest.php
@@ -5,18 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteForeignKeyDefinitionParser;
-use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\ReferentialAction;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqliteForeignKeyDefinitionParser::class)]
-#[UsesClass(ForeignKeyDefinition::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class SqliteForeignKeyDefinitionParserTest extends TestCase
 {
     public function testParsesNamedCompositeConstraintWithoutRegexSubstitution(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
@@ -37,6 +37,7 @@ use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(SqliteMutationResolver::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteForeignKeyDefinitionParser::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(AlterTableMutation::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteMutationResolverTest.php
@@ -23,6 +23,7 @@ use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
+use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
@@ -261,6 +262,76 @@ final class SqliteMutationResolverTest extends TestCase
             'doubled' => '(source * 2)',
             'tripled' => '(source * 3)',
         ], $registry->get('metrics')?->generatedExpressions);
+    }
+
+    public function testAlterColumnMutationsPreserveRenameAndRemoveForeignKeys(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $registry->register('children', new TableDefinition(
+            ['id', 'old_parent'],
+            ['id' => 'INTEGER', 'old_parent' => 'INTEGER'],
+            ['id'],
+            [],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['old_parent'], 'parents', ['id'])],
+        ));
+        $resolver = new SqliteMutationResolver($store, $registry, new SqliteSchemaParser(), new SqliteParser());
+        $rename = $resolver->resolve(
+            'ALTER TABLE children RENAME COLUMN old_parent TO parent_id',
+            QueryKind::DDL_SIMULATED,
+        );
+
+        self::assertInstanceOf(AlterTableMutation::class, $rename);
+        $rename->apply($store, []);
+        $definition = $registry->get('children');
+        self::assertNotNull($definition);
+        self::assertSame(['parent_id'], $definition->foreignKeys['fk_parent']->columns);
+
+        $add = $resolver->resolve('ALTER TABLE children ADD COLUMN label TEXT', QueryKind::DDL_SIMULATED);
+        self::assertInstanceOf(AlterTableMutation::class, $add);
+        $add->apply($store, []);
+        $definition = $registry->get('children');
+        self::assertNotNull($definition);
+        self::assertArrayHasKey('fk_parent', $definition->foreignKeys);
+
+        $drop = $resolver->resolve('ALTER TABLE children DROP COLUMN parent_id', QueryKind::DDL_SIMULATED);
+        self::assertInstanceOf(AlterTableMutation::class, $drop);
+        $drop->apply($store, []);
+        $definition = $registry->get('children');
+        self::assertNotNull($definition);
+        self::assertSame([], $definition->foreignKeys);
+    }
+
+    public function testAlterAddColumnPreservesExistingAndAddedForeignKeys(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $registry->register('children', new TableDefinition(
+            ['parent_id'],
+            ['parent_id' => 'INTEGER'],
+            [],
+            [],
+            [],
+            foreignKeys: ['foreign_0' => new ForeignKeyDefinition(['parent_id'], 'parents', ['id'])],
+        ));
+        $resolver = new SqliteMutationResolver($store, $registry, new SqliteSchemaParser(), new SqliteParser());
+        $mutation = $resolver->resolve(
+            'ALTER TABLE children ADD COLUMN owner_id INTEGER REFERENCES owners(id) ON DELETE CASCADE',
+            QueryKind::DDL_SIMULATED,
+        );
+
+        self::assertInstanceOf(AlterTableMutation::class, $mutation);
+        $mutation->apply($store, []);
+        $definition = $registry->get('children');
+        self::assertNotNull($definition);
+        $foreignKeys = $definition->foreignKeys;
+        self::assertCount(2, $foreignKeys);
+        self::assertSame(['foreign_0', 'foreign_0_added'], array_keys($foreignKeys));
+        self::assertSame(['parents', 'owners'], array_map(
+            static fn (ForeignKeyDefinition $foreignKey): string => $foreignKey->referencedTable,
+            array_values($foreignKeys),
+        ));
     }
 
     public function testResolveAlterTableDropColumn(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteRewriterTest.php
@@ -43,6 +43,7 @@ use ZtdQuery\Shadow\ShadowStore;
 use ZtdQuery\Shadow\ShadowTableState;
 
 #[CoversClass(SqliteRewriter::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteForeignKeyDefinitionParser::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteUpsertExpressionParser::class)]

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
@@ -16,6 +16,7 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 
 #[CoversClass(SqliteSchemaParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteForeignKeyDefinitionParser::class)]
 #[UsesClass(SqliteLexicalMasker::class)]
 #[UsesClass(SqliteParser::class)]
 final class SqliteSchemaParserTest extends SchemaParserContractTest

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSchemaParserTest.php
@@ -821,6 +821,9 @@ final class SqliteSchemaParserTest extends SchemaParserContractTest
         $result = $parser->parse($sql);
         self::assertNotNull($result);
         self::assertSame(['id', 'uid'], $result->columns);
+        self::assertCount(1, $result->foreignKeys);
+        self::assertSame('users', array_values($result->foreignKeys)[0]->referencedTable);
+        self::assertSame(['uid'], array_values($result->foreignKeys)[0]->columns);
     }
 
     public function testParseLowercaseCheck(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(SqliteSessionFactory::class)]
+#[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteForeignKeyDefinitionParser::class)]
 #[UsesClass(SqliteCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteValueRenderer::class)]
 #[UsesClass(SqliteIdentifierQuoter::class)]


### PR DESCRIPTION
## Summary

- represent foreign-key definitions in shared schema metadata
- enforce referential checks for shadow INSERT and UPDATE operations
- apply ON DELETE and ON UPDATE cascade behavior to shadow tables
- classify every row-changing mutation through the DataMutation type instead of a duplicated runtime class list
- parse CREATE TABLE foreign keys with structural SQL tokens, including malformed-boundary handling without regular expressions
- preserve original row identities across multi-level cascades and normalize sparse metadata/row indexes

## Recurrence prevention

- added parser coverage for non-table CREATE statements, malformed constraints, incomplete actions, nested action tokens, quoted/composite identifiers, and omitted referenced columns
- added referential-integrity coverage for mixed update/delete transitions, partial result identities, retained keys, missing values, sparse indexes, self references, and multi-level update/delete cascades
- added a contract test requiring all nine row-changing mutation types to implement DataMutation

## Validation

- Core PHPUnit: 802 tests, 1397 assertions
- Core lint: PHP-CS-Fixer and PHPStan pass
- Core differential mutation testing against agent/issue-zero-43-generated-columns: 298/298 killed, 100% covered MSI

Closes #126