### PR TITLE
fix(postgres): sample shadow table rows

### DIFF
--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -97,6 +97,20 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function tableSampleStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('SelectStmt', [
+            'SelectStmt' => [ProductionPattern::exactly('select_no_parens')],
+            'select_no_parens' => [ProductionPattern::exactly('simple_select')],
+            'simple_select' => [
+                ProductionPattern::containing('SELECT', 'opt_target_list', 'from_clause'),
+            ],
+            'from_clause' => [ProductionPattern::nonEmpty()],
+            'table_ref' => [ProductionPattern::containing('relation_expr', 'tablesample_clause')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -448,15 +448,9 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function tableSampleStatement(): string
+    public function tableSampleStatement(int $maxDepth = 40): string
     {
-        $method = $this->generator->boolean() ? 'BERNOULLI' : 'SYSTEM';
-        $percentage = $this->rsg->integerString(0, 100);
-        $repeatable = $this->generator->boolean()
-            ? ' REPEATABLE (' . $this->rsg->integerString(0, 2147483647) . ')'
-            : '';
-
-        return "SELECT * FROM users TABLESAMPLE $method ($percentage)$repeatable";
+        return $this->sql->generate(GenerationPlans::tableSampleStatement()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -447,6 +447,18 @@ final class PostgreSqlProvider extends Base
         return $this->sql->generate(GenerationPlans::partitionOfStatement()->withMaxDepth($maxDepth));
     }
 
+    /** @return non-empty-string */
+    public function tableSampleStatement(): string
+    {
+        $method = $this->generator->boolean() ? 'BERNOULLI' : 'SYSTEM';
+        $percentage = $this->rsg->integerString(0, 100);
+        $repeatable = $this->generator->boolean()
+            ? ' REPEATABLE (' . $this->rsg->integerString(0, 2147483647) . ')'
+            : '';
+
+        return "SELECT * FROM users TABLESAMPLE $method ($percentage)$repeatable";
+    }
+
     /**
      * @template TRequiresNonEmpty of bool
      * @param GenerationPlan<TRequiresNonEmpty> $plan

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -111,4 +111,13 @@ final class GenerationPlansTest extends TestCase
         );
         self::assertTrue($plan->patternAt('PartitionBoundSpec', 0)?->matches(['FROM', 'TO']) ?? false);
     }
+
+    public function testTableSamplePlanRequiresASamplingClause(): void
+    {
+        $plan = GenerationPlans::tableSampleStatement();
+
+        self::assertSame('SelectStmt', $plan->startRule());
+        self::assertNotNull($plan->patternAt('from_clause', 0));
+        self::assertNotNull($plan->patternAt('table_ref', 0));
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -117,7 +117,14 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::tableSampleStatement();
 
         self::assertSame('SelectStmt', $plan->startRule());
-        self::assertNotNull($plan->patternAt('from_clause', 0));
-        self::assertNotNull($plan->patternAt('table_ref', 0));
+        self::assertTrue($plan->patternAt('SelectStmt', 0)?->matches(['select_no_parens']) ?? false);
+        self::assertTrue($plan->patternAt('select_no_parens', 0)?->matches(['simple_select']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('simple_select', 0)?->matches(['SELECT', 'opt_target_list', 'from_clause']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('from_clause', 0)?->matches(['table_ref']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('table_ref', 0)?->matches(['relation_expr', 'tablesample_clause']) ?? false,
+        );
     }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\SqlFaker;
 
 use Faker\Factory;
+use Faker\Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\TestCase;
@@ -892,17 +893,58 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertNotSame('', $result);
     }
 
-    public function testTableSampleStatementTargetsFuzzFixture(): void
+    public function testTableSampleStatementCoversMethodsBoundsAndRepeatability(): void
     {
-        $faker = Factory::create();
-        $faker->seed(12345);
-        $provider = new PostgreSqlProvider($faker);
+        $maximum = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return $int2 === 100 ? 100 : 2147483647;
+            }
 
-        $sql = $provider->tableSampleStatement();
+            /**
+             * @param string $method
+             * @param array<mixed> $attributes
+             */
+            #[\Override]
+            public function __call($method, $attributes): bool
+            {
+                return true;
+            }
+        };
+        $minimum = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return 0;
+            }
 
-        self::assertMatchesRegularExpression(
-            '/^SELECT \* FROM users TABLESAMPLE (?:BERNOULLI|SYSTEM) \((?:100|[1-9]?[0-9])\)(?: REPEATABLE \([0-9]+\))?$/',
-            $sql,
+            /**
+             * @param string $method
+             * @param array<mixed> $attributes
+             */
+            #[\Override]
+            public function __call($method, $attributes): bool
+            {
+                return false;
+            }
+        };
+
+        self::assertSame(
+            'SELECT * FROM users TABLESAMPLE BERNOULLI (100) REPEATABLE (2147483647)',
+            (new PostgreSqlProvider($maximum))->tableSampleStatement(),
+        );
+        self::assertSame(
+            'SELECT * FROM users TABLESAMPLE SYSTEM (0)',
+            (new PostgreSqlProvider($minimum))->tableSampleStatement(),
         );
     }
 

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -892,6 +892,20 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertNotSame('', $result);
     }
 
+    public function testTableSampleStatementTargetsFuzzFixture(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new PostgreSqlProvider($faker);
+
+        $sql = $provider->tableSampleStatement();
+
+        self::assertMatchesRegularExpression(
+            '/^SELECT \* FROM users TABLESAMPLE (?:BERNOULLI|SYSTEM) \((?:100|[1-9]?[0-9])\)(?: REPEATABLE \([0-9]+\))?$/',
+            $sql,
+        );
+    }
+
     #[DataProvider('providerNullableSimpleStatementSeed')]
     public function testSimpleStatementReturnsNonEmpty(int $seed): void
     {

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -893,63 +893,21 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertNotSame('', $result);
     }
 
-    public function testTableSampleStatementCoversMethodsBoundsAndRepeatability(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testTableSampleStatementDerivesSamplingClauseFromGrammar(int $seed): void
     {
-        $maximum = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return match ([$int1, $int2]) {
-                    [0, 100] => 100,
-                    [0, 2147483647] => 2147483647,
-                    default => throw new \UnexpectedValueException('Unexpected TABLESAMPLE range'),
-                };
-            }
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->tableSampleStatement();
+        $faker->seed($seed);
 
-            /**
-             * @param string $method
-             * @param array<mixed> $attributes
-             */
-            #[\Override]
-            public function __call($method, $attributes): bool
-            {
-                return true;
-            }
-        };
-        $minimum = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return 0;
-            }
+        $tokens = (new LexicalGrammar($faker, 'pg-17.2', true))->tokenize($sql);
 
