### PR TITLE
fix(postgres): share shadow rows with child partitions

### DIFF
--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -88,6 +88,15 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function partitionOfStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('CreateStmt', [
+            'CreateStmt' => [ProductionPattern::containing('PARTITION', 'OF', 'PartitionBoundSpec')],
+            'PartitionBoundSpec' => [ProductionPattern::containing('FROM', 'TO')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -441,6 +441,15 @@ final class PostgreSqlProvider extends Base
         return $this->sql->generate(GenerationPlans::foreignKeyCascadeStatement()->withMaxDepth($maxDepth));
     }
 
+    /** @return non-empty-string */
+    public function partitionOfStatement(): string
+    {
+        $child = $this->rsg->rawIdentifier();
+
+        return "CREATE TABLE $child PARTITION OF logs "
+            . "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')";
+    }
+
     /**
      * @template TRequiresNonEmpty of bool
      * @param GenerationPlan<TRequiresNonEmpty> $plan

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -442,12 +442,9 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function partitionOfStatement(): string
+    public function partitionOfStatement(int $maxDepth = 40): string
     {
-        $child = $this->rsg->rawIdentifier();
-
-        return "CREATE TABLE $child PARTITION OF logs "
-            . "FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')";
+        return $this->sql->generate(GenerationPlans::partitionOfStatement()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -100,4 +100,15 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('key_action', 0)?->matches(['CASCADE']) ?? false);
         self::assertTrue($plan->patternAt('key_action', 1)?->matches(['CASCADE']) ?? false);
     }
+
+    public function testChildPartitionPlanRequiresARangeBound(): void
+    {
+        $plan = GenerationPlans::partitionOfStatement();
+
+        self::assertSame('CreateStmt', $plan->startRule());
+        self::assertTrue(
+            $plan->patternAt('CreateStmt', 0)?->matches(['PARTITION', 'OF', 'PartitionBoundSpec']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('PartitionBoundSpec', 0)?->matches(['FROM', 'TO']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -52,15 +52,21 @@ use SqlFaker\Grammar\TerminalInventory;
 #[Medium]
 final class PostgreSqlProviderTest extends TestCase
 {
-    public function testPartitionOfStatementGeneratesRangeChildDdl(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testPartitionOfStatementGeneratesRangeChildDdl(int $seed): void
     {
         $faker = Factory::create();
+        $faker->seed($seed);
         $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->partitionOfStatement();
+        $faker->seed($seed);
 
-        self::assertMatchesRegularExpression(
-            "/^CREATE TABLE [a-zA-Z_][a-zA-Z0-9_]* PARTITION OF logs FOR VALUES FROM \('2024-01-01'\) TO \('2025-01-01'\)$/",
-            $provider->partitionOfStatement(),
-        );
+        $tokens = (new LexicalGrammar($faker, 'pg-17.2', true))->tokenize($sql);
+
+        self::assertSame($sql, $provider->partitionOfStatement(40));
+        self::assertContains('PARTITION', $tokens);
+        self::assertContains('FROM', $tokens);
+        self::assertContains('TO', $tokens);
     }
 
     #[DataProvider('providerTargetedGenerationSeed')]

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -52,6 +52,17 @@ use SqlFaker\Grammar\TerminalInventory;
 #[Medium]
 final class PostgreSqlProviderTest extends TestCase
 {
+    public function testPartitionOfStatementGeneratesRangeChildDdl(): void
+    {
+        $faker = Factory::create();
+        $provider = new PostgreSqlProvider($faker);
+
+        self::assertMatchesRegularExpression(
+            "/^CREATE TABLE [a-zA-Z_][a-zA-Z0-9_]* PARTITION OF logs FOR VALUES FROM \('2024-01-01'\) TO \('2025-01-01'\)$/",
+            $provider->partitionOfStatement(),
+        );
+    }
+
     #[DataProvider('providerTargetedGenerationSeed')]
     public function testInsertFunctionUpsertStatementDerivesFunctionExpressionFromGrammar(int $seed): void
     {

--- a/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
+++ b/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
@@ -27,7 +27,9 @@ interface SqlTransformer
      *     columnDefaults?: array<string, string>,
      *     identityStrategies?: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
      *     generatedExpressions?: array<string, string>,
-     *     partitioning?: \ZtdQuery\Schema\TablePartitioning|null
+     *     partitioning?: \ZtdQuery\Schema\TablePartitioning|null,
+     *     sourceSql?: string,
+     *     storageTable?: string
      * }> $tables Table name => shadow data and column information.
      * @return string The transformed SQL.
      */

--- a/packages/ztd-query-core/src/Schema/TableDefinition.php
+++ b/packages/ztd-query-core/src/Schema/TableDefinition.php
@@ -28,6 +28,10 @@ final class TableDefinition
 
     public readonly ?TablePartitioning $partitioning;
 
+    public readonly ?TablePartitionKey $partitionKey;
+
+    public readonly ?TablePartitionRelation $partitionRelation;
+
     /**
      * @param array<int, string> $columns Column names in declaration order.
      * @param array<string, string> $columnTypes Column name => MySQL type string.
@@ -40,6 +44,8 @@ final class TableDefinition
      * @param array<string, string> $generatedExpressions Column name => database generated expression.
      * @param array<string, ForeignKeyDefinition> $foreignKeys Constraint name => foreign-key definition.
      * @param TablePartitioning|null $partitioning Named partition selection predicates.
+     * @param TablePartitionKey|null $partitionKey Declarative partition key metadata.
+     * @param TablePartitionRelation|null $partitionRelation Parent partition relationship.
      */
     public function __construct(
         public readonly array $columns,
@@ -53,6 +59,8 @@ final class TableDefinition
         array $generatedExpressions = [],
         array $foreignKeys = [],
         ?TablePartitioning $partitioning = null,
+        ?TablePartitionKey $partitionKey = null,
+        ?TablePartitionRelation $partitionRelation = null,
     ) {
         $this->typedColumns = $typedColumns;
         $this->columnDefaults = $columnDefaults;
@@ -60,6 +68,8 @@ final class TableDefinition
         $this->generatedExpressions = $generatedExpressions;
         $this->foreignKeys = $foreignKeys;
         $this->partitioning = $partitioning;
+        $this->partitionKey = $partitionKey;
+        $this->partitionRelation = $partitionRelation;
     }
 
     public function candidateKeys(): CandidateKeySet
@@ -81,6 +91,46 @@ final class TableDefinition
             $this->generatedExpressions,
             $this->foreignKeys,
             $partitioning,
+            $this->partitionKey,
+            $this->partitionRelation,
+        );
+    }
+
+    public function withPartitionKey(?TablePartitionKey $partitionKey): self
+    {
+        return new self(
+            $this->columns,
+            $this->columnTypes,
+            $this->primaryKeys,
+            $this->notNullColumns,
+            $this->uniqueConstraints,
+            $this->typedColumns,
+            $this->columnDefaults,
+            $this->identityStrategies,
+            $this->generatedExpressions,
+            $this->foreignKeys,
+            $this->partitioning,
+            $partitionKey,
+            $this->partitionRelation,
+        );
+    }
+
+    public function withPartitionRelation(?TablePartitionRelation $partitionRelation): self
+    {
+        return new self(
+            $this->columns,
+            $this->columnTypes,
+            $this->primaryKeys,
+            $this->notNullColumns,
+            $this->uniqueConstraints,
+            $this->typedColumns,
+            $this->columnDefaults,
+            $this->identityStrategies,
+            $this->generatedExpressions,
+            $this->foreignKeys,
+            $this->partitioning,
+            $this->partitionKey,
+            $partitionRelation,
         );
     }
 }

--- a/packages/ztd-query-core/src/Schema/TablePartitionKey.php
+++ b/packages/ztd-query-core/src/Schema/TablePartitionKey.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+final class TablePartitionKey
+{
+    /** @param non-empty-list<string> $expressions */
+    public function __construct(
+        public readonly TablePartitionStrategy $strategy,
+        public readonly array $expressions,
+    ) {
+        foreach ($expressions as $expression) {
+            if (trim($expression) === '') {
+                throw new \InvalidArgumentException('Partition key expressions must not be empty.');
+            }
+        }
+    }
+}

--- a/packages/ztd-query-core/src/Schema/TablePartitionRelation.php
+++ b/packages/ztd-query-core/src/Schema/TablePartitionRelation.php
@@ -22,22 +22,4 @@ final class TablePartitionRelation
         $this->parentTable = $parentTable;
         $this->predicate = $predicate;
     }
-
-    /** @param list<string> $siblingPredicates */
-    public function selectionPredicate(array $siblingPredicates): string
-    {
-        if ($this->predicate !== null) {
-            return $this->predicate;
-        }
-        if ($siblingPredicates === []) {
-            return 'TRUE';
-        }
-
-        $predicates = array_map(
-            static fn (string $predicate): string => "($predicate)",
-            $siblingPredicates,
-        );
-
-        return 'COALESCE(NOT (' . implode(' OR ', $predicates) . '), TRUE)';
-    }
 }

--- a/packages/ztd-query-core/src/Schema/TablePartitionRelation.php
+++ b/packages/ztd-query-core/src/Schema/TablePartitionRelation.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+final class TablePartitionRelation
+{
+    public readonly string $parentTable;
+    public readonly ?string $predicate;
+
+    public function __construct(string $parentTable, ?string $predicate)
+    {
+        $parentTable = trim($parentTable);
+        if ($parentTable === '') {
+            throw new \InvalidArgumentException('Partition parent table must not be empty.');
+        }
+        if ($predicate !== null && trim($predicate) === '') {
+            throw new \InvalidArgumentException('Partition predicate must not be empty.');
+        }
+
+        $this->parentTable = $parentTable;
+        $this->predicate = $predicate;
+    }
+
+    /** @param list<string> $siblingPredicates */
+    public function selectionPredicate(array $siblingPredicates): string
+    {
+        if ($this->predicate !== null) {
+            return $this->predicate;
+        }
+        if ($siblingPredicates === []) {
+            return 'TRUE';
+        }
+
+        $predicates = array_map(
+            static fn (string $predicate): string => "($predicate)",
+            $siblingPredicates,
+        );
+
+        return 'COALESCE(NOT (' . implode(' OR ', $predicates) . '), TRUE)';
+    }
+}

--- a/packages/ztd-query-core/src/Schema/TablePartitionStrategy.php
+++ b/packages/ztd-query-core/src/Schema/TablePartitionStrategy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+enum TablePartitionStrategy: string
+{
+    case Range = 'range';
+    case List = 'list';
+    case Hash = 'hash';
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Schema;
 
 use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
@@ -18,6 +19,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[UsesClass(ColumnType::class)]
+#[UsesClass(CandidateKeySet::class)]
 #[UsesClass(ForeignKeyDefinition::class)]
 #[UsesClass(TablePartitioning::class)]
 #[UsesClass(TablePartitionKey::class)]

--- a/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
@@ -11,12 +11,17 @@ use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TablePartitioning;
+use ZtdQuery\Schema\TablePartitionKey;
+use ZtdQuery\Schema\TablePartitionRelation;
+use ZtdQuery\Schema\TablePartitionStrategy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[UsesClass(ColumnType::class)]
 #[UsesClass(ForeignKeyDefinition::class)]
 #[UsesClass(TablePartitioning::class)]
+#[UsesClass(TablePartitionKey::class)]
+#[UsesClass(TablePartitionRelation::class)]
 #[CoversClass(TableDefinition::class)]
 final class TableDefinitionTest extends TestCase
 {
@@ -67,6 +72,8 @@ final class TableDefinitionTest extends TestCase
         self::assertSame([], $definition->generatedExpressions);
         self::assertSame([], $definition->foreignKeys);
         self::assertNull($definition->partitioning);
+        self::assertNull($definition->partitionKey);
+        self::assertNull($definition->partitionRelation);
     }
 
     public function testWithPartitioningPreservesSchemaAndReturnsNewDefinition(): void
@@ -80,5 +87,19 @@ final class TableDefinitionTest extends TestCase
         self::assertSame($definition->columns, $partitioned->columns);
         self::assertSame($definition->primaryKeys, $partitioned->primaryKeys);
         self::assertSame($partitioning, $partitioned->partitioning);
+    }
+
+    public function testPartitionMetadataCopiesPreserveOtherSchemaState(): void
+    {
+        $definition = new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []);
+        $key = new TablePartitionKey(TablePartitionStrategy::Range, ['id']);
+        $relation = new TablePartitionRelation('events', 'id >= 10');
+
+        $partition = $definition->withPartitionKey($key)->withPartitionRelation($relation);
+
+        self::assertSame($key, $partition->partitionKey);
+        self::assertSame($relation, $partition->partitionRelation);
+        self::assertSame($definition->columns, $partition->columns);
+        self::assertSame($definition->candidateKeys()->keys(), $partition->candidateKeys()->keys());
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/TablePartitionKeyTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TablePartitionKeyTest.php
@@ -26,4 +26,11 @@ final class TablePartitionKeyTest extends TestCase
 
         new TablePartitionKey(TablePartitionStrategy::List, ['']);
     }
+
+    public function testRejectsWhitespaceOnlyExpression(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TablePartitionKey(TablePartitionStrategy::List, ['  ']);
+    }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/TablePartitionKeyTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TablePartitionKeyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\TablePartitionKey;
+use ZtdQuery\Schema\TablePartitionStrategy;
+
+#[CoversClass(TablePartitionKey::class)]
+final class TablePartitionKeyTest extends TestCase
+{
+    public function testStoresStrategyAndExpressions(): void
+    {
+        $key = new TablePartitionKey(TablePartitionStrategy::Range, ['created_at', 'id']);
+
+        self::assertSame(TablePartitionStrategy::Range, $key->strategy);
+        self::assertSame(['created_at', 'id'], $key->expressions);
+    }
+
+    public function testRejectsEmptyExpression(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TablePartitionKey(TablePartitionStrategy::List, ['']);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/TablePartitionRelationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TablePartitionRelationTest.php
@@ -16,18 +16,15 @@ final class TablePartitionRelationTest extends TestCase
         $relation = new TablePartitionRelation('events', 'created_at >= DATE \'2024-01-01\'');
 
         self::assertSame('events', $relation->parentTable);
-        self::assertSame('created_at >= DATE \'2024-01-01\'', $relation->selectionPredicate(['FALSE']));
+        self::assertSame('created_at >= DATE \'2024-01-01\'', $relation->predicate);
     }
 
     public function testDefaultPartitionExcludesSpecificSiblingsAndIncludesNull(): void
     {
         $relation = new TablePartitionRelation('events', null);
 
-        self::assertSame(
-            'COALESCE(NOT ((year = 2024) OR (year = 2025)), TRUE)',
-            $relation->selectionPredicate(['year = 2024', 'year = 2025']),
-        );
-        self::assertSame('TRUE', $relation->selectionPredicate([]));
+        self::assertSame('events', $relation->parentTable);
+        self::assertNull($relation->predicate);
     }
 
     public function testRejectsEmptyParentAndPredicate(): void

--- a/packages/ztd-query-core/tests/Unit/Schema/TablePartitionRelationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TablePartitionRelationTest.php
@@ -37,6 +37,13 @@ final class TablePartitionRelationTest extends TestCase
         new TablePartitionRelation('', 'id = 1');
     }
 