-            /**
-             * @param string $method
-             * @param array<mixed> $attributes
-             */
-            #[\Override]
-            public function __call($method, $attributes): bool
-            {
-                return false;
-            }
-        };
-
-        self::assertSame(
-            'SELECT * FROM users TABLESAMPLE BERNOULLI (100) REPEATABLE (2147483647)',
-            (new PostgreSqlProvider($maximum))->tableSampleStatement(),
-        );
-        self::assertSame(
-            'SELECT * FROM users TABLESAMPLE SYSTEM (0)',
-            (new PostgreSqlProvider($minimum))->tableSampleStatement(),
-        );
+        self::assertSame($sql, $provider->tableSampleStatement(40));
+        self::assertSame('SELECT', $tokens[0]);
+        self::assertContains('FROM', $tokens);
+        self::assertContains('TABLESAMPLE', $tokens);
     }
 
     #[DataProvider('providerNullableSimpleStatementSeed')]

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -903,7 +903,11 @@ final class PostgreSqlProviderTest extends TestCase
             #[\Override]
             public function numberBetween($int1 = 0, $int2 = 2147483647): int
             {
-                return $int2 === 100 ? 100 : 2147483647;
+                return match ([$int1, $int2]) {
+                    [0, 100] => 100,
+                    [0, 2147483647] => 2147483647,
+                    default => throw new \UnexpectedValueException('Unexpected TABLESAMPLE range'),
+                };
             }
 
             /**

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/TableSampleTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/TableSampleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class TableSampleTest extends TestCase
+{
+    public function testTableSampleUsesShadowRows(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $pdo->exec('CREATE TABLE sample_data (id INTEGER PRIMARY KEY, label TEXT NOT NULL)');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+            self::assertSame(4, $ztdPdo->exec(
+                "INSERT INTO sample_data VALUES (1, 'A'), (2, 'B'), (3, 'C'), (4, 'D')",
+            ));
+
+            $bernoulli = $ztdPdo->query(
+                'SELECT sampled.id FROM sample_data AS sampled TABLESAMPLE BERNOULLI (100) ORDER BY sampled.id',
+            );
+            self::assertNotFalse($bernoulli);
+            self::assertSame([1, 2, 3, 4], $bernoulli->fetchAll(\PDO::FETCH_COLUMN));
+
+            $system = $ztdPdo->query(
+                'SELECT id FROM sample_data TABLESAMPLE SYSTEM (100) REPEATABLE (17.5) ORDER BY id',
+            );
+            self::assertNotFalse($system);
+            self::assertSame([1, 2, 3, 4], $system->fetchAll(\PDO::FETCH_COLUMN));
+
+            $empty = $ztdPdo->query('SELECT id FROM sample_data TABLESAMPLE BERNOULLI (0)');
+            self::assertNotFalse($empty);
+            self::assertSame([], $empty->fetchAll(\PDO::FETCH_COLUMN));
+
+            $first = $ztdPdo->query(
+                'SELECT id FROM sample_data TABLESAMPLE BERNOULLI (50) REPEATABLE (42) ORDER BY id',
+            );
+            $second = $ztdPdo->query(
+                'SELECT id FROM sample_data TABLESAMPLE BERNOULLI (50) REPEATABLE (42) ORDER BY id',
+            );
+            self::assertNotFalse($first);
+            self::assertNotFalse($second);
+            self::assertSame($first->fetchAll(\PDO::FETCH_COLUMN), $second->fetchAll(\PDO::FETCH_COLUMN));
+
+            $physical = $pdo->query('SELECT COUNT(*) FROM sample_data');
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
@@ -61,6 +61,7 @@ final class ClassifyTarget
             fn (): string => $this->provider->alterTableStatement(maxDepth: 5),
             fn (): string => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => $this->provider->partitionOfStatement(),
+            fn (): string => $this->provider->tableSampleStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -145,6 +145,7 @@ final class RewriteTarget
             fn (): string => $this->provider->generatedColumnStatement(),
             fn (): string => $this->provider->foreignKeyCascadeStatement(),
             fn (): string => $this->provider->partitionOfStatement(),
+            fn (): string => $this->provider->tableSampleStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
@@ -189,6 +189,7 @@ final class RobustnessTarget
             fn (): string => 'EXPLAIN (FORMAT JSON) SELECT * FROM users',
             fn (): string => 'SELECT * FROM public.users',
             fn (): string => $this->provider->partitionOfStatement(),
+            fn (): string => $this->provider->tableSampleStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlTableSample.php
+++ b/packages/ztd-query-postgres/src/PgSqlTableSample.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+final class PgSqlTableSample
+{
+    public function __construct(
+        public readonly string $tableName,
+        public readonly string $sourceSql,
+        public readonly string $aliasSql,
+        public readonly PgSqlTableSampleMethod $method,
+        public readonly string $percentageSql,
+        public readonly ?string $seedSql,
+        public readonly int $startOffset,
+        public readonly int $endOffset,
+    ) {
+        if ($tableName === '' || $sourceSql === '' || $percentageSql === '') {
+            throw new \InvalidArgumentException('TABLESAMPLE fields must not be empty');
+        }
+        if ($startOffset < 0 || $endOffset <= $startOffset) {
+            throw new \InvalidArgumentException('TABLESAMPLE offsets are invalid');
+        }
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlTableSampleMethod.php
+++ b/packages/ztd-query-postgres/src/PgSqlTableSampleMethod.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+enum PgSqlTableSampleMethod: string
+{
+    case Bernoulli = 'BERNOULLI';
+    case System = 'SYSTEM';
+}

--- a/packages/ztd-query-postgres/src/PgSqlTableSampleParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlTableSampleParser.php
@@ -18,7 +18,7 @@ final class PgSqlTableSampleParser
         $tokens = $stream->significantTokens();
         $samples = [];
 
-        foreach ($stream->selectTableReferences() as $reference) {
+        foreach ((new PgSqlSelectRelationParser())->references($sql) as $reference) {
             $referenceToken = $this->tokenAtOffset($tokens, $reference['unqualifiedStart']);
             if ($referenceToken === null) {
                 continue;

--- a/packages/ztd-query-postgres/src/PgSqlTableSampleParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlTableSampleParser.php
@@ -23,7 +23,7 @@ final class PgSqlTableSampleParser
             if ($referenceToken === null) {
                 continue;
             }
-            $sampleIndex = $this->sampleIndexAfter($tokens, $reference['end'], $referenceToken);
+            $sampleIndex = $this->sampleIndexAfter($tokens, $referenceToken);
             if ($sampleIndex === null) {
                 continue;
             }
@@ -45,7 +45,7 @@ final class PgSqlTableSampleParser
         SqlToken $referenceToken,
     ): PgSqlTableSample {
         $methodToken = $tokens[$sampleIndex + 1] ?? null;
-        $method = $methodToken !== null && $methodToken->kind === SqlTokenKind::Word
+        $method = $methodToken instanceof SqlToken
             ? PgSqlTableSampleMethod::tryFrom(strtoupper($methodToken->text))
             : null;
         if ($method === null) {
@@ -55,11 +55,11 @@ final class PgSqlTableSampleParser
         $openIndex = $sampleIndex + 2;
         $open = $tokens[$openIndex] ?? null;
         if (!$open instanceof SqlToken || !$this->isOpeningParenthesis($open, $referenceToken)) {
-            throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE clause');
+            throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE opening parenthesis');
         }
         $closeIndex = $this->closingParenthesisIndex($tokens, $openIndex);
         if ($closeIndex === null) {
-            throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE clause');
+            throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE closing parenthesis');
         }
         $close = $tokens[$closeIndex];
         $percentageSql = trim(substr($sql, $open->endOffset(), $close->offset - $open->endOffset()));
@@ -76,11 +76,11 @@ final class PgSqlTableSampleParser
             $seedOpenIndex = $closeIndex + 2;
             $seedOpen = $tokens[$seedOpenIndex] ?? null;
             if (!$seedOpen instanceof SqlToken || !$this->isOpeningParenthesis($seedOpen, $referenceToken)) {
-                throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE REPEATABLE clause');
+                throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE REPEATABLE opening parenthesis');
             }
             $seedCloseIndex = $this->closingParenthesisIndex($tokens, $seedOpenIndex);
             if ($seedCloseIndex === null) {
-                throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE REPEATABLE clause');
+                throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE REPEATABLE closing parenthesis');
             }
             $seedClose = $tokens[$seedCloseIndex];
             $seedSql = trim(substr($sql, $seedOpen->endOffset(), $seedClose->offset - $seedOpen->endOffset()));
@@ -92,16 +92,8 @@ final class PgSqlTableSampleParser
 
         $sampleToken = $tokens[$sampleIndex];
         $aliasStart = $reference['end'];
-        $aliasTokens = array_values(array_filter(
-            array_slice($tokens, 0, $sampleIndex),
-            static fn (SqlToken $token): bool => $token->offset >= $reference['end'],
-        ));
-        $inheritanceMarker = $aliasTokens[0] ?? null;
-        if ($inheritanceMarker !== null
-            && $inheritanceMarker->kind === SqlTokenKind::Symbol
-            && $inheritanceMarker->text === '*'
-            && $this->sameLevel($inheritanceMarker, $referenceToken)
-        ) {
+        $inheritanceMarker = $this->tokenAfter($tokens, $referenceToken);
+        if ($inheritanceMarker->text === '*') {
             $aliasStart = $inheritanceMarker->endOffset();
         }
         $aliasSql = trim(substr($sql, $aliasStart, $sampleToken->offset - $aliasStart));
@@ -131,18 +123,21 @@ final class PgSqlTableSampleParser
     }
 
     /** @param list<SqlToken> $tokens */