+    public function testRejectsWhitespaceOnlyParent(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TablePartitionRelation('  ', 'id = 1');
+    }
+
     public function testRejectsBlankPredicate(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/packages/ztd-query-core/tests/Unit/Schema/TablePartitionRelationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TablePartitionRelationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\TablePartitionRelation;
+
+#[CoversClass(TablePartitionRelation::class)]
+final class TablePartitionRelationTest extends TestCase
+{
+    public function testSpecificPartitionUsesItsPredicate(): void
+    {
+        $relation = new TablePartitionRelation('events', 'created_at >= DATE \'2024-01-01\'');
+
+        self::assertSame('events', $relation->parentTable);
+        self::assertSame('created_at >= DATE \'2024-01-01\'', $relation->selectionPredicate(['FALSE']));
+    }
+
+    public function testDefaultPartitionExcludesSpecificSiblingsAndIncludesNull(): void
+    {
+        $relation = new TablePartitionRelation('events', null);
+
+        self::assertSame(
+            'COALESCE(NOT ((year = 2024) OR (year = 2025)), TRUE)',
+            $relation->selectionPredicate(['year = 2024', 'year = 2025']),
+        );
+        self::assertSame('TRUE', $relation->selectionPredicate([]));
+    }
+
+    public function testRejectsEmptyParentAndPredicate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TablePartitionRelation('', 'id = 1');
+    }
+
+    public function testRejectsBlankPredicate(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TablePartitionRelation('events', ' ');
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/TablePartitionStrategyTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TablePartitionStrategyTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\TablePartitionStrategy;
+
+#[CoversClass(TablePartitionStrategy::class)]
+final class TablePartitionStrategyTest extends TestCase
+{
+    public function testValuesIdentifyStrategies(): void
+    {
+        self::assertSame('range', TablePartitionStrategy::Range->value);
+        self::assertSame('list', TablePartitionStrategy::List->value);
+        self::assertSame('hash', TablePartitionStrategy::Hash->value);
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/PartitionChildTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/PartitionChildTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class PartitionChildTest extends TestCase
+{
+    public function testParentAndChildDmlSharePartitionedShadowRows(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $pdo->exec('CREATE TABLE logs (id INTEGER NOT NULL, log_date DATE NOT NULL, level TEXT NOT NULL, '
+                . 'PRIMARY KEY (id, log_date)) PARTITION BY RANGE (log_date)');
+            $pdo->exec("CREATE TABLE logs_2024 PARTITION OF logs FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')");
+            $pdo->exec("CREATE TABLE logs_2025 PARTITION OF logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')");
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            self::assertSame(2, $ztdPdo->exec(
+                "INSERT INTO logs VALUES (1, '2024-05-01', 'INFO'), (2, '2025-05-01', 'WARN')",
+            ));
+
+            $parent = $ztdPdo->query('SELECT id FROM logs ORDER BY id');
+            self::assertNotFalse($parent);
+            self::assertSame([1, 2], $parent->fetchAll(\PDO::FETCH_COLUMN));
+            $child2024 = $ztdPdo->query('SELECT id FROM logs_2024 ORDER BY id');
+            self::assertNotFalse($child2024);
+            self::assertSame([1], $child2024->fetchAll(\PDO::FETCH_COLUMN));
+            $child2025 = $ztdPdo->query('SELECT id FROM logs_2025 ORDER BY id');
+            self::assertNotFalse($child2025);
+            self::assertSame([2], $child2025->fetchAll(\PDO::FETCH_COLUMN));
+
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO logs_2024 VALUES (3, '2024-09-01', 'DEBUG')"));
+            self::assertSame(1, $ztdPdo->exec("UPDATE logs_2024 SET level = 'NOTICE' WHERE id = 1"));
+            self::assertSame(1, $ztdPdo->exec('DELETE FROM logs_2025 WHERE id = 2'));
+
+            $updated = $ztdPdo->query('SELECT id, level FROM logs ORDER BY id');
+            self::assertNotFalse($updated);
+            self::assertSame(
+                [['id' => 1, 'level' => 'NOTICE'], ['id' => 3, 'level' => 'DEBUG']],
+                $updated->fetchAll(),
+            );
+            $physical = $pdo->query('SELECT COUNT(*) FROM logs');
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
@@ -60,6 +60,7 @@ final class ClassifyTarget
             fn (): string => $this->provider->createTableStatement(maxDepth: 5),
             fn (): string => $this->provider->alterTableStatement(maxDepth: 5),
             fn (): string => $this->provider->dropTableStatement(maxDepth: 3),
+            fn (): string => $this->provider->partitionOfStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -87,6 +87,7 @@ final class RewriteTarget
             'orders' => 'CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, amount NUMERIC(10,2), created_at TIMESTAMP)',
             'order_items' => 'CREATE TABLE order_items (order_id INTEGER NOT NULL, product_id INTEGER NOT NULL, quantity INTEGER NOT NULL DEFAULT 1, PRIMARY KEY (order_id, product_id))',
             'products' => 'CREATE TABLE products (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL, price NUMERIC(10,2), category VARCHAR(100))',
+            'logs' => 'CREATE TABLE logs (id INTEGER NOT NULL, log_date DATE NOT NULL, level TEXT NOT NULL, PRIMARY KEY (id, log_date)) PARTITION BY RANGE (log_date)',
         ];
 
         foreach ($schemas as $tableName => $createSql) {
@@ -117,6 +118,10 @@ final class RewriteTarget
             ['id' => '1', 'name' => 'Widget', 'price' => '19.99', 'category' => 'tools'],
             ['id' => '2', 'name' => 'Gadget', 'price' => '49.99', 'category' => 'electronics'],
         ]);
+        $store->set('logs', [
+            ['id' => '1', 'log_date' => '2024-05-01', 'level' => 'INFO'],
+            ['id' => '2', 'log_date' => '2025-05-01', 'level' => 'WARN'],
+        ]);
     }
 
     /**
@@ -139,6 +144,7 @@ final class RewriteTarget
             fn (): string => $this->provider->viewStatement(),
             fn (): string => $this->provider->generatedColumnStatement(),
             fn (): string => $this->provider->foreignKeyCascadeStatement(),
+            fn (): string => $this->provider->partitionOfStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
@@ -130,6 +130,7 @@ final class RobustnessTarget
             'orders' => 'CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, amount NUMERIC(10,2), created_at TIMESTAMP)',
             'order_items' => 'CREATE TABLE order_items (order_id INTEGER NOT NULL, product_id INTEGER NOT NULL, quantity INTEGER NOT NULL DEFAULT 1, PRIMARY KEY (order_id, product_id))',
             'products' => 'CREATE TABLE products (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL, price NUMERIC(10,2), category VARCHAR(100))',
+            'logs' => 'CREATE TABLE logs (id INTEGER NOT NULL, log_date DATE NOT NULL, level TEXT NOT NULL, PRIMARY KEY (id, log_date)) PARTITION BY RANGE (log_date)',
         ];
 
         foreach ($schemas as $tableName => $createSql) {
@@ -164,6 +165,10 @@ final class RobustnessTarget
                 ['id' => '1', 'name' => 'Widget', 'price' => '19.99', 'category' => 'tools'],
                 ['id' => '2', 'name' => 'Gadget', 'price' => '49.99', 'category' => 'electronics'],
             ],
+            'logs' => [
+                ['id' => '1', 'log_date' => '2024-05-01', 'level' => 'INFO'],
+                ['id' => '2', 'log_date' => '2025-05-01', 'level' => 'WARN'],
+            ],
         ];
     }
 
@@ -183,6 +188,7 @@ final class RobustnessTarget
             fn (): string => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => 'EXPLAIN (FORMAT JSON) SELECT * FROM users',
             fn (): string => 'SELECT * FROM public.users',
+            fn (): string => $this->provider->partitionOfStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -238,8 +238,8 @@ final class PgSqlMutationResolver
     private function storageTable(string $tableName): string
     {
         $seen = [];
-        while (!isset($seen[$tableName])) {
-            $seen[$tableName] = true;
+        while (!in_array($tableName, $seen, true)) {
+            $seen[] = $tableName;
             $parent = $this->registry->get($tableName)?->partitionRelation?->parentTable;
             if ($parent === null) {
                 return $tableName;

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -32,6 +32,7 @@ final class PgSqlMutationResolver
     private TableDefinitionRegistry $registry;
     private SchemaParser $schemaParser;
     private PgSqlParser $parser;
+    private PgSqlPartitionParser $partitionParser;
 
     public function __construct(
         ShadowStore $shadowStore,
@@ -43,6 +44,7 @@ final class PgSqlMutationResolver
         $this->registry = $registry;
         $this->schemaParser = $schemaParser;
         $this->parser = $parser;
+        $this->partitionParser = new PgSqlPartitionParser();
     }
 
     /**
@@ -74,6 +76,7 @@ final class PgSqlMutationResolver
 
         $definition = $this->registry->get($tableName);
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
+        $storageTable = $this->storageTable($tableName);
 
         if ($this->parser->hasOnConflict($sql)) {
             $conflictInfo = $this->parser->extractOnConflictUpdateColumns($sql);
@@ -92,7 +95,7 @@ final class PgSqlMutationResolver
                 $predicate = $this->parser->extractOnConflictUpdateWhere($sql);
 
                 return new UpsertMutation(
-                    $tableName,
+                    $storageTable,
                     $primaryKeys,
                     $updateColumns,
                     $resolvedValues,
@@ -109,7 +112,7 @@ final class PgSqlMutationResolver
             }
 
             return new InsertMutation(
-                $tableName,
+                $storageTable,
                 $primaryKeys,
                 true,
                 candidateKeys: $definition?->candidateKeys(),
@@ -117,7 +120,7 @@ final class PgSqlMutationResolver
         }
 
         return new InsertMutation(
-            $tableName,
+            $storageTable,
             $primaryKeys,
             false,
             candidateKeys: $definition?->candidateKeys(),
@@ -136,10 +139,11 @@ final class PgSqlMutationResolver
             throw new UnknownSchemaException($sql, $targetTable, 'table');
         }
 
-        $this->shadowStore->ensure($targetTable);
+        $storageTable = $this->storageTable($targetTable);
+        $this->shadowStore->ensure($storageTable);
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
-        return new UpdateMutation($targetTable, $primaryKeys);
+        return new UpdateMutation($storageTable, $primaryKeys);
     }
 
     private function resolveDelete(string $sql): ShadowMutation
@@ -154,10 +158,11 @@ final class PgSqlMutationResolver
             throw new UnknownSchemaException($sql, $targetTable, 'table');
         }
 
-        $this->shadowStore->ensure($targetTable);
+        $storageTable = $this->storageTable($targetTable);
+        $this->shadowStore->ensure($storageTable);
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
-        return new DeleteMutation($targetTable, $primaryKeys);
+        return new DeleteMutation($storageTable, $primaryKeys);
     }
 
     private function resolveTruncate(string $sql): ShadowMutation
@@ -186,6 +191,29 @@ final class PgSqlMutationResolver
             throw new UnsupportedSqlException($sql, 'Table already exists');
         }
 
+        $parentTable = $this->partitionParser->parentTable($sql);
+        if ($parentTable !== null) {
+            $parentDefinition = $this->registry->get($parentTable);
+            if ($parentDefinition === null) {
+                throw new UnknownSchemaException($sql, $parentTable, 'table');
+            }
+            if ($parentDefinition->partitionKey === null) {
+                throw new UnsupportedSqlException($sql, 'Partition parent has no partition key metadata');
+            }
+            $relation = $this->partitionParser->parseRelation($sql, $parentDefinition->partitionKey);
+            if ($relation === null) {
+                throw new UnsupportedSqlException($sql, 'Unsupported partition bound');
+            }
+
+            $definition = $parentDefinition->withPartitionRelation($relation);
+            $childKey = $this->partitionParser->parseKey($sql);
+            if ($childKey !== null) {
+                $definition = $definition->withPartitionKey($childKey);
+            }
+
+            return new CreateTableMutation($tableName, $definition, $this->registry, $ifNotExists);
+        }
+
         if ($this->parser->hasCreateTableLike($sql)) {
             $sourceTable = $this->parser->extractCreateTableLikeSource($sql);
             if ($sourceTable === null || !$this->registry->has($sourceTable)) {
@@ -205,6 +233,21 @@ final class PgSqlMutationResolver
         $definition = $this->schemaParser->parse($sql);
 
         return new CreateTableMutation($tableName, $definition, $this->registry, $ifNotExists);
+    }
+
+    private function storageTable(string $tableName): string
+    {
+        $seen = [];
+        while (!isset($seen[$tableName])) {
+            $seen[$tableName] = true;
+            $parent = $this->registry->get($tableName)?->partitionRelation?->parentTable;
+            if ($parent === null) {
+                return $tableName;
+            }
+            $tableName = $parent;
+        }
+
+        return $tableName;
     }
 
     private function resolveDropTable(string $sql): ShadowMutation

--- a/packages/ztd-query-postgres/src/PgSqlPartitionParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlPartitionParser.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Schema\TablePartitionKey;
+use ZtdQuery\Schema\TablePartitionRelation;
+use ZtdQuery\Schema\TablePartitionStrategy;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PgSqlPartitionParser
+{
+    public function parseKey(string $sql): ?TablePartitionKey
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $partition = $this->keywordPairIndex($tokens, 'PARTITION', 'BY');
+        if ($partition === null) {
+            return null;
+        }
+
+        $strategyToken = $tokens[$partition + 2] ?? null;
+        if (!$strategyToken instanceof SqlToken) {
+            return null;
+        }
+        $strategy = match (true) {
+            $strategyToken->isKeyword('RANGE') => TablePartitionStrategy::Range,
+            $strategyToken->isKeyword('LIST') => TablePartitionStrategy::List,
+            $strategyToken->isKeyword('HASH') => TablePartitionStrategy::Hash,
+            default => null,
+        };
+        if ($strategy === null) {
+            return null;
+        }
+
+        $openIndex = $partition + 3;
+        $closeIndex = $this->closingParenthesisIndex($tokens, $openIndex);
+        if ($closeIndex === null) {
+            return null;
+        }
+        $open = $tokens[$openIndex];
+        $close = $tokens[$closeIndex];
+        $body = substr($sql, $open->endOffset(), $close->offset - $open->endOffset());
+        $expressions = SqlTokenStream::tokenize($body)->splitTopLevel();
+        if ($expressions === [] || in_array('', $expressions, true)) {
+            return null;
+        }
+
+        return new TablePartitionKey($strategy, $expressions);
+    }
+
+    public function parentTable(string $sql): ?string
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $partition = $this->keywordPairIndex($tokens, 'PARTITION', 'OF');
+        if ($partition === null) {
+            return null;
+        }
+
+        return $this->identifierAt($tokens, $partition + 2)['name'] ?? null;
+    }
+
+    public function parseRelation(string $sql, TablePartitionKey $parentKey): ?TablePartitionRelation
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $partition = $this->keywordPairIndex($tokens, 'PARTITION', 'OF');
+        if ($partition === null) {
+            return null;
+        }
+        $parent = $this->identifierAt($tokens, $partition + 2);
+        if ($parent === null) {
+            return null;
+        }
+
+        $defaultIndex = $this->keywordIndex($tokens, 'DEFAULT', $parent['next']);
+        $valuesIndex = $this->keywordPairIndex($tokens, 'FOR', 'VALUES', $parent['next']);
+        if ($defaultIndex !== null && ($valuesIndex === null || $defaultIndex < $valuesIndex)) {
+            return new TablePartitionRelation($parent['name'], null);
+        }
+        if ($valuesIndex === null) {
+            return null;
+        }
+
+        $predicate = match ($parentKey->strategy) {
+            TablePartitionStrategy::Range => $this->rangePredicate($sql, $tokens, $valuesIndex + 2, $parentKey),
+            TablePartitionStrategy::List => $this->listPredicate($sql, $tokens, $valuesIndex + 2, $parentKey),
+            TablePartitionStrategy::Hash => null,
+        };
+
+        return $predicate === null ? null : new TablePartitionRelation($parent['name'], $predicate);
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function rangePredicate(string $sql, array $tokens, int $index, TablePartitionKey $key): ?string
+    {
+        $from = $tokens[$index] ?? null;
+        if (!$from instanceof SqlToken || !$from->isKeyword('FROM')) {
+            return null;
+        }
+        $lower = $this->parenthesizedValues($sql, $tokens, $index + 1);
+        if ($lower === null) {
+            return null;
+        }
+
+        $to = $tokens[$lower['next']] ?? null;
+        if (!$to instanceof SqlToken || !$to->isKeyword('TO')) {
+            return null;
+        }
+        $upper = $this->parenthesizedValues($sql, $tokens, $lower['next'] + 1);
+        if ($upper === null) {
+            return null;
+        }
+
+        $lowerPredicate = $this->rangeBoundary($key->expressions, $lower['values'], '>=', 'MINVALUE');
+        $upperPredicate = $this->rangeBoundary($key->expressions, $upper['values'], '<', 'MAXVALUE');
+        if ($lowerPredicate === false || $upperPredicate === false) {
+            return null;
+        }
+
+        $predicates = array_values(array_filter(
+            [$lowerPredicate, $upperPredicate],
+            static fn (string|false|null $predicate): bool => is_string($predicate),
+        ));
+
+        return $predicates === [] ? 'TRUE' : implode(' AND ', $predicates);
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function listPredicate(string $sql, array $tokens, int $index, TablePartitionKey $key): ?string
+    {
+        if (count($key->expressions) !== 1) {
+            return null;
+        }
+        $in = $tokens[$index] ?? null;
+        if (!$in instanceof SqlToken || !$in->isKeyword('IN')) {
+            return null;
+        }
+        $values = $this->parenthesizedValues($sql, $tokens, $index + 1);
+        if ($values === null) {
+            return null;
+        }
+
+        $nonNull = [];
+        $hasNull = false;
+        foreach ($values['values'] as $value) {
+            $valueTokens = SqlTokenStream::tokenize($value)->significantTokens();
+            if (count($valueTokens) === 1 && $valueTokens[0]->isKeyword('NULL')) {
+                $hasNull = true;
+                continue;
+            }
+            $nonNull[] = $value;
+        }
+        if ($nonNull === [] && !$hasNull) {
+            return null;
+        }
+
+        $expression = '(' . $key->expressions[0] . ')';
+        $predicate = $nonNull === [] ? null : $expression . ' IN (' . implode(', ', $nonNull) . ')';
+        if ($hasNull) {
+            $nullPredicate = "$expression IS NULL";
+            $predicate = $predicate === null ? $nullPredicate : "($predicate OR $nullPredicate)";
+        }
+
+        return $predicate;
+    }
+
+    /**
+     * @param non-empty-list<string> $expressions
+     * @param list<string> $values
+     */
+    private function rangeBoundary(array $expressions, array $values, string $operator, string $unbounded): string|false|null
+    {
+        if (count($expressions) !== count($values)) {
+            return false;
+        }
+
+        $special = [];
+        foreach ($values as $value) {
+            $special[] = in_array(strtoupper(trim($value)), ['MINVALUE', 'MAXVALUE'], true);
+        }
+        if (!in_array(false, $special, true)) {
+            foreach ($values as $value) {
+                if (strcasecmp(trim($value), $unbounded) !== 0) {
+                    return false;
+                }
+            }
+
+            return null;
+        }
+        if (in_array(true, $special, true)) {
+            return false;
+        }
+
+        if (count($expressions) === 1) {
+            return '(' . $expressions[0] . ") $operator " . $values[0];
+        }
+
+        return 'ROW(' . implode(', ', $expressions) . ") $operator ROW(" . implode(', ', $values) . ')';
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{values: list<string>, next: int}|null
+     */
+    private function parenthesizedValues(string $sql, array $tokens, int $openIndex): ?array
+    {
+        $closeIndex = $this->closingParenthesisIndex($tokens, $openIndex);
+        if ($closeIndex === null) {
+            return null;
+        }
+        $open = $tokens[$openIndex];
+        $close = $tokens[$closeIndex];
+        $body = substr($sql, $open->endOffset(), $close->offset - $open->endOffset());
+        $values = SqlTokenStream::tokenize($body)->splitTopLevel();
+        if ($values === [] || in_array('', $values, true)) {
+            return null;
+        }
+
+        return ['values' => $values, 'next' => $closeIndex + 1];
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function closingParenthesisIndex(array $tokens, int $openIndex): ?int
+    {
+        $open = $tokens[$openIndex] ?? null;
+        if (!$open instanceof SqlToken || !$this->isSymbol($open, '(')) {
+            return null;
+        }
+        foreach (array_slice($tokens, $openIndex + 1, null, true) as $index => $token) {
+            if ($this->isSymbol($token, ')') && $token->depth === $open->depth) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{name: string, next: int}|null
+     */
+    private function identifierAt(array $tokens, int $index): ?array
+    {
+        $token = $tokens[$index] ?? null;
+        $name = $token instanceof SqlToken ? $this->identifierName($token) : null;
+        if ($name === null) {
+            return null;
+        }
+        $index++;
+
+        while ($this->isSymbol($tokens[$index] ?? null, '.')) {
+            $component = $tokens[$index + 1] ?? null;
+            $componentName = $component instanceof SqlToken ? $this->identifierName($component) : null;
+            if ($componentName === null) {
+                return null;
+            }
+            $name = $componentName;
+            $index += 2;
+        }
+
+        return ['name' => $name, 'next' => $index];
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function keywordPairIndex(array $tokens, string $first, string $second, int $start = 0): ?int
+    {
+        foreach (array_slice($tokens, $start, null, true) as $index => $token) {
+            if ($token->isTopLevel()
+                && $token->isKeyword($first)
+                && ($tokens[$index + 1] ?? null)?->isKeyword($second) === true
+            ) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function keywordIndex(array $tokens, string $keyword, int $start): ?int
+    {
+        foreach (array_slice($tokens, $start, null, true) as $index => $token) {
+            if ($token->isTopLevel() && $token->isKeyword($keyword)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private function identifierName(SqlToken $token): ?string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return strtolower($token->text);
+        }
+        if ($token->kind !== SqlTokenKind::QuotedIdentifier || strlen($token->text) < 2) {
+            return null;
+        }
+
+        return str_replace('""', '"', substr($token->text, 1, -1));
+    }
+
+    private function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        return $token instanceof SqlToken
+            && $token->kind === SqlTokenKind::Symbol
+            && $token->text === $symbol;
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlPartitionParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlPartitionParser.php
@@ -15,7 +15,8 @@ final class PgSqlPartitionParser
 {
     public function parseKey(string $sql): ?TablePartitionKey
     {
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $stream = SqlTokenStream::tokenize($sql);
+        $tokens = $stream->significantTokens();
         $partition = $this->keywordPairIndex($tokens, 'PARTITION', 'BY');
         if ($partition === null) {
             return null;
@@ -53,30 +54,32 @@ final class PgSqlPartitionParser
 
     public function parentTable(string $sql): ?string
     {
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $stream = SqlTokenStream::tokenize($sql);
+        $tokens = $stream->significantTokens();
         $partition = $this->keywordPairIndex($tokens, 'PARTITION', 'OF');
         if ($partition === null) {
             return null;
         }
 
-        return $this->identifierAt($tokens, $partition + 2)['name'] ?? null;
+        return $this->qualifiedIdentifierAt($stream, $tokens, $partition + 2)['name'] ?? null;
     }
 
     public function parseRelation(string $sql, TablePartitionKey $parentKey): ?TablePartitionRelation
     {
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $stream = SqlTokenStream::tokenize($sql);
+        $tokens = $stream->significantTokens();
         $partition = $this->keywordPairIndex($tokens, 'PARTITION', 'OF');
         if ($partition === null) {
             return null;
         }
-        $parent = $this->identifierAt($tokens, $partition + 2);
+        $parent = $this->qualifiedIdentifierAt($stream, $tokens, $partition + 2);
         if ($parent === null) {
             return null;
         }
 
-        $defaultIndex = $this->keywordIndex($tokens, 'DEFAULT', $parent['next']);
-        $valuesIndex = $this->keywordPairIndex($tokens, 'FOR', 'VALUES', $parent['next']);
-        if ($defaultIndex !== null && ($valuesIndex === null || $defaultIndex < $valuesIndex)) {
+        $defaultIndex = $this->keywordIndex($tokens, 'DEFAULT');
+        $valuesIndex = $this->keywordPairIndex($tokens, 'FOR', 'VALUES');
+        if ($defaultIndex !== null) {
             return new TablePartitionRelation($parent['name'], null);
         }
         if ($valuesIndex === null) {
@@ -119,10 +122,10 @@ final class PgSqlPartitionParser
             return null;
         }
 
-        $predicates = array_values(array_filter(
+        $predicates = array_filter(
             [$lowerPredicate, $upperPredicate],
             static fn (string|false|null $predicate): bool => is_string($predicate),
-        ));
+        );
 
         return $predicates === [] ? 'TRUE' : implode(' AND ', $predicates);
     }
@@ -152,10 +155,6 @@ final class PgSqlPartitionParser
             }
             $nonNull[] = $value;
         }
-        if ($nonNull === [] && !$hasNull) {
-            return null;
-        }
-
         $expression = '(' . $key->expressions[0] . ')';
         $predicate = $nonNull === [] ? null : $expression . ' IN (' . implode(', ', $nonNull) . ')';
         if ($hasNull) {
@@ -178,11 +177,11 @@ final class PgSqlPartitionParser
 
         $special = [];
         foreach ($values as $value) {
-            $special[] = in_array(strtoupper(trim($value)), ['MINVALUE', 'MAXVALUE'], true);
+            $special[] = in_array(strtoupper($value), ['MINVALUE', 'MAXVALUE'], true);
         }
         if (!in_array(false, $special, true)) {
             foreach ($values as $value) {
-                if (strcasecmp(trim($value), $unbounded) !== 0) {
+                if (strcasecmp($value, $unbounded) !== 0) {
                     return false;
                 }
             }
@@ -214,9 +213,6 @@ final class PgSqlPartitionParser
         $close = $tokens[$closeIndex];
         $body = substr($sql, $open->endOffset(), $close->offset - $open->endOffset());
         $values = SqlTokenStream::tokenize($body)->splitTopLevel();
-        if ($values === [] || in_array('', $values, true)) {
-            return null;
-        }
 
         return ['values' => $values, 'next' => $closeIndex + 1];
     }
@@ -225,11 +221,54 @@ final class PgSqlPartitionParser
     private function closingParenthesisIndex(array $tokens, int $openIndex): ?int
     {
         $open = $tokens[$openIndex] ?? null;
-        if (!$open instanceof SqlToken || !$this->isSymbol($open, '(')) {
+        if (!$open instanceof SqlToken) {
             return null;
         }
-        foreach (array_slice($tokens, $openIndex + 1, null, true) as $index => $token) {
-            if ($this->isSymbol($token, ')') && $token->depth === $open->depth) {
+        if (!$this->isSymbol($open, '(')) {
+            return null;
+        }
+
+        $afterOpen = false;
+        foreach ($tokens as $index => $token) {
+            if ($token === $open) {
+                $afterOpen = true;
+            } elseif ($afterOpen && $this->isSymbol($token, ')') && $token->depth === $open->depth) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function keywordPairIndex(array $tokens, string $first, string $second): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isTopLevel()) {
+                continue;
+            }
+            if (!$token->isKeyword($first)) {
+                continue;
+            }
+            $next = $tokens[$index + 1] ?? null;
+            if (!$next instanceof SqlToken) {
+                continue;
+            }
+            if (!$next->isKeyword($second)) {
+                continue;
+            }
+
+            return $index;
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function keywordIndex(array $tokens, string $keyword): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isTopLevel() && $token->isKeyword($keyword)) {
                 return $index;
             }
         }
@@ -241,71 +280,39 @@ final class PgSqlPartitionParser
      * @param list<SqlToken> $tokens
      * @return array{name: string, next: int}|null
      */
-    private function identifierAt(array $tokens, int $index): ?array
+    private function qualifiedIdentifierAt(SqlTokenStream $stream, array $tokens, int $index): ?array
     {
         $token = $tokens[$index] ?? null;
-        $name = $token instanceof SqlToken ? $this->identifierName($token) : null;
-        if ($name === null) {
+        if (!$token instanceof SqlToken) {
             return null;
         }
-        $index++;
+        if (!in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+            return null;
+        }
+        $identifier = $stream->identifierAt($index);
+        if ($identifier === null) {
+            return null;
+        }
+        if ($token->kind === SqlTokenKind::Word) {
+            $identifier['name'] = strtolower($identifier['name']);
+        }
 
-        while ($this->isSymbol($tokens[$index] ?? null, '.')) {
-            $component = $tokens[$index + 1] ?? null;
-            $componentName = $component instanceof SqlToken ? $this->identifierName($component) : null;
-            if ($componentName === null) {
+        $dot = $tokens[$identifier['next']] ?? null;
+        while ($dot instanceof SqlToken && $this->isSymbol($dot, '.')) {
+            $componentIndex = $identifier['next'] + 1;
+            $component = $this->qualifiedIdentifierAt($stream, $tokens, $componentIndex);
+            if ($component === null) {
                 return null;
             }
-            $name = $componentName;
-            $index += 2;
+            $identifier = $component;
+            $dot = $tokens[$identifier['next']] ?? null;
         }
 
-        return ['name' => $name, 'next' => $index];
+        return $identifier;
     }
 
-    /** @param list<SqlToken> $tokens */
-    private function keywordPairIndex(array $tokens, string $first, string $second, int $start = 0): ?int
+    private function isSymbol(SqlToken $token, string $symbol): bool
     {
-        foreach (array_slice($tokens, $start, null, true) as $index => $token) {
-            if ($token->isTopLevel()
-                && $token->isKeyword($first)
-                && ($tokens[$index + 1] ?? null)?->isKeyword($second) === true
-            ) {
-                return $index;
-            }
-        }
-
-        return null;
-    }
-
-    /** @param list<SqlToken> $tokens */
-    private function keywordIndex(array $tokens, string $keyword, int $start): ?int
-    {
-        foreach (array_slice($tokens, $start, null, true) as $index => $token) {
-            if ($token->isTopLevel() && $token->isKeyword($keyword)) {
-                return $index;
-            }
-        }
-
-        return null;
-    }
-
-    private function identifierName(SqlToken $token): ?string
-    {
-        if ($token->kind === SqlTokenKind::Word) {
-            return strtolower($token->text);
-        }
-        if ($token->kind !== SqlTokenKind::QuotedIdentifier || strlen($token->text) < 2) {
-            return null;
-        }
-
-        return str_replace('""', '"', substr($token->text, 1, -1));
-    }
-
-    private function isSymbol(?SqlToken $token, string $symbol): bool
-    {
-        return $token instanceof SqlToken
-            && $token->kind === SqlTokenKind::Symbol
-            && $token->text === $symbol;
+        return $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
     }
 }

--- a/packages/ztd-query-postgres/src/PgSqlPartitionPredicateRenderer.php
+++ b/packages/ztd-query-postgres/src/PgSqlPartitionPredicateRenderer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Schema\TablePartitionRelation;
+
+final class PgSqlPartitionPredicateRenderer
+{
+    /** @param list<string> $siblingPredicates */
+    public function render(TablePartitionRelation $relation, array $siblingPredicates): string
+    {
+        if ($relation->predicate !== null) {
+            return $relation->predicate;
+        }
+        if ($siblingPredicates === []) {
+            return 'TRUE';
+        }
+
+        $predicates = array_map(
+            static fn (string $predicate): string => "($predicate)",
+            $siblingPredicates,
+        );
+
+        return 'COALESCE(NOT (' . implode(' OR ', $predicates) . '), TRUE)';
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlPartitionReflector.php
+++ b/packages/ztd-query-postgres/src/PgSqlPartitionReflector.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Connection\ConnectionInterface;
+use ZtdQuery\Schema\TablePartitionKey;
+use ZtdQuery\Schema\TablePartitionRelation;
+
+final class PgSqlPartitionReflector
+{
+    public function __construct(private readonly ConnectionInterface $connection)
+    {
+    }
+
+    /**
+     * @return array{
+     *     keys: array<string, TablePartitionKey>,
+     *     relations: array<string, TablePartitionRelation>
+     * }
+     */
+    public function reflect(): array
+    {
+        $parser = new PgSqlPartitionParser();
+        $keys = [];
+        $keyStatement = $this->connection->query(
+            'SELECT c.relname AS table_name, pg_get_partkeydef(c.oid) AS partition_key '
+            . 'FROM pg_partitioned_table pt '
+            . 'JOIN pg_class c ON c.oid = pt.partrelid '
+            . 'JOIN pg_namespace n ON n.oid = c.relnamespace '
+            . 'WHERE n.nspname = current_schema() ORDER BY c.relname',
+        );
+        if ($keyStatement !== false) {
+            foreach ($keyStatement->fetchAll() as $row) {
+                $tableName = $row['table_name'] ?? null;
+                $partitionKey = $row['partition_key'] ?? null;
+                if (!is_string($tableName) || $tableName === '' || !is_string($partitionKey)) {
+                    continue;
+                }
+                $key = $parser->parseKey("PARTITION BY $partitionKey");
+                if ($key !== null) {
+                    $keys[$tableName] = $key;
+                }
+            }
+        }
+
+        $relations = [];
+        $relationStatement = $this->connection->query(
+            'SELECT child.relname AS child_table, parent.relname AS parent_table, '
+            . 'pg_get_partition_constraintdef(child.oid) AS predicate '
+            . 'FROM pg_inherits i '
+            . 'JOIN pg_class child ON child.oid = i.inhrelid '
+            . 'JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace '
+            . 'JOIN pg_class parent ON parent.oid = i.inhparent '
+            . 'JOIN pg_partitioned_table pt ON pt.partrelid = parent.oid '
+            . 'WHERE child_ns.nspname = current_schema() ORDER BY child.relname',
+        );
+        if ($relationStatement !== false) {
+            foreach ($relationStatement->fetchAll() as $row) {
+                $childTable = $row['child_table'] ?? null;
+                $parentTable = $row['parent_table'] ?? null;
+                $predicate = $row['predicate'] ?? null;
+                if (!is_string($childTable)
+                    || $childTable === ''
+                    || !is_string($parentTable)
+                    || $parentTable === ''
+                    || !is_string($predicate)
+                    || trim($predicate) === ''
+                ) {
+                    continue;
+                }
+                $relations[$childTable] = new TablePartitionRelation($parentTable, $predicate);
+            }
+        }
+
+        return ['keys' => $keys, 'relations' => $relations];
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -296,8 +296,8 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
     private function storageTable(string $tableName): string
     {
         $seen = [];
-        while (!isset($seen[$tableName])) {
-            $seen[$tableName] = true;
+        while (!in_array($tableName, $seen, true)) {
+            $seen[] = $tableName;
             $parent = $this->registry->get($tableName)?->partitionRelation?->parentTable;
             if ($parent === null) {
                 return $tableName;

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -193,7 +193,9 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
      *     columnDefaults: array<string, string>,
      *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
-     *     generatedExpressions: array<string, string>
+     *     generatedExpressions: array<string, string>,
+     *     sourceSql?: string,
+     *     storageTable?: string
      * }>
      */
     private function buildTableContext(): array
@@ -250,6 +252,37 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             ];
         }
 
+        $quoter = new PgSqlIdentifierQuoter();
+        foreach ($allDefinitions as $tableName => $definition) {
+            $relation = $definition->partitionRelation;
+            if ($relation === null) {
+                continue;
+            }
+
+            $siblingPredicates = [];
+            foreach ($allDefinitions as $siblingDefinition) {
+                $sibling = $siblingDefinition->partitionRelation;
+                if ($sibling !== null
+                    && strcasecmp($sibling->parentTable, $relation->parentTable) === 0
+                    && $sibling->predicate !== null
+                ) {
+                    $siblingPredicates[] = $sibling->predicate;
+                }
+            }
+            $predicate = $relation->selectionPredicate($siblingPredicates);
+            $storageTable = $this->storageTable($tableName);
+            $partitionContext = $context[$tableName] ?? null;
+            if ($partitionContext === null) {
+                continue;
+            }
+            $partitionContext['rows'] = $this->shadowStore->get($storageTable);
+            $partitionContext['storageTable'] = $storageTable;
+            $partitionContext['sourceSql'] = 'SELECT * FROM '
+                . $quoter->quote($relation->parentTable)
+                . " WHERE $predicate";
+            $context[$tableName] = $partitionContext;
+        }
+
         foreach ((new PgSqlViewShadowRenderer())->render($this->views, array_keys($context)) as $viewName => $viewSql) {
             if (isset($context[$viewName])) {
                 continue;
@@ -258,6 +291,21 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
         }
 
         return $context;
+    }
+
+    private function storageTable(string $tableName): string
+    {
+        $seen = [];
+        while (!isset($seen[$tableName])) {
+            $seen[$tableName] = true;
+            $parent = $this->registry->get($tableName)?->partitionRelation?->parentTable;
+            if ($parent === null) {
+                return $tableName;
+            }
+            $tableName = $parent;
+        }
+
+        return $tableName;
     }
 
     private function tableExists(string $tableName): bool

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -38,6 +38,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
     private PgSqlParser $parser;
     private PgSqlReturningProjectionParser $returningProjectionParser;
     private PgSqlCteShadowComposer $cteComposer;
+    private PgSqlPartitionPredicateRenderer $partitionPredicateRenderer;
     private ViewDefinitionSet $views;
 
     public function __construct(
@@ -57,6 +58,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
         $this->parser = $parser;
         $this->returningProjectionParser = new PgSqlReturningProjectionParser();
         $this->cteComposer = new PgSqlCteShadowComposer();
+        $this->partitionPredicateRenderer = new PgSqlPartitionPredicateRenderer();
         $this->views = $views ?? new ViewDefinitionSet();
     }
 
@@ -269,7 +271,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
                     $siblingPredicates[] = $sibling->predicate;
                 }
             }
-            $predicate = $relation->selectionPredicate($siblingPredicates);
+            $predicate = $this->partitionPredicateRenderer->render($relation, $siblingPredicates);
             $storageTable = $this->storageTable($tableName);
             $partitionContext = $context[$tableName] ?? null;
             if ($partitionContext === null) {

--- a/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
@@ -122,7 +122,8 @@ final class PgSqlSchemaParser implements SchemaParser
 
     private function tableBody(string $sql): ?string
     {
-        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $stream = SqlTokenStream::tokenize($sql);
+        $tokens = $stream->significantTokens();
         $create = $tokens[0] ?? null;
         if (!$create instanceof SqlToken || !$create->isKeyword('CREATE')) {
             return null;
@@ -132,7 +133,6 @@ final class PgSqlSchemaParser implements SchemaParser
         foreach ($tokens as $index => $token) {
             if ($token->isTopLevel() && $token->isKeyword('TABLE')) {
                 $tableIndex = $index;
-                break;
             }
         }
         if ($tableIndex === null) {
@@ -140,28 +140,35 @@ final class PgSqlSchemaParser implements SchemaParser
         }
 
         $index = $tableIndex + 1;
-        if (($tokens[$index] ?? null)?->isKeyword('IF') === true
-            && ($tokens[$index + 1] ?? null)?->isKeyword('NOT') === true
-            && ($tokens[$index + 2] ?? null)?->isKeyword('EXISTS') === true
-        ) {
-            $index += 3;
-        }
-        if (!$this->isIdentifier($tokens[$index] ?? null)) {
+        $candidate = $tokens[$index] ?? null;
+        if (!$candidate instanceof SqlToken) {
             return null;
         }
-        $index++;
-        while ($this->isSymbol($tokens[$index] ?? null, '.')) {
-            if (!$this->isIdentifier($tokens[$index + 1] ?? null)) {
+        if ($candidate->isKeyword('IF')) {
+            $not = $tokens[$index + 1] ?? null;
+            $exists = $tokens[$index + 2] ?? null;
+            if (!$not instanceof SqlToken || !$not->isKeyword('NOT')) {
                 return null;
             }
-            $index += 2;
+            if (!$exists instanceof SqlToken || !$exists->isKeyword('EXISTS')) {
+                return null;
+            }
+            $index += 3;
         }
-
-        $open = $tokens[$index] ?? null;
-        if (!$open instanceof SqlToken || !$this->isSymbol($open, '(')) {
+        $identifier = $this->qualifiedIdentifierAt($stream, $tokens, $index);
+        if ($identifier === null) {
             return null;
         }
-        foreach (array_slice($tokens, $index + 1) as $token) {
+
+        $open = $tokens[$identifier['next']] ?? null;
+        if (!$open instanceof SqlToken) {
+            return null;
+        }
+        if (!$this->isSymbol($open, '(')) {
+            return null;
+        }
+
+        foreach ($tokens as $token) {
             if ($this->isSymbol($token, ')') && $token->depth === $open->depth) {
                 return substr($sql, $open->endOffset(), $token->offset - $open->endOffset());
             }
@@ -170,17 +177,40 @@ final class PgSqlSchemaParser implements SchemaParser
         return null;
     }
 
-    private function isIdentifier(?SqlToken $token): bool
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{name: string, next: int}|null
+     */
+    private function qualifiedIdentifierAt(SqlTokenStream $stream, array $tokens, int $index): ?array
     {
-        return $token instanceof SqlToken
-            && in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true);
+        $token = $tokens[$index] ?? null;
+        if (!$token instanceof SqlToken) {
+            return null;
+        }
+        if (!in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+            return null;
+        }
+        $identifier = $stream->identifierAt($index);
+        if ($identifier === null) {
+            return null;
+        }
+
+        $dot = $tokens[$identifier['next']] ?? null;
+        while ($dot instanceof SqlToken && $this->isSymbol($dot, '.')) {
+            $component = $this->qualifiedIdentifierAt($stream, $tokens, $identifier['next'] + 1);
+            if ($component === null) {
+                return null;
+            }
+            $identifier = $component;
+            $dot = $tokens[$identifier['next']] ?? null;
+        }
+
+        return $identifier;
     }
 
-    private function isSymbol(?SqlToken $token, string $symbol): bool
+    private function isSymbol(SqlToken $token, string $symbol): bool
     {
-        return $token instanceof SqlToken
-            && $token->kind === SqlTokenKind::Symbol
-            && $token->text === $symbol;
+        return $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
     }
 
     private static function isSequenceDefault(string $expression): bool

--- a/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaParser.php
@@ -9,13 +9,14 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
 /**
  * PostgreSQL implementation of SchemaParser.
  *
- * Parses CREATE TABLE statements using regex-based approach
- * to extract column definitions, types, constraints, and keys.
+ * Parses CREATE TABLE statements into structured schema metadata.
  */
 final class PgSqlSchemaParser implements SchemaParser
 {
@@ -24,11 +25,10 @@ final class PgSqlSchemaParser implements SchemaParser
      */
     public function parse(string $createTableSql): ?TableDefinition
     {
-        if (preg_match('/^\s*CREATE\s+(?:TEMPORARY\s+|TEMP\s+|UNLOGGED\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"[^"]+"|[a-zA-Z_]\w*(?:\."[^"]+"|\.(?:[a-zA-Z_]\w*))?)\s*\((.+)\)/is', $createTableSql, $m) !== 1) {
+        $body = $this->tableBody($createTableSql);
+        if ($body === null) {
             return null;
         }
-
-        $body = $m[1];
 
         $columns = [];
         $columnTypes = [];
@@ -116,7 +116,71 @@ final class PgSqlSchemaParser implements SchemaParser
             $identityStrategies,
             $generatedExpressions,
             $foreignKeys,
+            partitionKey: (new PgSqlPartitionParser())->parseKey($createTableSql),
         );
+    }
+
+    private function tableBody(string $sql): ?string
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $create = $tokens[0] ?? null;
+        if (!$create instanceof SqlToken || !$create->isKeyword('CREATE')) {
+            return null;
+        }
+
+        $tableIndex = null;
+        foreach ($tokens as $index => $token) {
+            if ($token->isTopLevel() && $token->isKeyword('TABLE')) {
+                $tableIndex = $index;
+                break;
+            }
+        }
+        if ($tableIndex === null) {
+            return null;
+        }
+
+        $index = $tableIndex + 1;
+        if (($tokens[$index] ?? null)?->isKeyword('IF') === true
+            && ($tokens[$index + 1] ?? null)?->isKeyword('NOT') === true
+            && ($tokens[$index + 2] ?? null)?->isKeyword('EXISTS') === true
+        ) {
+            $index += 3;
+        }
+        if (!$this->isIdentifier($tokens[$index] ?? null)) {
+            return null;
+        }
+        $index++;
+        while ($this->isSymbol($tokens[$index] ?? null, '.')) {
+            if (!$this->isIdentifier($tokens[$index + 1] ?? null)) {
+                return null;
+            }
+            $index += 2;
+        }
+
+        $open = $tokens[$index] ?? null;
+        if (!$open instanceof SqlToken || !$this->isSymbol($open, '(')) {
+            return null;
+        }
+        foreach (array_slice($tokens, $index + 1) as $token) {
+            if ($this->isSymbol($token, ')') && $token->depth === $open->depth) {
+                return substr($sql, $open->endOffset(), $token->offset - $open->endOffset());
+            }
+        }
+
+        return null;
+    }
+
+    private function isIdentifier(?SqlToken $token): bool
+    {
+        return $token instanceof SqlToken
+            && in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true);
+    }
+
+    private function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        return $token instanceof SqlToken
+            && $token->kind === SqlTokenKind::Symbol
+            && $token->text === $symbol;
     }
 
     private static function isSequenceDefault(string $expression): bool

--- a/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
+++ b/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
@@ -40,6 +40,19 @@ final class PgSqlSessionFactory implements SessionFactory
                 $registry->register($tableName, $definition);
             }
         }
+        $partitionMetadata = (new PgSqlPartitionReflector($connection))->reflect();
+        foreach ($partitionMetadata['keys'] as $tableName => $partitionKey) {
+            $definition = $registry->get($tableName);
+            if ($definition !== null) {
+                $registry->register($tableName, $definition->withPartitionKey($partitionKey));
+            }
+        }
+        foreach ($partitionMetadata['relations'] as $tableName => $partitionRelation) {
+            $definition = $registry->get($tableName);
+            if ($definition !== null) {
+                $registry->register($tableName, $definition->withPartitionRelation($partitionRelation));
+            }
+        }
         $views = new ViewDefinitionSet();
         foreach ($reflector->reflectViews() as $viewName => $definition) {
             $views->register($viewName, $definition);

--- a/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
@@ -66,6 +66,7 @@ final class InsertTransformer implements SqlTransformer
         $columnDefaults = $tables[$tableName]['columnDefaults'] ?? [];
         $identityStrategies = $tables[$tableName]['identityStrategies'] ?? [];
         $existingRows = $tables[$tableName]['rows'] ?? [];
+        $identityTable = $tables[$tableName]['storageTable'] ?? $tableName;
 
         if ($this->parser->hasInsertSelect($sql)) {
             $selectSql = $this->parser->extractInsertSelectSql($sql);
@@ -75,7 +76,7 @@ final class InsertTransformer implements SqlTransformer
 
             $sourceColumns = $insertColumns !== [] ? $insertColumns : $tableColumns;
             $generatedIdentityStarts = $this->identityAllocator->allocateSelectStarts(
-                $tableName,
+                $identityTable,
                 $identityStrategies,
                 $sourceColumns,
                 $existingRows,
@@ -109,7 +110,7 @@ final class InsertTransformer implements SqlTransformer
                 throw new UnsupportedSqlException($sql, 'Insert values count does not match column count');
             }
             $generatedValues = $this->identityAllocator->allocateMissing(
-                $tableName,
+                $identityTable,
                 $identityStrategies,
                 array_keys($providedExpressions),
                 $existingRows,

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -56,6 +56,10 @@ final class SelectTransformer implements SqlTransformer
                 $ctes[$tableName] = $this->quoter->quote($tableName) . " AS MATERIALIZED ({$tableContext['viewSql']})";
                 continue;
             }
+            if (isset($tableContext['sourceSql'])) {
+                $ctes[$tableName] = $this->quoter->quote($tableName) . " AS MATERIALIZED ({$tableContext['sourceSql']})";
+                continue;
+            }
 
             $rows = $tableContext['rows'];
             $columns = $tableContext['columns'];

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -10,6 +10,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlMutationResolver;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\PgSqlSchemaParser;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
@@ -34,8 +35,135 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
+#[UsesClass(PgSqlPartitionParser::class)]
 final class PgSqlMutationResolverTest extends TestCase
 {
+    public function testPartitionDdlInheritsParentSchemaAndChildDmlUsesParentStorage(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $schemaParser = new PgSqlSchemaParser();
+        $parent = $schemaParser->parse(
+            'CREATE TABLE logs (id INTEGER, log_date DATE, PRIMARY KEY (id, log_date)) '
+            . 'PARTITION BY RANGE (log_date)',
+        );
+        self::assertNotNull($parent);
+        $registry->register('logs', $parent);
+        $resolver = new PgSqlMutationResolver($shadowStore, $registry, $schemaParser, new PgSqlParser());
+
+        $create = $resolver->resolve(
+            "CREATE TABLE logs_2024 PARTITION OF logs FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')",
+            'CREATE_TABLE',
+            QueryKind::DDL_SIMULATED,
+        );
+        self::assertNotNull($create);
+        $create->apply($shadowStore, []);
+
+        $child = $registry->get('logs_2024');
+        self::assertNotNull($child);
+        self::assertSame($parent->columns, $child->columns);
+        self::assertSame('logs', $child->partitionRelation?->parentTable);
+
+        $insert = $resolver->resolve(
+            "INSERT INTO logs_2024 VALUES (1, '2024-06-01')",
+            'INSERT',
+            QueryKind::WRITE_SIMULATED,
+        );
+        self::assertNotNull($insert);
+        self::assertSame('logs', $insert->tableName());
+        $insert->apply($shadowStore, [['id' => 1, 'log_date' => '2024-06-01']]);
+
+        self::assertSame([['id' => 1, 'log_date' => '2024-06-01']], $shadowStore->get('logs'));
+        self::assertSame([], $shadowStore->get('logs_2024'));
+    }
+
+    public function testPartitionDdlRejectsUnknownParentAndUnsupportedHashBounds(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $schemaParser = new PgSqlSchemaParser();
+        $resolver = new PgSqlMutationResolver($shadowStore, $registry, $schemaParser, new PgSqlParser());
+
+        try {
+            $resolver->resolve(
+                'CREATE TABLE child PARTITION OF missing FOR VALUES IN (1)',
+                'CREATE_TABLE',
+                QueryKind::DDL_SIMULATED,
+            );
+            self::fail('Expected an unknown parent error.');
+        } catch (UnknownSchemaException) {
+            self::assertFalse($registry->has('child'));
+        }
+
+        $parent = $schemaParser->parse('CREATE TABLE values_table (id INTEGER) PARTITION BY HASH (id)');
+        self::assertNotNull($parent);
+        $registry->register('values_table', $parent);
+
+        $this->expectException(UnsupportedSqlException::class);
+        $resolver->resolve(
+            'CREATE TABLE values_0 PARTITION OF values_table FOR VALUES WITH (MODULUS 4, REMAINDER 0)',
+            'CREATE_TABLE',
+            QueryKind::DDL_SIMULATED,
+        );
+    }
+
+    public function testSubpartitionDdlStoresItsOwnPartitionKey(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $schemaParser = new PgSqlSchemaParser();
+        $parent = $schemaParser->parse(
+            'CREATE TABLE logs (id INTEGER, log_date DATE, level TEXT) PARTITION BY RANGE (log_date)',
+        );
+        self::assertNotNull($parent);
+        $registry->register('logs', $parent);
+        $resolver = new PgSqlMutationResolver($shadowStore, $registry, $schemaParser, new PgSqlParser());
+
+        $mutation = $resolver->resolve(
+            "CREATE TABLE logs_2024 PARTITION OF logs FOR VALUES FROM ('2024-01-01') TO ('2025-01-01') "
+            . 'PARTITION BY LIST (level)',
+            'CREATE_TABLE',
+            QueryKind::DDL_SIMULATED,
+        );
+        self::assertNotNull($mutation);
+        $mutation->apply($shadowStore, []);
+
+        $key = $registry->get('logs_2024')?->partitionKey;
+        self::assertNotNull($key);
+        self::assertSame(\ZtdQuery\Schema\TablePartitionStrategy::List, $key->strategy);
+        self::assertSame(['level'], $key->expressions);
+    }
+
+    public function testNestedPartitionDmlTargetsRootStorage(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], [], []);
+        $registry->register('root_table', $definition);
+        $registry->register('child_table', $definition->withPartitionRelation(
+            new \ZtdQuery\Schema\TablePartitionRelation('root_table', 'id >= 0'),
+        ));
+        $registry->register('grandchild_table', $definition->withPartitionRelation(
+            new \ZtdQuery\Schema\TablePartitionRelation('child_table', 'id < 10'),
+        ));
+        $resolver = new PgSqlMutationResolver(
+            $shadowStore,
+            $registry,
+            new PgSqlSchemaParser(),
+            new PgSqlParser(),
+        );
+
+        $mutation = $resolver->resolve(
+            'INSERT INTO grandchild_table VALUES (1)',
+            'INSERT',
+            QueryKind::WRITE_SIMULATED,
+        );
+
+        self::assertNotNull($mutation);
+        self::assertSame('root_table', $mutation->tableName());
+    }
+
+
     public function testResolveInsertReturnsInsertMutation(): void
     {
         $shadowStore = new ShadowStore();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionParserTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
+use ZtdQuery\Schema\TablePartitionKey;
+use ZtdQuery\Schema\TablePartitionStrategy;
+
+#[CoversClass(PgSqlPartitionParser::class)]
+final class PgSqlPartitionParserTest extends TestCase
+{
+    public function testParsesRangePartitionKeyAndBounds(): void
+    {
+        $parser = new PgSqlPartitionParser();
+        $key = $parser->parseKey('CREATE TABLE logs (log_date DATE) PARTITION BY RANGE (log_date)');
+
+        self::assertNotNull($key);
+        self::assertSame(TablePartitionStrategy::Range, $key->strategy);
+        self::assertSame(['log_date'], $key->expressions);
+
+        $relation = $parser->parseRelation(
+            "CREATE TABLE logs_2024 PARTITION OF public.logs FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')",
+            $key,
+        );
+
+        self::assertNotNull($relation);
+        self::assertSame('logs', $relation->parentTable);
+        self::assertSame(
+            "(log_date) >= '2024-01-01' AND (log_date) < '2025-01-01'",
+            $relation->predicate,
+        );
+    }
+
+    public function testParsesListPartitionIncludingNull(): void
+    {
+        $parser = new PgSqlPartitionParser();
+        $key = new TablePartitionKey(TablePartitionStrategy::List, ['region']);
+
+        $relation = $parser->parseRelation(
+            "CREATE TABLE accounts_local PARTITION OF accounts FOR VALUES IN ('east', 'west', NULL)",
+            $key,
+        );
+
+        self::assertNotNull($relation);
+        self::assertSame("((region) IN ('east', 'west') OR (region) IS NULL)", $relation->predicate);
+    }
+
+    public function testParsesDefaultPartition(): void
+    {
+        $parser = new PgSqlPartitionParser();
+        $key = new TablePartitionKey(TablePartitionStrategy::List, ['region']);
+
+        $relation = $parser->parseRelation('CREATE TABLE accounts_other PARTITION OF accounts DEFAULT', $key);
+
+        self::assertNotNull($relation);
+        self::assertNull($relation->predicate);
+    }
+
+    public function testParsesFiniteMultiColumnRangeAsRowComparison(): void
+    {
+        $parser = new PgSqlPartitionParser();
+        $key = new TablePartitionKey(TablePartitionStrategy::Range, ['year', 'month']);
+
+        $relation = $parser->parseRelation(
+            'CREATE TABLE metrics_2024 PARTITION OF metrics FOR VALUES FROM (2024, 1) TO (2025, 1)',
+            $key,
+        );
+
+        self::assertNotNull($relation);
+        self::assertSame('ROW(year, month) >= ROW(2024, 1) AND ROW(year, month) < ROW(2025, 1)', $relation->predicate);
+    }
+
+    public function testParsesUnboundedRange(): void
+    {
+        $parser = new PgSqlPartitionParser();
+        $key = new TablePartitionKey(TablePartitionStrategy::Range, ['id']);
+
+        $relation = $parser->parseRelation(
+            'CREATE TABLE smallest PARTITION OF values_table FOR VALUES FROM (MINVALUE) TO (10)',
+            $key,
+        );
+
+        self::assertNotNull($relation);
+        self::assertSame('(id) < 10', $relation->predicate);
+    }
+
+    public function testRejectsHashAndMixedUnboundedRangeInsteadOfGuessing(): void
+    {
+        $parser = new PgSqlPartitionParser();
+
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE values_hash PARTITION OF values_table FOR VALUES WITH (MODULUS 4, REMAINDER 0)',
+            new TablePartitionKey(TablePartitionStrategy::Hash, ['id']),
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE values_range PARTITION OF values_table FOR VALUES FROM (1, MINVALUE) TO (2, MAXVALUE)',
+            new TablePartitionKey(TablePartitionStrategy::Range, ['id', 'sequence']),
+        ));
+    }
+
+    public function testRejectsMalformedPartitionClauses(): void
+    {
+        $parser = new PgSqlPartitionParser();
+
+        self::assertNull($parser->parseKey('CREATE TABLE logs (id INTEGER)'));
+        self::assertNull($parser->parseKey('CREATE TABLE logs (id INTEGER) PARTITION BY UNKNOWN (id)'));
+        self::assertNull($parser->parseKey('CREATE TABLE logs (id INTEGER) PARTITION BY RANGE ()'));
+        self::assertNull($parser->parentTable('CREATE TABLE logs (id INTEGER)'));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE logs_2024 PARTITION OF logs FOR VALUES FROM () TO (10)',
+            new TablePartitionKey(TablePartitionStrategy::Range, ['id']),
+        ));
+    }
+
+    public function testParsesAllKeyStrategies(): void
+    {
+        $parser = new PgSqlPartitionParser();
+
+        self::assertSame(
+            TablePartitionStrategy::List,
+            $parser->parseKey('CREATE TABLE accounts (region TEXT) PARTITION BY LIST (region)')?->strategy,
+        );
+        self::assertSame(
+            TablePartitionStrategy::Hash,
+            $parser->parseKey('CREATE TABLE values_table (id INTEGER) PARTITION BY HASH (id)')?->strategy,
+        );
+    }
+
+    public function testRejectsMalformedBoundsIndependently(): void
+    {
+        $parser = new PgSqlPartitionParser();
+        $range = new TablePartitionKey(TablePartitionStrategy::Range, ['id']);
+        $list = new TablePartitionKey(TablePartitionStrategy::List, ['id']);
+
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES IN (1)',
+            $range,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES FROM (1) IN (2)',
+            $range,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES FROM (1) TO ()',
+            $range,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES FROM () TO (2)',
+            $range,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES FROM (1, 2) TO (3, 4)',
+            $range,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES FROM (MAXVALUE) TO (MAXVALUE)',
+            $range,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES FROM (MINVALUE) TO (MINVALUE)',
+            $range,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES FROM (1) TO (2)',
+            $list,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES IN ()',
+            $list,
+        ));
+    }
+
+    public function testListPredicatesDistinguishValuesNullAndWhitespace(): void
+    {
+        $parser = new PgSqlPartitionParser();
+        $key = new TablePartitionKey(TablePartitionStrategy::List, ['region']);
+
+        self::assertSame(
+            "(region) IN ('east', 'west')",
+            $parser->parseRelation(
+                "CREATE TABLE east_west PARTITION OF accounts FOR VALUES IN ('east', 'west')",
+                $key,
+            )?->predicate,
+        );
+        self::assertSame(
+            '(region) IS NULL',
+            $parser->parseRelation(
+                'CREATE TABLE unset_region PARTITION OF accounts FOR VALUES IN (NULL)',
+                $key,
+            )?->predicate,
+        );
+        self::assertSame(
+            '(id) < 10',
+            $parser->parseRelation(
+                'CREATE TABLE low_values PARTITION OF values_table FOR VALUES FROM ( minvalue ) TO (10)',
+                new TablePartitionKey(TablePartitionStrategy::Range, ['id']),
+            )?->predicate,
+        );
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionParserTest.php
@@ -107,9 +107,12 @@ final class PgSqlPartitionParserTest extends TestCase
         $parser = new PgSqlPartitionParser();
 
         self::assertNull($parser->parseKey('CREATE TABLE logs (id INTEGER)'));
+        self::assertNull($parser->parseKey('CREATE TABLE RANGE (id)'));
         self::assertNull($parser->parseKey('CREATE TABLE logs (id INTEGER) PARTITION BY UNKNOWN (id)'));
         self::assertNull($parser->parseKey('CREATE TABLE logs (id INTEGER) PARTITION BY RANGE ()'));
+        self::assertNull($parser->parseKey('CREATE TABLE logs (id INTEGER) PARTITION BY RANGE [id])'));
         self::assertNull($parser->parentTable('CREATE TABLE logs (id INTEGER)'));
+        self::assertNull($parser->parentTable('CREATE TABLE child PARTITION OF [parent] DEFAULT'));
         self::assertNull($parser->parseRelation(
             'CREATE TABLE logs_2024 PARTITION OF logs FOR VALUES FROM () TO (10)',
             new TablePartitionKey(TablePartitionStrategy::Range, ['id']),
@@ -138,6 +141,10 @@ final class PgSqlPartitionParserTest extends TestCase
 
         self::assertNull($parser->parseRelation(
             'CREATE TABLE child PARTITION OF parent FOR VALUES IN (1)',
+            $range,
+        ));
+        self::assertNull($parser->parseRelation(
+            'CREATE TABLE child PARTITION OF parent FOR VALUES IN (1) TO (2)',
             $range,
         ));
         self::assertNull($parser->parseRelation(
@@ -194,11 +201,62 @@ final class PgSqlPartitionParserTest extends TestCase
             )?->predicate,
         );
         self::assertSame(
+            "((region) IN ('east') OR (region) IS NULL)",
+            $parser->parseRelation(
+                "CREATE TABLE unset_region PARTITION OF accounts FOR VALUES IN (NULL, 'east')",
+                $key,
+            )?->predicate,
+        );
+        self::assertSame(
             '(id) < 10',
             $parser->parseRelation(
                 'CREATE TABLE low_values PARTITION OF values_table FOR VALUES FROM ( minvalue ) TO (10)',
                 new TablePartitionKey(TablePartitionStrategy::Range, ['id']),
             )?->predicate,
+        );
+    }
+
+    public function testIgnoresNestedPartitionKeywordsWhenFindingTopLevelClauses(): void
+    {
+        $parser = new PgSqlPartitionParser();
+        $key = $parser->parseKey(
+            'CREATE TABLE logs (id INTEGER CHECK (PARTITION BY)) PARTITION BY RANGE (id)',
+        );
+
+        self::assertNotNull($key);
+        self::assertSame(TablePartitionStrategy::Range, $key->strategy);
+        self::assertSame(['id'], $key->expressions);
+        self::assertSame(
+            '(id) IN (1)',
+            $parser->parseRelation(
+                'CREATE TABLE child (id INTEGER DEFAULT 0) PARTITION OF parent FOR VALUES IN (1)',
+                new TablePartitionKey(TablePartitionStrategy::List, ['id']),
+            )?->predicate,
+        );
+    }
+
+    public function testSkipsIncompleteKeywordPairBeforeThePartitionClause(): void
+    {
+        $key = (new PgSqlPartitionParser())->parseKey(
+            'CREATE TABLE logs (id INTEGER) PARTITION WRONG RANGE (wrong) PARTITION BY RANGE (id)',
+        );
+
+        self::assertNotNull($key);
+        self::assertSame(TablePartitionStrategy::Range, $key->strategy);
+        self::assertSame(['id'], $key->expressions);
+    }
+
+    public function testNormalizesUnquotedParentNamesAndPreservesQuotedNames(): void
+    {
+        $parser = new PgSqlPartitionParser();
+
+        self::assertSame(
+            'logs',
+            $parser->parentTable('CREATE TABLE child PARTITION OF Public.Logs DEFAULT'),
+        );
+        self::assertSame(
+            'Logs',
+            $parser->parentTable('CREATE TABLE child PARTITION OF public."Logs" DEFAULT'),
         );
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionPredicateRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionPredicateRendererTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionPredicateRenderer;
+use ZtdQuery\Schema\TablePartitionRelation;
+
+#[CoversClass(PgSqlPartitionPredicateRenderer::class)]
+final class PgSqlPartitionPredicateRendererTest extends TestCase
+{
+    public function testRendersSpecificPartitionPredicate(): void
+    {
+        $relation = new TablePartitionRelation('events', 'created_at >= DATE \'2024-01-01\'');
+
+        self::assertSame(
+            'created_at >= DATE \'2024-01-01\'',
+            (new PgSqlPartitionPredicateRenderer())->render($relation, ['FALSE']),
+        );
+    }
+
+    public function testRendersDefaultPartitionPredicateFromSiblings(): void
+    {
+        $renderer = new PgSqlPartitionPredicateRenderer();
+        $relation = new TablePartitionRelation('events', null);
+
+        self::assertSame(
+            'COALESCE(NOT ((year = 2024) OR (year = 2025)), TRUE)',
+            $renderer->render($relation, ['year = 2024', 'year = 2025']),
+        );
+        self::assertSame('TRUE', $renderer->render($relation, []));
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionReflectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionReflectorTest.php
@@ -53,6 +53,8 @@ final class PgSqlPartitionReflectorTest extends TestCase
 
         $metadata = $reflector->reflect();
 
+        self::assertSame(['logs'], array_keys($metadata['keys']));
+        self::assertSame(['logs_2024'], array_keys($metadata['relations']));
         self::assertSame(TablePartitionStrategy::Range, $metadata['keys']['logs']->strategy);
         self::assertSame(['log_date'], $metadata['keys']['logs']->expressions);
         self::assertSame('logs', $metadata['relations']['logs_2024']->parentTable);

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionReflectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionReflectorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Tests\Fake\FakeSequentialConnection;
+use Tests\Fake\FakeStatement;
+use ZtdQuery\Connection\ConnectionInterface;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionReflector;
+use ZtdQuery\Schema\TablePartitionStrategy;
+
+#[CoversClass(PgSqlPartitionReflector::class)]
+#[UsesClass(PgSqlPartitionParser::class)]
+final class PgSqlPartitionReflectorTest extends TestCase
+{
+    public function testReflectsKeysAndParentRelationsFromCatalog(): void
+    {
+        $keyStatement = new FakeStatement([
+            ['table_name' => null, 'partition_key' => 'RANGE (id)'],
+            ['table_name' => '', 'partition_key' => 'RANGE (id)'],
+            ['table_name' => 'broken', 'partition_key' => null],
+            ['table_name' => 'invalid', 'partition_key' => 'invalid'],
+            ['table_name' => 'logs', 'partition_key' => 'RANGE (log_date)'],
+        ]);
+        $relationStatement = new FakeStatement([
+            ['child_table' => null, 'parent_table' => 'logs', 'predicate' => 'TRUE'],
+            ['child_table' => '', 'parent_table' => 'logs', 'predicate' => 'TRUE'],
+            ['child_table' => 'missing_parent', 'parent_table' => null, 'predicate' => 'TRUE'],
+            ['child_table' => 'empty_parent', 'parent_table' => '', 'predicate' => 'TRUE'],
+            ['child_table' => 'missing_predicate', 'parent_table' => 'logs', 'predicate' => null],
+            ['child_table' => 'blank_predicate', 'parent_table' => 'logs', 'predicate' => ' '],
+            [
+                'child_table' => 'logs_2024',
+                'parent_table' => 'logs',
+                'predicate' => "((log_date >= '2024-01-01'::date) AND (log_date < '2025-01-01'::date))",
+            ],
+        ]);
+        $queries = [];
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            static function (string $sql) use (&$queries, $keyStatement, $relationStatement) {
+                $queries[] = $sql;
+
+                return count($queries) === 1 ? $keyStatement : $relationStatement;
+            },
+        );
+        $reflector = new PgSqlPartitionReflector($connection);
+
+        $metadata = $reflector->reflect();
+
+        self::assertSame(TablePartitionStrategy::Range, $metadata['keys']['logs']->strategy);
+        self::assertSame(['log_date'], $metadata['keys']['logs']->expressions);
+        self::assertSame('logs', $metadata['relations']['logs_2024']->parentTable);
+        $predicate = $metadata['relations']['logs_2024']->predicate;
+        self::assertNotNull($predicate);
+        self::assertStringContainsString('log_date >=', $predicate);
+        self::assertSame([
+            'SELECT c.relname AS table_name, pg_get_partkeydef(c.oid) AS partition_key '
+            . 'FROM pg_partitioned_table pt '
+            . 'JOIN pg_class c ON c.oid = pt.partrelid '
+            . 'JOIN pg_namespace n ON n.oid = c.relnamespace '
+            . 'WHERE n.nspname = current_schema() ORDER BY c.relname',
+            'SELECT child.relname AS child_table, parent.relname AS parent_table, '
+            . 'pg_get_partition_constraintdef(child.oid) AS predicate '
+            . 'FROM pg_inherits i '
+            . 'JOIN pg_class child ON child.oid = i.inhrelid '
+            . 'JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace '
+            . 'JOIN pg_class parent ON parent.oid = i.inhparent '
+            . 'JOIN pg_partitioned_table pt ON pt.partrelid = parent.oid '
+            . 'WHERE child_ns.nspname = current_schema() ORDER BY child.relname',
+        ], $queries);
+    }
+
+    public function testReturnsEmptyMetadataWhenCatalogQueriesFail(): void
+    {
+        $metadata = (new PgSqlPartitionReflector(new FakeSequentialConnection([])))->reflect();
+
+        self::assertSame(['keys' => [], 'relations' => []], $metadata);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -17,6 +17,7 @@ use ZtdQuery\Platform\Postgres\PgSqlQueryGuard;
 use ZtdQuery\Platform\Postgres\PgSqlReturningProjectionParser;
 use ZtdQuery\Platform\Postgres\PgSqlRewriter;
 use ZtdQuery\Platform\Postgres\PgSqlSchemaParser;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
 use ZtdQuery\Platform\Postgres\PgSqlTransformer;
 use ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser;
 use ZtdQuery\Platform\Postgres\Transformer\DeleteTransformer;
@@ -28,6 +29,7 @@ use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\TablePartitionRelation;
 use ZtdQuery\Schema\ViewDefinition;
 use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
@@ -48,6 +50,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
+#[UsesClass(PgSqlPartitionParser::class)]
 #[UsesClass(PgSqlQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlReadOnlyDiagnosticStatement::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTransactionStatementParser::class)]
@@ -70,6 +73,114 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
+    public function testChildPartitionSelectUsesFilteredParentShadowSource(): void
+    {
+        $store = new ShadowStore();
+        $store->set('logs', [
+            ['id' => 1, 'log_date' => '2024-05-01'],
+            ['id' => 2, 'log_date' => '2025-05-01'],
+        ]);
+        $registry = new TableDefinitionRegistry();
+        $parent = (new PgSqlSchemaParser())->parse(
+            'CREATE TABLE logs (id INTEGER, log_date DATE, PRIMARY KEY (id, log_date)) '
+            . 'PARTITION BY RANGE (log_date)',
+        );
+        self::assertNotNull($parent);
+        $registry->register('logs', $parent);
+        $registry->register('logs_2024', $parent->withPartitionRelation(new TablePartitionRelation(
+            'logs',
+            "(log_date >= '2024-01-01'::date) AND (log_date < '2025-01-01'::date)",
+        )));
+
+        $sql = $this->createRewriter($store, $registry)->rewrite('SELECT id FROM logs_2024')->sql();
+
+        self::assertStringContainsString('"logs" AS MATERIALIZED', $sql);
+        self::assertStringContainsString(
+            '"logs_2024" AS MATERIALIZED (SELECT * FROM "logs" WHERE '
+            . "(log_date >= '2024-01-01'::date) AND (log_date < '2025-01-01'::date))",
+            $sql,
+        );
+        self::assertStringEndsWith('SELECT id FROM logs_2024', $sql);
+    }
+
+    public function testChildPartitionWriteMutationTargetsRootParent(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $parent = (new PgSqlSchemaParser())->parse(
+            'CREATE TABLE logs (id INTEGER, log_date DATE, PRIMARY KEY (id, log_date)) '
+            . 'PARTITION BY RANGE (log_date)',
+        );
+        self::assertNotNull($parent);
+        $registry->register('logs', $parent);
+        $registry->register('logs_2024', $parent->withPartitionRelation(new TablePartitionRelation(
+            'logs',
+            "log_date >= '2024-01-01'::date AND log_date < '2025-01-01'::date",
+        )));
+
+        $plan = $this->createRewriter($store, $registry)->rewrite(
+            "INSERT INTO logs_2024 VALUES (1, '2024-05-01')",
+        );
+
+        self::assertNotNull($plan->mutation());
+        self::assertSame('logs', $plan->mutation()->tableName());
+        self::assertStringContainsString("CAST('2024-05-01' AS DATE) AS \"log_date\"", $plan->sql());
+    }
+
+    public function testDefaultPartitionExcludesOnlySpecificSiblingsOfSameParent(): void
+    {
+        $store = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(['region'], ['region' => 'TEXT'], [], [], []);
+        $registry->register('accounts', $definition);
+        $registry->register('accounts_east', $definition->withPartitionRelation(
+            new TablePartitionRelation('accounts', "region = 'east'"),
+        ));
+        $registry->register('accounts_other', $definition->withPartitionRelation(
+            new TablePartitionRelation('accounts', null),
+        ));
+        $registry->register('unrelated', $definition->withPartitionRelation(
+            new TablePartitionRelation('another_parent', "region = 'west'"),
+        ));
+
+        $sql = $this->createRewriter($store, $registry)->rewrite('SELECT * FROM accounts_other')->sql();
+
+        self::assertStringContainsString(
+            "SELECT * FROM \"accounts\" WHERE COALESCE(NOT ((region = 'east')), TRUE)",
+            $sql,
+        );
+        self::assertStringNotContainsString("region = 'west'", $sql);
+    }
+
+    public function testNestedPartitionInsertAllocatesIdentityFromRootRows(): void
+    {
+        $store = new ShadowStore();
+        $store->set('root_table', [['id' => 5, 'region' => 'east']]);
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(
+            ['id', 'region'],
+            ['id' => 'INTEGER', 'region' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+            identityStrategies: ['id' => \ZtdQuery\Schema\IdentityGenerationStrategy::MaxValue],
+        );
+        $registry->register('root_table', $definition);
+        $registry->register('child_table', $definition->withPartitionRelation(
+            new TablePartitionRelation('root_table', "region = 'east'"),
+        ));
+        $registry->register('grandchild_table', $definition->withPartitionRelation(
+            new TablePartitionRelation('child_table', 'id < 10'),
+        ));
+
+        $sql = $this->createRewriter($store, $registry)->rewrite(
+            "INSERT INTO grandchild_table (region) VALUES ('east')",
+        )->sql();
+
+        self::assertStringContainsString('6 AS "id"', $sql);
+    }
+
+
     public function testGeneratedExpressionIsPresentBeforeTheFirstShadowWrite(): void
     {
         $store = new ShadowStore();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -71,6 +71,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlPartitionPredicateRenderer::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
     public function testChildPartitionSelectUsesFilteredParentShadowSource(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
@@ -1204,6 +1204,19 @@ final class PgSqlSchemaParserTest extends SchemaParserContractTest
         self::assertSame(['id'], $def->columns);
     }
 
+    public function testRejectsMalformedCreateTablePreambleAndBodyDelimiters(): void
+    {
+        $parser = new PgSqlSchemaParser();
+
+        self::assertNull($parser->parse('CREATE TABLE IF EXISTS t (id INTEGER)'));
+        self::assertNull($parser->parse('CREATE TABLE IF WRONG EXISTS t (id INTEGER)'));
+        self::assertNull($parser->parse('CREATE TABLE IF NOT MISSING t (id INTEGER)'));
+        self::assertNull($parser->parse('CREATE TABLE t [id INTEGER])'));
+        self::assertNull($parser->parse('CREATE TABLE [t] (id INTEGER)'));
+        self::assertNull($parser->parse('CREATE TABLE public. (id INTEGER)'));
+        self::assertNull($parser->parse('CREATE TABLE t'));
+    }
+
     public function testParseLowercaseTimestamp(): void
     {
         $parser = new PgSqlSchemaParser();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
@@ -11,9 +11,12 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
+use ZtdQuery\Schema\TablePartitionStrategy;
 
 #[CoversClass(PgSqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser::class)]
+#[UsesClass(PgSqlPartitionParser::class)]
 final class PgSqlSchemaParserTest extends SchemaParserContractTest
 {
     protected function createParser(): SchemaParser
@@ -55,6 +58,39 @@ final class PgSqlSchemaParserTest extends SchemaParserContractTest
         self::assertSame(['id'], $def->primaryKeys);
         self::assertContains('id', $def->notNullColumns);
         self::assertContains('name', $def->notNullColumns);
+    }
+
+    public function testPartitionClauseDoesNotBecomePartOfTableBody(): void
+    {
+        $definition = (new PgSqlSchemaParser())->parse(
+            'CREATE TABLE logs (id INTEGER, log_date DATE, PRIMARY KEY (id, log_date)) '
+            . 'PARTITION BY RANGE (log_date)',
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame(['id', 'log_date'], $definition->columns);
+        self::assertSame(['id', 'log_date'], $definition->primaryKeys);
+        $partitionKey = $definition->partitionKey;
+        self::assertNotNull($partitionKey);
+        self::assertSame(TablePartitionStrategy::Range, $partitionKey->strategy);
+        self::assertSame(['log_date'], $partitionKey->expressions);
+    }
+
+    public function testCreateKeywordInsideAnotherStatementDoesNotParse(): void
+    {
+        self::assertNull((new PgSqlSchemaParser())->parse(
+            'SELECT 1 FROM source_table; CREATE TABLE hidden (id INTEGER)',
+        ));
+    }
+
+    public function testIncompleteIfNotExistsAndQualifiedNamesDoNotParse(): void
+    {
+        $parser = new PgSqlSchemaParser();
+
+        self::assertNull($parser->parse('CREATE TABLE IF users (id INTEGER)'));
+        self::assertNull($parser->parse('CREATE TABLE IF NOT users (id INTEGER)'));
+        self::assertNull($parser->parse('CREATE TABLE IF EXISTS users (id INTEGER)'));
+        self::assertNull($parser->parse('CREATE TABLE public. (id INTEGER)'));
     }
 
     public function testParseColumnTypes(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -57,6 +57,7 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlPartitionPredicateRenderer::class)]
 final class PgSqlSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedPartitionMetadata(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Tests\Fake\FakeStatement;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\Postgres\PgSqlSessionFactory;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
+use ZtdQuery\Platform\Postgres\PgSqlPartitionReflector;
 use ZtdQuery\Session;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -31,6 +34,8 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
+#[UsesClass(PgSqlPartitionParser::class)]
+#[UsesClass(PgSqlPartitionReflector::class)]
 #[UsesClass(PgSqlQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlReadOnlyDiagnosticStatement::class)]
 #[UsesClass(PgSqlRewriter::class)]
@@ -54,6 +59,84 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 final class PgSqlSessionFactoryTest extends TestCase
 {
+    public function testCreateRegistersReflectedPartitionMetadata(): void
+    {
+        $tables = new FakeStatement([
+            ['table_name' => 'logs'],
+            ['table_name' => 'logs_2024'],
+        ]);
+        $columns = new FakeStatement([
+            [
+                'column_name' => 'id',
+                'data_type' => 'integer',
+                'character_maximum_length' => null,
+                'numeric_precision' => 32,
+                'numeric_scale' => 0,
+                'is_nullable' => 'NO',
+                'column_default' => null,
+                'udt_name' => 'int4',
+            ],
+            [
+                'column_name' => 'log_date',
+                'data_type' => 'date',
+                'character_maximum_length' => null,
+                'numeric_precision' => null,
+                'numeric_scale' => null,
+                'is_nullable' => 'NO',
+                'column_default' => null,
+                'udt_name' => 'date',
+            ],
+        ]);
+        $primaryKey = new FakeStatement([
+            ['column_name' => 'id'],
+            ['column_name' => 'log_date'],
+        ]);
+        $empty = new FakeStatement([]);
+        $partitionKeys = new FakeStatement([
+            ['table_name' => 'logs', 'partition_key' => 'RANGE (log_date)'],
+        ]);
+        $relations = new FakeStatement([
+            [
+                'child_table' => 'logs_2024',
+                'parent_table' => 'logs',
+                'predicate' => "log_date >= '2024-01-01'::date AND log_date < '2025-01-01'::date",
+            ],
+        ]);
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            static function (string $sql) use (
+                $tables,
+                $columns,
+                $primaryKey,
+                $empty,
+                $partitionKeys,
+                $relations,
+            ) {
+                return match (true) {
+                    str_contains($sql, 'information_schema.tables') => $tables,
+                    str_contains($sql, 'information_schema.columns') => $columns,
+                    str_contains($sql, "constraint_type = 'PRIMARY KEY'") => $primaryKey,
+                    str_contains($sql, 'SELECT c.relname AS table_name') => $partitionKeys,
+                    str_contains($sql, 'SELECT child.relname AS child_table') => $relations,
+                    default => $empty,
+                };
+            },
+        );
+
+        $session = (new PgSqlSessionFactory())->create($connection, ZtdConfig::default());
+        $sql = $session->rewrite('SELECT * FROM logs_2024')->sql();
+
+        self::assertStringContainsString('"logs" AS MATERIALIZED', $sql);
+        self::assertStringContainsString(
+            '"logs_2024" AS MATERIALIZED (SELECT * FROM "logs" WHERE log_date >=',
+            $sql,
+        );
+        $create = $session->rewrite(
+            "CREATE TABLE logs_2025 PARTITION OF logs FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')",
+        );
+        self::assertNotNull($create->mutation());
+    }
+
     public function testCreateRegistersReflectedViews(): void
     {
         $empty = self::createStub(StatementInterface::class);

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -401,6 +401,28 @@ final class InsertTransformerTest extends TestCase
         self::assertStringContainsString('3 AS "id"', $second);
     }
 
+    public function testParentAndPartitionShareSerialAllocationNamespace(): void
+    {
+        $transformer = new InsertTransformer(new PgSqlParser(), new SelectTransformer());
+        $table = [
+            'rows' => [],
+            'columns' => ['id', 'name'],
+            'columnTypes' => [],
+            'identityStrategies' => ['id' => IdentityGenerationStrategy::Sequence],
+        ];
+        $tables = [
+            'logs' => $table,
+            'logs_2024' => $table + ['storageTable' => 'logs'],
+        ];
+
+        $parent = $transformer->transform("INSERT INTO logs (name) VALUES ('parent')", $tables);
+        $transformer->commitRewriteState();
+        $child = $transformer->transform("INSERT INTO logs_2024 (name) VALUES ('child')", $tables);
+
+        self::assertStringContainsString('1 AS "id"', $parent);
+        self::assertStringContainsString('2 AS "id"', $child);
+    }
+
     public function testUncommittedTransformDoesNotConsumeSerialValue(): void
     {
         $transformer = new InsertTransformer(new PgSqlParser(), new SelectTransformer());


### PR DESCRIPTION
## Summary

- model PostgreSQL partition keys and parent-child relations with typed schema metadata
- reflect catalog partition bounds and route child reads and writes through the root shadow table
- support RANGE, LIST, DEFAULT, and nested partitions while rejecting unsafe HASH simulation
- add SQLFaker generation, fuzz targets, unit tests, a real PostgreSQL integration test, and mutation verification

## Stack

- Base: the #158 branch (`agent/issue-zero-45-mysql-partitions`)
- This PR contains one issue-specific fix for PostgreSQL child partitions

Closes #159