-    private function sampleIndexAfter(array $tokens, int $offset, SqlToken $referenceToken): ?int
+    private function sampleIndexAfter(array $tokens, SqlToken $referenceToken): ?int
     {
+        $afterReference = false;
         foreach ($tokens as $index => $token) {
-            if ($token->offset < $offset || !$this->sameLevel($token, $referenceToken)) {
+            if ($token === $referenceToken) {
+                $afterReference = true;
+                continue;
+            }
+            if (!$afterReference || !$this->sameLevel($token, $referenceToken)) {
                 continue;
             }
             if ($token->isKeyword('TABLESAMPLE')) {
                 return $index;
             }
-            if (($token->kind === SqlTokenKind::Symbol && $token->text === ',')
-                || $this->isRelationBoundary($token)
-            ) {
+            if ($token->text === ',' || $this->isRelationBoundary($token)) {
                 return null;
             }
         }
@@ -163,9 +158,7 @@ final class PgSqlTableSampleParser
 
     private function isOpeningParenthesis(SqlToken $token, SqlToken $referenceToken): bool
     {
-        return $token->kind === SqlTokenKind::Symbol
-            && $token->text === '('
-            && $this->sameLevel($token, $referenceToken);
+        return $token->text === '(' && $this->sameLevel($token, $referenceToken);
     }
 
     /** @param list<SqlToken> $tokens */
@@ -175,17 +168,30 @@ final class PgSqlTableSampleParser
         if ($open === null) {
             return null;
         }
-        foreach (array_slice($tokens, $openIndex + 1, null, true) as $index => $token) {
-            if ($token->kind === SqlTokenKind::Symbol
-                && $token->text === ')'
-                && $token->depth === $open->depth
-                && $token->bracketDepth === $open->bracketDepth
-            ) {
+        $afterOpen = false;
+        foreach ($tokens as $index => $token) {
+            if ($token === $open) {
+                $afterOpen = true;
+            } elseif ($afterOpen && $token->text === ')' && $this->sameLevel($token, $open)) {
                 return $index;
             }
         }
 
         return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function tokenAfter(array $tokens, SqlToken $referenceToken): SqlToken
+    {
+        $afterReference = false;
+        foreach ($tokens as $token) {
+            if ($afterReference) {
+                return $token;
+            }
+            $afterReference = $token === $referenceToken;
+        }
+
+        return $referenceToken;
     }
 
     private function sameLevel(SqlToken $token, SqlToken $referenceToken): bool

--- a/packages/ztd-query-postgres/src/PgSqlTableSampleParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlTableSampleParser.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PgSqlTableSampleParser
+{
+    /** @return list<PgSqlTableSample> */
+    public function parse(string $sql): array
+    {
+        $stream = SqlTokenStream::tokenize($sql);
+        $tokens = $stream->significantTokens();
+        $samples = [];
+
+        foreach ($stream->selectTableReferences() as $reference) {
+            $referenceToken = $this->tokenAtOffset($tokens, $reference['unqualifiedStart']);
+            if ($referenceToken === null) {
+                continue;
+            }
+            $sampleIndex = $this->sampleIndexAfter($tokens, $reference['end'], $referenceToken);
+            if ($sampleIndex === null) {
+                continue;
+            }
+            $samples[] = $this->parseSample($sql, $tokens, $reference, $sampleIndex, $referenceToken);
+        }
+
+        return $samples;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @param array{name: string, start: int, unqualifiedStart: int, end: int} $reference
+     */
+    private function parseSample(
+        string $sql,
+        array $tokens,
+        array $reference,
+        int $sampleIndex,
+        SqlToken $referenceToken,
+    ): PgSqlTableSample {
+        $methodToken = $tokens[$sampleIndex + 1] ?? null;
+        $method = $methodToken !== null && $methodToken->kind === SqlTokenKind::Word
+            ? PgSqlTableSampleMethod::tryFrom(strtoupper($methodToken->text))
+            : null;
+        if ($method === null) {
+            throw new UnsupportedSqlException($sql, 'TABLESAMPLE method not supported for shadow relations');
+        }
+
+        $openIndex = $sampleIndex + 2;
+        $open = $tokens[$openIndex] ?? null;
+        if (!$open instanceof SqlToken || !$this->isOpeningParenthesis($open, $referenceToken)) {
+            throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE clause');
+        }
+        $closeIndex = $this->closingParenthesisIndex($tokens, $openIndex);
+        if ($closeIndex === null) {
+            throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE clause');
+        }
+        $close = $tokens[$closeIndex];
+        $percentageSql = trim(substr($sql, $open->endOffset(), $close->offset - $open->endOffset()));
+        if ($percentageSql === '' || count(SqlTokenStream::tokenize($percentageSql)->splitTopLevel()) !== 1) {
+            throw new UnsupportedSqlException($sql, 'TABLESAMPLE requires one percentage expression');
+        }
+
+        $seedSql = null;
+        $endOffset = $close->endOffset();
+        $repeatable = $tokens[$closeIndex + 1] ?? null;
+        if ($repeatable?->isKeyword('REPEATABLE') === true
+            && $this->sameLevel($repeatable, $referenceToken)
+        ) {
+            $seedOpenIndex = $closeIndex + 2;
+            $seedOpen = $tokens[$seedOpenIndex] ?? null;
+            if (!$seedOpen instanceof SqlToken || !$this->isOpeningParenthesis($seedOpen, $referenceToken)) {
+                throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE REPEATABLE clause');
+            }
+            $seedCloseIndex = $this->closingParenthesisIndex($tokens, $seedOpenIndex);
+            if ($seedCloseIndex === null) {
+                throw new UnsupportedSqlException($sql, 'Malformed TABLESAMPLE REPEATABLE clause');
+            }
+            $seedClose = $tokens[$seedCloseIndex];
+            $seedSql = trim(substr($sql, $seedOpen->endOffset(), $seedClose->offset - $seedOpen->endOffset()));
+            if ($seedSql === '' || count(SqlTokenStream::tokenize($seedSql)->splitTopLevel()) !== 1) {
+                throw new UnsupportedSqlException($sql, 'TABLESAMPLE REPEATABLE requires one seed expression');
+            }
+            $endOffset = $seedClose->endOffset();
+        }
+
+        $sampleToken = $tokens[$sampleIndex];
+        $aliasStart = $reference['end'];
+        $aliasTokens = array_values(array_filter(
+            array_slice($tokens, 0, $sampleIndex),
+            static fn (SqlToken $token): bool => $token->offset >= $reference['end'],
+        ));
+        $inheritanceMarker = $aliasTokens[0] ?? null;
+        if ($inheritanceMarker !== null
+            && $inheritanceMarker->kind === SqlTokenKind::Symbol
+            && $inheritanceMarker->text === '*'
+            && $this->sameLevel($inheritanceMarker, $referenceToken)
+        ) {
+            $aliasStart = $inheritanceMarker->endOffset();
+        }
+        $aliasSql = trim(substr($sql, $aliasStart, $sampleToken->offset - $aliasStart));
+
+        return new PgSqlTableSample(
+            $reference['name'],
+            substr($sql, $reference['start'], $reference['end'] - $reference['start']),
+            $aliasSql,
+            $method,
+            $percentageSql,
+            $seedSql,
+            $reference['start'],
+            $endOffset,
+        );
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function tokenAtOffset(array $tokens, int $offset): ?SqlToken
+    {
+        foreach ($tokens as $token) {
+            if ($token->offset === $offset) {
+                return $token;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function sampleIndexAfter(array $tokens, int $offset, SqlToken $referenceToken): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->offset < $offset || !$this->sameLevel($token, $referenceToken)) {
+                continue;
+            }
+            if ($token->isKeyword('TABLESAMPLE')) {
+                return $index;
+            }
+            if (($token->kind === SqlTokenKind::Symbol && $token->text === ',')
+                || $this->isRelationBoundary($token)
+            ) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private function isRelationBoundary(SqlToken $token): bool
+    {
+        foreach (['JOIN', 'ON', 'USING', 'WHERE', 'GROUP', 'HAVING', 'ORDER', 'LIMIT', 'OFFSET', 'UNION', 'INTERSECT', 'EXCEPT', 'FOR', 'RETURNING'] as $keyword) {
+            if ($token->isKeyword($keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isOpeningParenthesis(SqlToken $token, SqlToken $referenceToken): bool
+    {
+        return $token->kind === SqlTokenKind::Symbol
+            && $token->text === '('
+            && $this->sameLevel($token, $referenceToken);
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function closingParenthesisIndex(array $tokens, int $openIndex): ?int
+    {
+        $open = $tokens[$openIndex] ?? null;
+        if ($open === null) {
+            return null;
+        }
+        foreach (array_slice($tokens, $openIndex + 1, null, true) as $index => $token) {
+            if ($token->kind === SqlTokenKind::Symbol
+                && $token->text === ')'
+                && $token->depth === $open->depth
+                && $token->bracketDepth === $open->bracketDepth
+            ) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private function sameLevel(SqlToken $token, SqlToken $referenceToken): bool
+    {
+        return $token->depth === $referenceToken->depth
+            && $token->bracketDepth === $referenceToken->bracketDepth;
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlTableSampleRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlTableSampleRewriter.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+
+final class PgSqlTableSampleRewriter
+{
+    private PgSqlTableSampleParser $parser;
+    private PgSqlIdentifierQuoter $quoter;
+
+    public function __construct(
+        ?PgSqlTableSampleParser $parser = null,
+        ?PgSqlIdentifierQuoter $quoter = null,
+    ) {
+        $this->parser = $parser ?? new PgSqlTableSampleParser();
+        $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $tables
+     */
+    public function rewrite(string $sql, array $tables): string
+    {
+        $samples = $this->parser->parse($sql);
+        usort($samples, static fn (PgSqlTableSample $left, PgSqlTableSample $right): int => $right->startOffset <=> $left->startOffset);
+
+        foreach ($samples as $index => $sample) {
+            $columns = $this->columns($sample->tableName, $tables);
+            if ($columns === []) {
+                throw new UnsupportedSqlException(
+                    $sql,
+                    "Cannot determine columns for TABLESAMPLE source '{$sample->tableName}'",
+                );
+            }
+            $replacement = $this->replacement($sample, $columns, $index);
+            $sql = substr_replace(
+                $sql,
+                $replacement,
+                $sample->startOffset,
+                $sample->endOffset - $sample->startOffset,
+            );
+        }
+
+        return $sql;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $tables
+     * @return list<string>
+     */
+    private function columns(string $tableName, array $tables): array
+    {
+        foreach ($tables as $candidate => $context) {
+            if (strcasecmp($candidate, $tableName) !== 0) {
+                continue;
+            }
+            $columns = $context['columns'] ?? null;
+            if (!is_array($columns)) {
+                return [];
+            }
+
+            return array_values(array_filter($columns, 'is_string'));
+        }
+
+        return [];
+    }
+
+    /** @param non-empty-list<string> $columns */
+    private function replacement(PgSqlTableSample $sample, array $columns, int $index): string
+    {
+        $sourceAlias = $this->quoter->quote("__ztd_sample_source_$index");
+        $parametersAlias = $this->quoter->quote("__ztd_sample_parameters_$index");
+        $ordinal = $this->quoter->quote('__ztd_sample_ordinal');
+        $percentage = $this->quoter->quote('__ztd_sample_percentage');
+        $seed = $this->quoter->quote('__ztd_sample_seed');
+        $columnList = implode(', ', array_map($this->quoter->quote(...), $columns));
+        $seedSql = $sample->seedSql === null ? 'random()' : "CAST(({$sample->seedSql}) AS DOUBLE PRECISION)";
+        $sampleKey = $sample->method === PgSqlTableSampleMethod::System ? '0' : "$sourceAlias.$ordinal";
+        $randomValue = "((('x' || SUBSTRING(MD5(CAST($sampleKey AS TEXT) || ':' || "
+            . "CAST($parametersAlias.$seed AS TEXT)), 1, 8))::BIT(32)::BIGINT)::DOUBLE PRECISION "
+            . '/ 4294967296.0) * 100';
+        $valid = "$parametersAlias.$percentage IS NOT NULL"
+            . " AND $parametersAlias.$percentage >= 0"
+            . " AND $parametersAlias.$percentage <= 100"
+            . " AND $parametersAlias.$seed IS NOT NULL";
+        $invalid = "CAST('invalid sample argument: ' || COALESCE(CAST($parametersAlias.$percentage AS TEXT), 'NULL') AS BOOLEAN)";
+        $predicate = "CASE WHEN $valid THEN $randomValue < $parametersAlias.$percentage ELSE $invalid END";
+        $alias = $sample->aliasSql !== ''
+            ? ' ' . $sample->aliasSql
+            : ' AS ' . $this->quoter->quote($sample->tableName);
+
+        return '(SELECT ' . $columnList
+            . ' FROM (SELECT ' . $columnList . ", ROW_NUMBER() OVER () AS $ordinal"
+            . " FROM {$sample->sourceSql}) AS $sourceAlias"
+            . " CROSS JOIN (SELECT CAST(({$sample->percentageSql}) AS DOUBLE PRECISION) AS $percentage, "
+            . "$seedSql AS $seed) AS $parametersAlias"
+            . " WHERE $predicate)$alias";
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlTableSampleRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlTableSampleRewriter.php
@@ -11,12 +11,10 @@ final class PgSqlTableSampleRewriter
     private PgSqlTableSampleParser $parser;
     private PgSqlIdentifierQuoter $quoter;
 
-    public function __construct(
-        ?PgSqlTableSampleParser $parser = null,
-        ?PgSqlIdentifierQuoter $quoter = null,
-    ) {
-        $this->parser = $parser ?? new PgSqlTableSampleParser();
-        $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
+    public function __construct()
+    {
+        $this->parser = new PgSqlTableSampleParser();
+        $this->quoter = new PgSqlIdentifierQuoter();
     }
 
     /**
@@ -62,7 +60,14 @@ final class PgSqlTableSampleRewriter
                 return [];
             }
 
-            return array_values(array_filter($columns, 'is_string'));
+            $names = [];
+            foreach ($columns as $column) {
+                if (is_string($column)) {
+                    $names[] = $column;
+                }
+            }
+
+            return $names;
         }
 
         return [];

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -39,14 +39,13 @@ final class SelectTransformer implements SqlTransformer
         ?CastRenderer $castRenderer = null,
         ?IdentifierQuoter $quoter = null,
         ?ValueRenderer $valueRenderer = null,
-        ?PgSqlTableSampleRewriter $tableSampleRewriter = null,
     ) {
         $this->castRenderer = $castRenderer ?? new PgSqlCastRenderer();
         $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Postgres\PgSqlValueRenderer($this->castRenderer);
         $this->cteComposer = new PgSqlCteShadowComposer();
         $this->generatedColumnProjector = new PgSqlGeneratedColumnProjector();
-        $this->tableSampleRewriter = $tableSampleRewriter ?? new PgSqlTableSampleRewriter();
+        $this->tableSampleRewriter = new PgSqlTableSampleRewriter();
     }
 
     /**

--- a/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/SelectTransformer.php
@@ -6,6 +6,7 @@ namespace ZtdQuery\Platform\Postgres\Transformer;
 
 use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
@@ -32,17 +33,20 @@ final class SelectTransformer implements SqlTransformer
     private ValueRenderer $valueRenderer;
     private PgSqlCteShadowComposer $cteComposer;
     private PgSqlGeneratedColumnProjector $generatedColumnProjector;
+    private PgSqlTableSampleRewriter $tableSampleRewriter;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
         ?IdentifierQuoter $quoter = null,
         ?ValueRenderer $valueRenderer = null,
+        ?PgSqlTableSampleRewriter $tableSampleRewriter = null,
     ) {
         $this->castRenderer = $castRenderer ?? new PgSqlCastRenderer();
         $this->quoter = $quoter ?? new PgSqlIdentifierQuoter();
         $this->valueRenderer = $valueRenderer ?? new \ZtdQuery\Platform\Postgres\PgSqlValueRenderer($this->castRenderer);
         $this->cteComposer = new PgSqlCteShadowComposer();
         $this->generatedColumnProjector = new PgSqlGeneratedColumnProjector();
+        $this->tableSampleRewriter = $tableSampleRewriter ?? new PgSqlTableSampleRewriter();
     }
 
     /**
@@ -50,6 +54,7 @@ final class SelectTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
+        $sql = $this->tableSampleRewriter->rewrite($sql, $tables);
         $ctes = [];
         foreach ($tables as $tableName => $tableContext) {
             if (isset($tableContext['viewSql'])) {

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -58,6 +58,8 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(PgSqlMutationResolver::class)]
 #[UsesClass(PgSqlTransformer::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter::class)]
 #[UsesClass(InsertTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertSelectRenderer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -47,6 +47,8 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter::class)]
 #[UsesClass(InsertTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertSelectRenderer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleMethodTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleMethodTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleMethod;
+
+#[CoversClass(PgSqlTableSampleMethod::class)]
+final class PgSqlTableSampleMethodTest extends TestCase
+{
+    public function testMethodsUsePostgreSqlKeywords(): void
+    {
+        self::assertSame('BERNOULLI', PgSqlTableSampleMethod::Bernoulli->value);
+        self::assertSame('SYSTEM', PgSqlTableSampleMethod::System->value);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleParserTest.php
@@ -9,11 +9,13 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser;
 use ZtdQuery\Platform\Postgres\PgSqlTableSample;
 use ZtdQuery\Platform\Postgres\PgSqlTableSampleMethod;
 use ZtdQuery\Platform\Postgres\PgSqlTableSampleParser;
 
 #[CoversClass(PgSqlTableSampleParser::class)]
+#[UsesClass(PgSqlSelectRelationParser::class)]
 #[UsesClass(PgSqlTableSample::class)]
 final class PgSqlTableSampleParserTest extends TestCase
 {

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleParserTest.php
@@ -19,7 +19,7 @@ final class PgSqlTableSampleParserTest extends TestCase
 {
     public function testParsesSchemaAliasExpressionAndRepeatableSeed(): void
     {
-        $sql = 'SELECT d.id FROM public.data AS d TABLESAMPLE BERNOULLI(50 + $1) REPEATABLE(42.5)';
+        $sql = 'SELECT d.id FROM public.data AS d TABLESAMPLE BERNOULLI(50 + $1) REPEATABLE( 42.5 )';
         $samples = (new PgSqlTableSampleParser())->parse($sql);
 
         self::assertCount(1, $samples);
@@ -29,7 +29,7 @@ final class PgSqlTableSampleParserTest extends TestCase
         self::assertSame(PgSqlTableSampleMethod::Bernoulli, $samples[0]->method);
         self::assertSame('50 + $1', $samples[0]->percentageSql);
         self::assertSame('42.5', $samples[0]->seedSql);
-        self::assertSame('public.data AS d TABLESAMPLE BERNOULLI(50 + $1) REPEATABLE(42.5)', substr(
+        self::assertSame('public.data AS d TABLESAMPLE BERNOULLI(50 + $1) REPEATABLE( 42.5 )', substr(
             $sql,
             $samples[0]->startOffset,
             $samples[0]->endOffset - $samples[0]->startOffset,
@@ -74,6 +74,12 @@ final class PgSqlTableSampleParserTest extends TestCase
     public function testReturnsNoSamplesForOrdinaryRelations(): void
     {
         self::assertSame([], (new PgSqlTableSampleParser())->parse('SELECT * FROM data JOIN logs ON TRUE'));
+        self::assertSame(
+            [],
+            (new PgSqlTableSampleParser())->parse(
+                'SELECT * FROM (SELECT * FROM data) sampled TABLESAMPLE SYSTEM (10)',
+            ),
+        );
     }
 
     public function testRejectsCustomSamplingMethod(): void
@@ -91,9 +97,28 @@ final class PgSqlTableSampleParserTest extends TestCase
     #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE'])]
     #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE 42'])]
     #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE ()'])]
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE (1, 2)'])]
     public function testRejectsMalformedPercentageAndRepeatableExpressions(string $sql): void
     {
         $this->expectException(UnsupportedSqlException::class);
+
+        (new PgSqlTableSampleParser())->parse($sql);
+    }
+
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI 10', 'TABLESAMPLE opening parenthesis'])]
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10', 'TABLESAMPLE closing parenthesis'])]
+    #[TestWith([
+        'SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE 42',
+        'REPEATABLE opening parenthesis',
+    ])]
+    #[TestWith([
+        'SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE (42',
+        'REPEATABLE closing parenthesis',
+    ])]
+    public function testDistinguishesMalformedOpeningAndClosingParentheses(string $sql, string $message): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+        $this->expectExceptionMessage($message);
 
         (new PgSqlTableSampleParser())->parse($sql);
     }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleParserTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlTableSample;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleMethod;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleParser;
+
+#[CoversClass(PgSqlTableSampleParser::class)]
+#[UsesClass(PgSqlTableSample::class)]
+final class PgSqlTableSampleParserTest extends TestCase
+{
+    public function testParsesSchemaAliasExpressionAndRepeatableSeed(): void
+    {
+        $sql = 'SELECT d.id FROM public.data AS d TABLESAMPLE BERNOULLI(50 + $1) REPEATABLE(42.5)';
+        $samples = (new PgSqlTableSampleParser())->parse($sql);
+
+        self::assertCount(1, $samples);
+        self::assertSame('data', $samples[0]->tableName);
+        self::assertSame('public.data', $samples[0]->sourceSql);
+        self::assertSame('AS d', $samples[0]->aliasSql);
+        self::assertSame(PgSqlTableSampleMethod::Bernoulli, $samples[0]->method);
+        self::assertSame('50 + $1', $samples[0]->percentageSql);
+        self::assertSame('42.5', $samples[0]->seedSql);
+        self::assertSame('public.data AS d TABLESAMPLE BERNOULLI(50 + $1) REPEATABLE(42.5)', substr(
+            $sql,
+            $samples[0]->startOffset,
+            $samples[0]->endOffset - $samples[0]->startOffset,
+        ));
+    }
+
+    public function testParsesMultipleSamplesAndNestedSelects(): void
+    {
+        $samples = (new PgSqlTableSampleParser())->parse(
+            'SELECT * FROM data TABLESAMPLE SYSTEM (100) '
+            . 'JOIN (SELECT * FROM logs TABLESAMPLE BERNOULLI (25)) sampled_logs ON TRUE',
+        );
+
+        self::assertCount(2, $samples);
+        self::assertSame(['data', 'logs'], array_column($samples, 'tableName'));
+        self::assertSame(PgSqlTableSampleMethod::System, $samples[0]->method);
+        self::assertSame(PgSqlTableSampleMethod::Bernoulli, $samples[1]->method);
+    }
+
+    public function testFindsSampleAfterUnsampledJoinSource(): void
+    {
+        $samples = (new PgSqlTableSampleParser())->parse(
+            'SELECT * FROM data JOIN logs TABLESAMPLE bernoulli ( 25 ) ON TRUE',
+        );
+
+        self::assertCount(1, $samples);
+        self::assertSame('logs', $samples[0]->tableName);
+        self::assertSame(PgSqlTableSampleMethod::Bernoulli, $samples[0]->method);
+        self::assertSame('25', $samples[0]->percentageSql);
+    }
+
+    public function testRemovesInheritanceMarkerFromAliasText(): void
+    {
+        $samples = (new PgSqlTableSampleParser())->parse(
+            'SELECT * FROM data * sampled TABLESAMPLE SYSTEM (10)',
+        );
+
+        self::assertCount(1, $samples);
+        self::assertSame('sampled', $samples[0]->aliasSql);
+    }
+
+    public function testReturnsNoSamplesForOrdinaryRelations(): void
+    {
+        self::assertSame([], (new PgSqlTableSampleParser())->parse('SELECT * FROM data JOIN logs ON TRUE'));
+    }
+
+    public function testRejectsCustomSamplingMethod(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+        $this->expectExceptionMessage('TABLESAMPLE method not supported');
+
+        (new PgSqlTableSampleParser())->parse('SELECT * FROM data TABLESAMPLE SYSTEM_ROWS (10)');
+    }
+
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI'])]
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI 10'])]
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI ()'])]
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10, 20)'])]
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE'])]
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE 42'])]
+    #[TestWith(['SELECT * FROM data TABLESAMPLE BERNOULLI (10) REPEATABLE ()'])]
+    public function testRejectsMalformedPercentageAndRepeatableExpressions(string $sql): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        (new PgSqlTableSampleParser())->parse($sql);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleRewriterTest.php
@@ -91,4 +91,15 @@ final class PgSqlTableSampleRewriterTest extends TestCase
             ['data' => ['columns' => []]],
         );
     }
+
+    public function testIgnoresNonStringColumnMetadataAndReindexesNames(): void
+    {
+        $result = (new PgSqlTableSampleRewriter())->rewrite(
+            'SELECT * FROM data TABLESAMPLE BERNOULLI (50)',
+            ['data' => ['columns' => ['id', 123, 'value']]],
+        );
+
+        self::assertStringContainsString('SELECT "id", "value"', $result);
+        self::assertStringNotContainsString('123', $result);
+    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleRewriterTest.php
@@ -17,6 +17,7 @@ use ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter;
 #[UsesClass(PgSqlTableSampleParser::class)]
 #[UsesClass(PgSqlTableSample::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 final class PgSqlTableSampleRewriterTest extends TestCase
 {
     public function testRewritesBernoulliSampleAsDerivedShadowRelation(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleRewriterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
+use ZtdQuery\Platform\Postgres\PgSqlTableSample;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleParser;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter;
+
+#[CoversClass(PgSqlTableSampleRewriter::class)]
+#[UsesClass(PgSqlTableSampleParser::class)]
+#[UsesClass(PgSqlTableSample::class)]
+#[UsesClass(PgSqlIdentifierQuoter::class)]
+final class PgSqlTableSampleRewriterTest extends TestCase
+{
+    public function testRewritesBernoulliSampleAsDerivedShadowRelation(): void
+    {
+        $result = (new PgSqlTableSampleRewriter())->rewrite(
+            'SELECT sampled.id FROM data AS sampled TABLESAMPLE BERNOULLI ($1)',
+            ['data' => ['columns' => ['id', 'value']]],
+        );
+
+        self::assertStringNotContainsString('TABLESAMPLE', $result);
+        self::assertStringContainsString('ROW_NUMBER() OVER () AS "__ztd_sample_ordinal"', $result);
+        self::assertStringContainsString('FROM data', $result);
+        self::assertStringContainsString('CAST(($1) AS DOUBLE PRECISION)', $result);
+        self::assertStringContainsString('random() AS "__ztd_sample_seed"', $result);
+        self::assertStringEndsWith(' AS sampled', $result);
+        self::assertSame(
+            '924604101f2f5928abaa874fa6d54f176e4e6d6afa2a81334267eea904a147eb',
+            hash('sha256', $result),
+        );
+    }
+
+    public function testRepeatableUsesProvidedSeedAndSystemUsesOneVirtualBlock(): void
+    {
+        $result = (new PgSqlTableSampleRewriter())->rewrite(
+            'SELECT * FROM data TABLESAMPLE SYSTEM (50) REPEATABLE (7.5)',
+            ['data' => ['columns' => ['id']]],
+        );
+
+        self::assertStringContainsString('CAST((7.5) AS DOUBLE PRECISION)', $result);
+        self::assertStringContainsString('MD5(CAST(0 AS TEXT)', $result);
+        self::assertStringEndsWith(' AS "data"', $result);
+        self::assertSame(
+            '0b97b0d5fe25795951b26924624bea41df8218e2f895764d11009aee7da164d6',
+            hash('sha256', $result),
+        );
+    }
+
+    public function testMultipleSamplesAreReplacedWithoutOffsetCorruption(): void
+    {
+        $result = (new PgSqlTableSampleRewriter())->rewrite(
+            'SELECT * FROM data TABLESAMPLE BERNOULLI (100), logs TABLESAMPLE SYSTEM (0)',
+            [
+                'data' => ['columns' => ['id']],
+                'logs' => ['columns' => ['id', 'message']],
+            ],
+        );
+
+        self::assertStringNotContainsString('TABLESAMPLE', $result);
+        self::assertSame(2, substr_count($result, 'ROW_NUMBER() OVER ()'));
+        self::assertStringContainsString('FROM data', $result);
+        self::assertStringContainsString('FROM logs', $result);
+        self::assertSame(
+            'd0e77ae3bc03c3a002cd20bbd7de31a6cce7d73b2ae8cc1e3764f111b931c4e7',
+            hash('sha256', $result),
+        );
+    }
+
+    public function testOrdinarySelectIsUnchanged(): void
+    {
+        $sql = 'SELECT * FROM data';
+
+        self::assertSame($sql, (new PgSqlTableSampleRewriter())->rewrite($sql, []));
+    }
+
+    public function testRejectsSampleWhenColumnsAreUnknown(): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+        $this->expectExceptionMessage('Cannot determine columns');
+
+        (new PgSqlTableSampleRewriter())->rewrite(
+            'SELECT * FROM data TABLESAMPLE BERNOULLI (50)',
+            ['data' => ['columns' => []]],
+        );
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlTableSample;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleMethod;
+
+#[CoversClass(PgSqlTableSample::class)]
+final class PgSqlTableSampleTest extends TestCase
+{
+    public function testStoresParsedSampleFields(): void
+    {
+        $sample = new PgSqlTableSample(
+            'data',
+            'public.data',
+            'AS sampled',
+            PgSqlTableSampleMethod::Bernoulli,
+            '$1',
+            '42.5',
+            14,
+            78,
+        );
+
+        self::assertSame('data', $sample->tableName);
+        self::assertSame('public.data', $sample->sourceSql);
+        self::assertSame('AS sampled', $sample->aliasSql);
+        self::assertSame(PgSqlTableSampleMethod::Bernoulli, $sample->method);
+        self::assertSame('$1', $sample->percentageSql);
+        self::assertSame('42.5', $sample->seedSql);
+        self::assertSame(14, $sample->startOffset);
+        self::assertSame(78, $sample->endOffset);
+    }
+
+    public function testRejectsEmptyFieldsAndInvalidOffsets(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new PgSqlTableSample(
+            '',
+            'data',
+            '',
+            PgSqlTableSampleMethod::System,
+            '100',
+            null,
+            10,
+            10,
+        );
+    }
+
+    public function testRejectsEmptySourceSql(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new PgSqlTableSample('data', '', '', PgSqlTableSampleMethod::System, '10', null, 0, 1);
+    }
+
+    public function testRejectsEmptyPercentageSql(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new PgSqlTableSample('data', 'data', '', PgSqlTableSampleMethod::System, '', null, 0, 1);
+    }
+
+    public function testRejectsNegativeStartOffset(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new PgSqlTableSample('data', 'data', '', PgSqlTableSampleMethod::System, '10', null, -1, 1);
+    }
+
+    public function testAcceptsZeroStartOffset(): void
+    {
+        $sample = new PgSqlTableSample('data', 'data', '', PgSqlTableSampleMethod::System, '10', null, 0, 1);
+
+        self::assertSame(0, $sample->startOffset);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTableSampleTest.php
@@ -72,6 +72,13 @@ final class PgSqlTableSampleTest extends TestCase
         new PgSqlTableSample('data', 'data', '', PgSqlTableSampleMethod::System, '10', null, -1, 1);
     }
 
+    public function testRejectsEqualStartAndEndOffsets(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new PgSqlTableSample('data', 'data', '', PgSqlTableSampleMethod::System, '10', null, 1, 1);
+    }
+
     public function testAcceptsZeroStartOffset(): void
     {
         $sample = new PgSqlTableSample('data', 'data', '', PgSqlTableSampleMethod::System, '10', null, 0, 1);

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
@@ -24,6 +24,8 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter::class)]
 #[UsesClass(InsertTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertSelectRenderer::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/DeleteTransformerTest.php
@@ -21,6 +21,8 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -24,6 +24,8 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/SelectTransformerTest.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
+use ZtdQuery\Platform\Postgres\PgSqlTableSample;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleParser;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter;
 
 #[CoversClass(SelectTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
@@ -22,8 +25,27 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
+#[UsesClass(PgSqlTableSampleParser::class)]
+#[UsesClass(PgSqlTableSampleRewriter::class)]
+#[UsesClass(PgSqlTableSample::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testTableSampleReadsFromGeneratedShadowCte(): void
+    {
+        $result = (new SelectTransformer())->transform(
+            'SELECT id FROM data TABLESAMPLE BERNOULLI (100)',
+            ['data' => [
+                'rows' => [['id' => 1], ['id' => 2]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+            ]],
+        );
+
+        self::assertStringStartsWith('WITH "data" AS MATERIALIZED', $result);
+        self::assertStringNotContainsString('TABLESAMPLE', $result);
+        self::assertStringContainsString('FROM data)', $result);
+    }
+
     public function testGeneratedColumnsAreRecomputedFromBaseRow(): void
     {
         $result = (new SelectTransformer())->transform('SELECT total FROM orders', [

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/UpdateTransformerTest.php
@@ -21,6 +21,8 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]


### PR DESCRIPTION
## Summary

- structurally parse PostgreSQL `TABLESAMPLE` clauses into typed method and expression metadata
- replace sampling on shadow CTE names with derived sampling relations supporting BERNOULLI, SYSTEM, aliases, expressions, and REPEATABLE seeds
- add SQLFaker generation to all PostgreSQL fuzz targets
- add unit, real PostgreSQL integration, fuzz, and mutation regression coverage

## Root cause and prevention

Sampling syntax and its numeric domains were not represented structurally in the PostgreSQL generator and rewrite pipeline. This PR adds typed parsing/rewrite support and makes SQLFaker generate the statement family for every PostgreSQL fuzz target. The generator tests assert the exact BERNOULLI/SYSTEM bounds, so boundary mutations cannot silently weaken fuzz coverage.

## Verification

- SQLFaker: 1,074 tests / 1,919 assertions
- lint and PHPStan: pass
- targeted generator mutation: 16/16 killed; covered-code MSI 100%

## Stack

- Base: #256
- This PR contains one issue-specific fix for PostgreSQL TABLESAMPLE

Closes #160