### PR TITLE
fix(mysql): honor explicit partition selection

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -193,6 +193,22 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function partitionSelectStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('select_stmt', [
+            'query_expression' => [
+                ProductionPattern::exactly('query_expression_body', 'opt_order_clause', 'opt_limit_clause'),
+            ],
+            'query_expression_body' => [ProductionPattern::exactly('query_primary')],
+            'query_primary' => [ProductionPattern::exactly('query_specification')],
+            'opt_from_clause' => [ProductionPattern::nonEmpty()],
+            'from_tables' => [ProductionPattern::exactly('table_reference_list')],
+            'table_factor' => [ProductionPattern::exactly('single_table')],
+            'opt_use_partition' => [ProductionPattern::nonEmpty()],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -730,8 +730,8 @@ final class MySqlProvider extends Base
         return $this->sql->generate(GenerationPlans::foreignKeyCascadeStatement()->withMaxDepth($maxDepth));
     }
     /** @return non-empty-string */
-    public function partitionSelectStatement(): string
+    public function partitionSelectStatement(int $maxDepth = 40): string
     {
-        return 'SELECT * FROM events PARTITION (p2024)';
+        return $this->sql->generate(GenerationPlans::partitionSelectStatement()->withMaxDepth($maxDepth));
     }
 }

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -729,4 +729,9 @@ final class MySqlProvider extends Base
     {
         return $this->sql->generate(GenerationPlans::foreignKeyCascadeStatement()->withMaxDepth($maxDepth));
     }
+    /** @return non-empty-string */
+    public function partitionSelectStatement(): string
+    {
+        return 'SELECT * FROM events PARTITION (p2024)';
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -243,4 +243,13 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('delete_option', 0)?->matches(['CASCADE']) ?? false);
         self::assertTrue($plan->patternAt('delete_option', 1)?->matches(['CASCADE']) ?? false);
     }
+
+    public function testPartitionSelectPlanRequiresThePartitionClause(): void
+    {
+        $plan = GenerationPlans::partitionSelectStatement();
+
+        self::assertSame('select_stmt', $plan->startRule());
+        self::assertNotNull($plan->patternAt('opt_from_clause', 0));
+        self::assertNotNull($plan->patternAt('opt_use_partition', 0));
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -249,7 +249,18 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::partitionSelectStatement();
 
         self::assertSame('select_stmt', $plan->startRule());
-        self::assertNotNull($plan->patternAt('opt_from_clause', 0));
-        self::assertNotNull($plan->patternAt('opt_use_partition', 0));
+        self::assertTrue(
+            $plan->patternAt('query_expression', 0)?->matches([
+                'query_expression_body',
+                'opt_order_clause',
+                'opt_limit_clause',
+            ]) ?? false,
+        );
+        self::assertTrue($plan->patternAt('query_expression_body', 0)?->matches(['query_primary']) ?? false);
+        self::assertTrue($plan->patternAt('query_primary', 0)?->matches(['query_specification']) ?? false);
+        self::assertTrue($plan->patternAt('opt_from_clause', 0)?->matches(['from_tables']) ?? false);
+        self::assertTrue($plan->patternAt('from_tables', 0)?->matches(['table_reference_list']) ?? false);
+        self::assertTrue($plan->patternAt('table_factor', 0)?->matches(['single_table']) ?? false);
+        self::assertTrue($plan->patternAt('opt_use_partition', 0)?->matches(['PARTITION_SYM']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -165,11 +165,26 @@ final class MySqlProviderTest extends TestCase
         self::assertStringContainsString('ON_SYM DELETE_SYM CASCADE', implode(' ', $tokens));
     }
 
-    public function testPartitionSelectStatement(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testPartitionSelectStatement(int $seed): void
     {
-        $sql = (new MySqlProvider(Factory::create()))->partitionSelectStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new MySqlProvider($faker);
+        $sql = $provider->partitionSelectStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'mysql-8.4.7', true))
+            ->tokenize($sql);
+        $select = array_search('SELECT_SYM', $tokens, true);
+        $from = array_search('FROM', $tokens, true);
+        $partition = array_search('PARTITION_SYM', $tokens, true);
 
-        self::assertSame('SELECT * FROM events PARTITION (p2024)', $sql);
+        self::assertSame($sql, $provider->partitionSelectStatement(40));
+        self::assertIsInt($select);
+        self::assertIsInt($from);
+        self::assertIsInt($partition);
+        self::assertGreaterThan($select, $from);
+        self::assertGreaterThan($from, $partition);
     }
 
     public function testSql(): void

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -165,6 +165,13 @@ final class MySqlProviderTest extends TestCase
         self::assertStringContainsString('ON_SYM DELETE_SYM CASCADE', implode(' ', $tokens));
     }
 
+    public function testPartitionSelectStatement(): void
+    {
+        $sql = (new MySqlProvider(Factory::create()))->partitionSelectStatement();
+
+        self::assertSame('SELECT * FROM events PARTITION (p2024)', $sql);
+    }
+
     public function testSql(): void
     {
         $faker = Factory::create();

--- a/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
+++ b/packages/ztd-query-core/src/Rewrite/SqlTransformer.php
@@ -26,7 +26,8 @@ interface SqlTransformer
      *     candidateKeys?: array<string, array<int, string>>,
      *     columnDefaults?: array<string, string>,
      *     identityStrategies?: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
-     *     generatedExpressions?: array<string, string>
+     *     generatedExpressions?: array<string, string>,
+     *     partitioning?: \ZtdQuery\Schema\TablePartitioning|null
      * }> $tables Table name => shadow data and column information.
      * @return string The transformed SQL.
      */

--- a/packages/ztd-query-core/src/Schema/TableDefinition.php
+++ b/packages/ztd-query-core/src/Schema/TableDefinition.php
@@ -26,6 +26,8 @@ final class TableDefinition
     /** @var array<string, ForeignKeyDefinition> */
     public readonly array $foreignKeys;
 
+    public readonly ?TablePartitioning $partitioning;
+
     /**
      * @param array<int, string> $columns Column names in declaration order.
      * @param array<string, string> $columnTypes Column name => MySQL type string.
@@ -37,6 +39,7 @@ final class TableDefinition
      * @param array<string, IdentityGenerationStrategy> $identityStrategies Column name => shadow generation strategy.
      * @param array<string, string> $generatedExpressions Column name => database generated expression.
      * @param array<string, ForeignKeyDefinition> $foreignKeys Constraint name => foreign-key definition.
+     * @param TablePartitioning|null $partitioning Named partition selection predicates.
      */
     public function __construct(
         public readonly array $columns,
@@ -49,16 +52,35 @@ final class TableDefinition
         array $identityStrategies = [],
         array $generatedExpressions = [],
         array $foreignKeys = [],
+        ?TablePartitioning $partitioning = null,
     ) {
         $this->typedColumns = $typedColumns;
         $this->columnDefaults = $columnDefaults;
         $this->identityStrategies = $identityStrategies;
         $this->generatedExpressions = $generatedExpressions;
         $this->foreignKeys = $foreignKeys;
+        $this->partitioning = $partitioning;
     }
 
     public function candidateKeys(): CandidateKeySet
     {
         return CandidateKeySet::fromSchema($this->primaryKeys, $this->uniqueConstraints);
+    }
+
+    public function withPartitioning(?TablePartitioning $partitioning): self
+    {
+        return new self(
+            $this->columns,
+            $this->columnTypes,
+            $this->primaryKeys,
+            $this->notNullColumns,
+            $this->uniqueConstraints,
+            $this->typedColumns,
+            $this->columnDefaults,
+            $this->identityStrategies,
+            $this->generatedExpressions,
+            $this->foreignKeys,
+            $partitioning,
+        );
     }
 }

--- a/packages/ztd-query-core/src/Schema/TablePartitioning.php
+++ b/packages/ztd-query-core/src/Schema/TablePartitioning.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+/**
+ * Predicates that select rows belonging to named table partitions.
+ */
+final class TablePartitioning
+{
+    /** @var array<string, string> */
+    private readonly array $selectionPredicates;
+
+    /** @param array<string, string> $selectionPredicates */
+    public function __construct(array $selectionPredicates)
+    {
+        $normalized = [];
+        foreach ($selectionPredicates as $name => $predicate) {
+            if (trim($name) === '' || trim($predicate) === '') {
+                throw new \InvalidArgumentException('Partition names and predicates must not be empty.');
+            }
+            $normalized[strtolower($name)] = $predicate;
+        }
+        $this->selectionPredicates = $normalized;
+    }
+
+    /** @param non-empty-list<string> $names */
+    public function predicateFor(array $names): ?string
+    {
+        $predicates = [];
+        foreach ($names as $name) {
+            $normalized = strtolower($name);
+            if (!isset($this->selectionPredicates[$normalized])) {
+                return null;
+            }
+            $predicates[$normalized] = $this->selectionPredicates[$normalized];
+        }
+
+        return implode(' OR ', array_map(
+            static fn (string $predicate): string => "($predicate)",
+            $predicates,
+        ));
+    }
+}

--- a/packages/ztd-query-core/src/Schema/TablePartitioning.php
+++ b/packages/ztd-query-core/src/Schema/TablePartitioning.php
@@ -25,8 +25,11 @@ final class TablePartitioning
         $this->selectionPredicates = $normalized;
     }
 
-    /** @param non-empty-list<string> $names */
-    public function predicateFor(array $names): ?string
+    /**
+     * @param non-empty-list<string> $names
+     * @return list<string>|null
+     */
+    public function predicatesFor(array $names): ?array
     {
         $predicates = [];
         foreach ($names as $name) {
@@ -37,9 +40,6 @@ final class TablePartitioning
             $predicates[$normalized] = $this->selectionPredicates[$normalized];
         }
 
-        return implode(' OR ', array_map(
-            static fn (string $predicate): string => "($predicate)",
-            $predicates,
-        ));
+        return array_values($predicates);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
@@ -48,7 +48,7 @@ final class TableDefinitionTest extends TestCase
         self::assertSame(['id' => IdentityGenerationStrategy::MaxValue], $definition->identityStrategies);
         self::assertSame(['name' => "CONCAT('user-', id)"], $definition->generatedExpressions);
         self::assertSame(['fk_parent'], array_keys($definition->foreignKeys));
-        self::assertSame('(id < 10)', $definition->partitioning?->predicateFor(['p0']));
+        self::assertSame(['id < 10'], $definition->partitioning?->predicatesFor(['p0']));
     }
 
     public function testTypedColumnsDefaultsToEmpty(): void

--- a/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
@@ -10,11 +10,13 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Schema\ForeignKeyDefinition;
 use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Schema\TablePartitioning;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[UsesClass(ColumnType::class)]
 #[UsesClass(ForeignKeyDefinition::class)]
+#[UsesClass(TablePartitioning::class)]
 #[CoversClass(TableDefinition::class)]
 final class TableDefinitionTest extends TestCase
 {
@@ -33,6 +35,7 @@ final class TableDefinitionTest extends TestCase
             ['id' => IdentityGenerationStrategy::MaxValue],
             ['name' => "CONCAT('user-', id)"],
             ['fk_parent' => new ForeignKeyDefinition(['id'], 'parents', ['id'])],
+            new TablePartitioning(['p0' => 'id < 10']),
         );
 
         self::assertSame(['id', 'name'], $definition->columns);
@@ -45,6 +48,7 @@ final class TableDefinitionTest extends TestCase
         self::assertSame(['id' => IdentityGenerationStrategy::MaxValue], $definition->identityStrategies);
         self::assertSame(['name' => "CONCAT('user-', id)"], $definition->generatedExpressions);
         self::assertSame(['fk_parent'], array_keys($definition->foreignKeys));
+        self::assertSame('(id < 10)', $definition->partitioning?->predicateFor(['p0']));
     }
 
     public function testTypedColumnsDefaultsToEmpty(): void
@@ -62,5 +66,19 @@ final class TableDefinitionTest extends TestCase
         self::assertSame([], $definition->identityStrategies);
         self::assertSame([], $definition->generatedExpressions);
         self::assertSame([], $definition->foreignKeys);
+        self::assertNull($definition->partitioning);
+    }
+
+    public function testWithPartitioningPreservesSchemaAndReturnsNewDefinition(): void
+    {
+        $definition = new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []);
+        $partitioning = new TablePartitioning(['p0' => 'id < 10']);
+
+        $partitioned = $definition->withPartitioning($partitioning);
+
+        self::assertNotSame($definition, $partitioned);
+        self::assertSame($definition->columns, $partitioned->columns);
+        self::assertSame($definition->primaryKeys, $partitioned->primaryKeys);
+        self::assertSame($partitioning, $partitioned->partitioning);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/TablePartitioningTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TablePartitioningTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\TablePartitioning;
+
+#[CoversClass(TablePartitioning::class)]
+final class TablePartitioningTest extends TestCase
+{
+    public function testCombinesNamedPredicatesCaseInsensitivelyAndWithoutDuplicates(): void
+    {
+        $partitioning = new TablePartitioning([
+            'Recent' => 'created_at >= 2024',
+            'Archive' => 'created_at < 2024',
+        ]);
+
+        self::assertSame(
+            '(created_at >= 2024) OR (created_at < 2024)',
+            $partitioning->predicateFor(['RECENT', 'archive', 'recent']),
+        );
+    }
+
+    public function testReturnsNullForUnknownPartition(): void
+    {
+        self::assertNull((new TablePartitioning(['p0' => 'id < 10']))->predicateFor(['missing']));
+    }
+
+    public function testRejectsEmptyPartitionMetadata(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        new TablePartitioning(['' => 'id < 10']);
+    }
+
+    public function testRejectsEmptyPartitionPredicate(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        new TablePartitioning(['p0' => '  ']);
+    }
+
+    public function testRejectsWhitespacePartitionName(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        new TablePartitioning(['  ' => 'id < 10']);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/TablePartitioningTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TablePartitioningTest.php
@@ -19,14 +19,14 @@ final class TablePartitioningTest extends TestCase
         ]);
 
         self::assertSame(
-            '(created_at >= 2024) OR (created_at < 2024)',
-            $partitioning->predicateFor(['RECENT', 'archive', 'recent']),
+            ['created_at >= 2024', 'created_at < 2024'],
+            $partitioning->predicatesFor(['RECENT', 'archive', 'recent']),
         );
     }
 
     public function testReturnsNullForUnknownPartition(): void
     {
-        self::assertNull((new TablePartitioning(['p0' => 'id < 10']))->predicateFor(['missing']));
+        self::assertNull((new TablePartitioning(['p0' => 'id < 10']))->predicatesFor(['missing']));
     }
 
     public function testRejectsEmptyPartitionMetadata(): void

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/ClassifyTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/ClassifyTarget.php
@@ -61,6 +61,7 @@ final class ClassifyTarget
             fn () => $this->provider->alterTableStatement(maxDepth: 5),
             fn () => $this->provider->replaceStatement(maxDepth: 5),
             fn () => $this->provider->truncateStatement(maxDepth: 3),
+            fn (): string => $this->provider->partitionSelectStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -87,6 +87,7 @@ final class RewriteTarget
             'orders' => 'CREATE TABLE orders (id INT PRIMARY KEY, user_id INT NOT NULL, amount DECIMAL(10,2), created_at DATETIME)',
             'order_items' => 'CREATE TABLE order_items (order_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL DEFAULT 1, PRIMARY KEY (order_id, product_id))',
             'products' => 'CREATE TABLE products (id INT PRIMARY KEY, name VARCHAR(255) NOT NULL, price DECIMAL(10,2), category VARCHAR(100))',
+            'events' => 'CREATE TABLE events (id INT PRIMARY KEY, event_date DATE) PARTITION BY RANGE (YEAR(event_date)) (PARTITION p2023 VALUES LESS THAN (2024), PARTITION p2024 VALUES LESS THAN (2025), PARTITION pmax VALUES LESS THAN MAXVALUE)',
         ];
 
         foreach ($schemas as $tableName => $createSql) {
@@ -116,6 +117,10 @@ final class RewriteTarget
         $store->set('products', [
             ['id' => '1', 'name' => 'Widget', 'price' => '19.99', 'category' => 'tools'],
             ['id' => '2', 'name' => 'Gadget', 'price' => '49.99', 'category' => 'electronics'],
+        ]);
+        $store->set('events', [
+            ['id' => '1', 'event_date' => '2023-06-01'],
+            ['id' => '2', 'event_date' => '2024-06-01'],
         ]);
     }
 
@@ -151,6 +156,7 @@ final class RewriteTarget
             fn (): string => $this->provider->viewStatement(),
             fn (): string => $this->provider->generatedColumnStatement(),
             fn (): string => $this->provider->foreignKeyCascadeStatement(),
+            fn (): string => $this->provider->partitionSelectStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -132,6 +132,7 @@ final class RobustnessTarget
             'orders' => 'CREATE TABLE orders (id INT PRIMARY KEY, user_id INT NOT NULL, amount DECIMAL(10,2), created_at DATETIME)',
             'order_items' => 'CREATE TABLE order_items (order_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL DEFAULT 1, PRIMARY KEY (order_id, product_id))',
             'products' => 'CREATE TABLE products (id INT PRIMARY KEY, name VARCHAR(255) NOT NULL, price DECIMAL(10,2), category VARCHAR(100))',
+            'events' => 'CREATE TABLE events (id INT PRIMARY KEY, event_date DATE) PARTITION BY RANGE (YEAR(event_date)) (PARTITION p2023 VALUES LESS THAN (2024), PARTITION p2024 VALUES LESS THAN (2025), PARTITION pmax VALUES LESS THAN MAXVALUE)',
         ];
 
         foreach ($schemas as $tableName => $createSql) {
@@ -166,6 +167,10 @@ final class RobustnessTarget
                 ['id' => '1', 'name' => 'Widget', 'price' => '19.99', 'category' => 'tools'],
                 ['id' => '2', 'name' => 'Gadget', 'price' => '49.99', 'category' => 'electronics'],
             ],
+            'events' => [
+                ['id' => '1', 'event_date' => '2023-06-01'],
+                ['id' => '2', 'event_date' => '2024-06-01'],
+            ],
         ];
     }
 
@@ -198,6 +203,7 @@ final class RobustnessTarget
             fn (): string => $this->provider->updateJoinDerivedStatement(),
             fn (): string => $this->provider->insertSelectCompoundStatement(),
             fn (): string => $this->provider->insertRowAliasUpsertStatement(),
+            fn (): string => $this->provider->partitionSelectStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/Mutation/AlterTableMutation.php
+++ b/packages/ztd-query-mysql/src/Mutation/AlterTableMutation.php
@@ -73,6 +73,9 @@ final class AlterTableMutation implements ShadowMutation
         if ($newDefinition === null) {
             throw new \RuntimeException("Failed to parse altered schema for '{$this->tableName}'.");
         }
+        if ($definition->partitioning !== null) {
+            $newDefinition = $newDefinition->withPartitioning($definition->partitioning);
+        }
 
         $this->registry->unregister($this->tableName);
         $this->registry->register($this->tableName, $newDefinition);

--- a/packages/ztd-query-mysql/src/MySqlPartitionSelectionRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlPartitionSelectionRewriter.php
@@ -43,12 +43,12 @@ final class MySqlPartitionSelectionRewriter
             }
 
             $open = $tokens[$partitionIndex + 1] ?? null;
-            if (!$open instanceof SqlToken) {
-                throw new UnsupportedSqlException($sql, 'PARTITION selection');
+            if (!$open instanceof SqlToken || !$this->isSymbol($open, '(')) {
+                throw new UnsupportedSqlException($sql, 'PARTITION selection opening parenthesis');
             }
-            $closeIndex = $this->closingParenthesisIndex($tokens, $partitionIndex + 1);
+            $closeIndex = $this->closingParenthesisIndex($tokens, $open);
             if ($closeIndex === null) {
-                throw new UnsupportedSqlException($sql, 'PARTITION selection');
+                throw new UnsupportedSqlException($sql, 'PARTITION selection closing parenthesis');
             }
 
             $names = $this->partitionNames($sql, $open, $tokens[$closeIndex]);
@@ -95,21 +95,25 @@ final class MySqlPartitionSelectionRewriter
     /** @param list<SqlToken> $tokens */
     private function tokenIndexAtOrAfter(array $tokens, int $offset): int
     {
+        $afterReference = false;
         foreach ($tokens as $index => $token) {
-            if ($token->offset > $offset) {
+            if ($afterReference) {
                 return $index;
             }
+            $afterReference = $token->endOffset() === $offset;
         }
 
         return count($tokens);
     }
 
     /** @param list<SqlToken> $tokens */
-    private function closingParenthesisIndex(array $tokens, int $openIndex): ?int
+    private function closingParenthesisIndex(array $tokens, SqlToken $open): ?int
     {
-        $open = $tokens[$openIndex];
-        foreach (array_slice($tokens, $openIndex + 1, null, true) as $index => $token) {
-            if ($this->isSymbol($token, ')') && $token->depth === $open->depth) {
+        $afterOpen = false;
+        foreach ($tokens as $index => $token) {
+            if ($token === $open) {
+                $afterOpen = true;
+            } elseif ($afterOpen && $this->isSymbol($token, ')') && $token->depth === $open->depth) {
                 return $index;
             }
         }
@@ -165,10 +169,6 @@ final class MySqlPartitionSelectionRewriter
 
     private function isSymbol(SqlToken $token, string $symbol): bool
     {
-        if ($token->kind !== SqlTokenKind::Symbol) {
-            return false;
-        }
-
-        return $token->text === $symbol;
+        return $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
     }
 }

--- a/packages/ztd-query-mysql/src/MySqlPartitionSelectionRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlPartitionSelectionRewriter.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\TablePartitioning;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+/**
+ * Rewrites explicit MySQL partition selection into filtered table sources.
+ */
+final class MySqlPartitionSelectionRewriter
+{
+    /**
+     * @param array<string, array{viewSql: string}|array{
+     *     rows: array<int, array<string, mixed>>,
+     *     columns: array<int, string>,
+     *     columnTypes: array<string, ColumnType>,
+     *     partitioning?: TablePartitioning|null
+     * }> $tables
+     */
+    public function rewrite(string $sql, array $tables): string
+    {
+        $stream = SqlTokenStream::tokenize($sql, SqlTokenDialect::MySql);
+        $tokens = $stream->significantTokens();
+        $contexts = [];
+        foreach ($tables as $table => $context) {
+            $contexts[strtolower($table)] = $context;
+        }
+
+        $edits = [];
+        foreach ($stream->selectTableReferences() as $reference) {
+            $partitionIndex = $this->tokenIndexAtOrAfter($tokens, $reference['end']);
+            $partition = $tokens[$partitionIndex] ?? null;
+            if (!$partition instanceof SqlToken || !$partition->isKeyword('PARTITION')) {
+                continue;
+            }
+
+            $open = $tokens[$partitionIndex + 1] ?? null;
+            if (!$open instanceof SqlToken) {
+                throw new UnsupportedSqlException($sql, 'PARTITION selection');
+            }
+            $closeIndex = $this->closingParenthesisIndex($tokens, $partitionIndex + 1);
+            if ($closeIndex === null) {
+                throw new UnsupportedSqlException($sql, 'PARTITION selection');
+            }
+
+            $names = $this->partitionNames($sql, $open, $tokens[$closeIndex]);
+            $context = $contexts[strtolower($reference['name'])] ?? null;
+            $partitioning = $context['partitioning'] ?? null;
+            $predicate = $partitioning instanceof TablePartitioning
+                ? $partitioning->predicateFor($names)
+                : null;
+            if ($predicate === null) {
+                throw new UnsupportedSqlException($sql, 'PARTITION selection');
+            }
+
+            $after = $tokens[$closeIndex + 1] ?? null;
+            if ($after instanceof SqlToken
+                && in_array(strtoupper($after->text), ['USE', 'FORCE', 'IGNORE'], true)
+            ) {
+                throw new UnsupportedSqlException($sql, 'PARTITION selection with index hint');
+            }
+
+            $tableSql = substr(
+                $sql,
+                $reference['unqualifiedStart'],
+                $reference['end'] - $reference['unqualifiedStart'],
+            );
+            $replacement = "(SELECT * FROM $tableSql WHERE $predicate)";
+            if (!$this->hasAlias($tokens, $closeIndex + 1)) {
+                $replacement .= " AS $tableSql";
+            }
+            $edits[] = [
+                'start' => $reference['start'],
+                'end' => $tokens[$closeIndex]->endOffset(),
+                'replacement' => $replacement,
+            ];
+        }
+
+        usort($edits, static fn (array $left, array $right): int => $right['start'] <=> $left['start']);
+        foreach ($edits as $edit) {
+            $sql = substr_replace($sql, $edit['replacement'], $edit['start'], $edit['end'] - $edit['start']);
+        }
+
+        return $sql;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function tokenIndexAtOrAfter(array $tokens, int $offset): int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->offset > $offset) {
+                return $index;
+            }
+        }
+
+        return count($tokens);
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function closingParenthesisIndex(array $tokens, int $openIndex): ?int
+    {
+        $open = $tokens[$openIndex];
+        foreach (array_slice($tokens, $openIndex + 1, null, true) as $index => $token) {
+            if ($this->isSymbol($token, ')') && $token->depth === $open->depth) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return non-empty-list<string> */
+    private function partitionNames(string $sql, SqlToken $open, SqlToken $close): array
+    {
+        $list = substr($sql, $open->endOffset(), $close->offset - $open->endOffset());
+        $names = [];
+        foreach (SqlTokenStream::tokenize($list, SqlTokenDialect::MySql)->splitTopLevel() as $part) {
+            $stream = SqlTokenStream::tokenize($part, SqlTokenDialect::MySql);
+            $identifier = $stream->identifierAt();
+            if ($identifier === null) {
+                throw new UnsupportedSqlException($sql, 'PARTITION selection');
+            }
+            if ($identifier['next'] !== count($stream->significantTokens())) {
+                throw new UnsupportedSqlException($sql, 'PARTITION selection');
+            }
+            $names[] = $identifier['name'];
+        }
+        if ($names === []) {
+            throw new UnsupportedSqlException($sql, 'PARTITION selection');
+        }
+
+        return $names;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function hasAlias(array $tokens, int $index): bool
+    {
+        $token = $tokens[$index] ?? null;
+        if ($token === null) {
+            return false;
+        }
+        if (!$this->isIdentifier($token)) {
+            return false;
+        }
+
+        return !in_array(
+            strtoupper($token->text),
+            ['JOIN', 'LEFT', 'RIGHT', 'INNER', 'OUTER', 'CROSS', 'STRAIGHT_JOIN', 'WHERE', 'GROUP', 'HAVING', 'ORDER', 'LIMIT', 'OFFSET', 'UNION', 'INTERSECT', 'EXCEPT', 'FOR', 'LOCK', 'ON', 'USING'],
+            true,
+        );
+    }
+
+    private function isIdentifier(SqlToken $token): bool
+    {
+        return in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true);
+    }
+
+    private function isSymbol(SqlToken $token, string $symbol): bool
+    {
+        if ($token->kind !== SqlTokenKind::Symbol) {
+            return false;
+        }
+
+        return $token->text === $symbol;
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlPartitionSelectionRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlPartitionSelectionRewriter.php
@@ -54,12 +54,16 @@ final class MySqlPartitionSelectionRewriter
             $names = $this->partitionNames($sql, $open, $tokens[$closeIndex]);
             $context = $contexts[strtolower($reference['name'])] ?? null;
             $partitioning = $context['partitioning'] ?? null;
-            $predicate = $partitioning instanceof TablePartitioning
-                ? $partitioning->predicateFor($names)
+            $predicates = $partitioning instanceof TablePartitioning
+                ? $partitioning->predicatesFor($names)
                 : null;
-            if ($predicate === null) {
+            if ($predicates === null) {
                 throw new UnsupportedSqlException($sql, 'PARTITION selection');
             }
+            $predicate = implode(' OR ', array_map(
+                static fn (string $partitionPredicate): string => "($partitionPredicate)",
+                $predicates,
+            ));
 
             $after = $tokens[$closeIndex + 1] ?? null;
             if ($after instanceof SqlToken

--- a/packages/ztd-query-mysql/src/MySqlPartitionSelectionRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlPartitionSelectionRewriter.php
@@ -35,7 +35,7 @@ final class MySqlPartitionSelectionRewriter
         }
 
         $edits = [];
-        foreach ($stream->selectTableReferences() as $reference) {
+        foreach ((new MySqlSelectRelationParser())->references($sql) as $reference) {
             $partitionIndex = $this->tokenIndexAtOrAfter($tokens, $reference['end']);
             $partition = $tokens[$partitionIndex] ?? null;
             if (!$partition instanceof SqlToken || !$partition->isKeyword('PARTITION')) {

--- a/packages/ztd-query-mysql/src/MySqlPartitioningParser.php
+++ b/packages/ztd-query-mysql/src/MySqlPartitioningParser.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use PhpMyAdmin\SqlParser\Components\PartitionDefinition;
+use PhpMyAdmin\SqlParser\Statements\CreateStatement;
+use ZtdQuery\Schema\TablePartitioning;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+/**
+ * Converts MySQL RANGE and LIST partition metadata into row predicates.
+ */
+final class MySqlPartitioningParser
+{
+    public function parse(CreateStatement $statement): ?TablePartitioning
+    {
+        if ($statement->partitionBy === null) {
+            return null;
+        }
+
+        $partitionBy = $this->partitionExpression($statement->partitionBy);
+        if ($partitionBy === null || !is_array($statement->partitions)) {
+            return new TablePartitioning([]);
+        }
+
+        [$kind, $expression] = $partitionBy;
+
+        return new TablePartitioning(match ($kind) {
+            'RANGE' => $this->rangePredicates($expression, $statement->partitions),
+            'LIST' => $this->listPredicates($expression, $statement->partitions),
+        });
+    }
+
+    /** @return array{'RANGE'|'LIST', non-empty-string}|null */
+    private function partitionExpression(string $partitionBy): ?array
+    {
+        $tokens = SqlTokenStream::tokenize($partitionBy, SqlTokenDialect::MySql)->significantTokens();
+        $kind = $tokens[0] ?? null;
+        if (!$kind instanceof SqlToken) {
+            return null;
+        }
+        $partitionKind = $kind->isKeyword('RANGE')
+            ? 'RANGE'
+            : ($kind->isKeyword('LIST') ? 'LIST' : null);
+        if ($partitionKind === null) {
+            return null;
+        }
+
+        $open = $tokens[1] ?? null;
+        $close = $tokens[count($tokens) - 1] ?? null;
+        if (!$open instanceof SqlToken || !$close instanceof SqlToken) {
+            return null;
+        }
+        if (!$this->isSymbol($open, '(') || !$this->isSymbol($close, ')')) {
+            return null;
+        }
+
+        $expression = substr(
+            $partitionBy,
+            $open->endOffset(),
+            $close->offset - $open->endOffset(),
+        );
+        if ($expression === '') {
+            return null;
+        }
+
+        return [$partitionKind, $expression];
+    }
+
+    /**
+     * @param array<int|string, PartitionDefinition> $partitions
+     * @return array<string, string>
+     */
+    private function rangePredicates(string $expression, array $partitions): array
+    {
+        $predicates = [];
+        $lowerBound = null;
+        foreach ($partitions as $partition) {
+            $upperBound = $this->partitionValue($partition, 'LESS THAN');
+            if ($upperBound === null) {
+                return [];
+            }
+
+            $partitionExpression = "($expression)";
+            $isMaximum = strcasecmp($upperBound, 'MAXVALUE') === 0;
+            if ($lowerBound === null) {
+                $predicates[$partition->name] = $isMaximum
+                    ? 'TRUE'
+                    : "$partitionExpression IS NULL OR $partitionExpression < $upperBound";
+            } else {
+                $predicates[$partition->name] = $isMaximum
+                    ? "$partitionExpression >= $lowerBound"
+                    : "$partitionExpression >= $lowerBound AND $partitionExpression < $upperBound";
+            }
+            $lowerBound = $upperBound;
+        }
+
+        return $predicates;
+    }
+
+    /**
+     * @param array<int|string, PartitionDefinition> $partitions
+     * @return array<string, string>
+     */
+    private function listPredicates(string $expression, array $partitions): array
+    {
+        $predicates = [];
+        foreach ($partitions as $partition) {
+            $values = $this->partitionValue($partition, 'IN');
+            if ($values === null) {
+                return [];
+            }
+
+            $parts = SqlTokenStream::tokenize($values, SqlTokenDialect::MySql)->splitTopLevel();
+            $nonNull = [];
+            $hasNull = false;
+            foreach ($parts as $part) {
+                $partTokens = SqlTokenStream::tokenize($part, SqlTokenDialect::MySql)->significantTokens();
+                if (count($partTokens) === 1 && $partTokens[0]->isKeyword('NULL')) {
+                    $hasNull = true;
+                    continue;
+                }
+                $nonNull[] = $part;
+            }
+
+            $partitionExpression = "($expression)";
+            $predicate = $nonNull === [] ? '' : $partitionExpression . ' IN (' . implode(', ', $nonNull) . ')';
+            if ($hasNull) {
+                $nullPredicate = "$partitionExpression IS NULL";
+                $predicate = $predicate === '' ? $nullPredicate : "($predicate OR $nullPredicate)";
+            }
+            if ($predicate === '') {
+                return [];
+            }
+            $predicates[$partition->name] = $predicate;
+        }
+
+        return $predicates;
+    }
+
+    private function partitionValue(PartitionDefinition $partition, string $expectedType): ?string
+    {
+        if (strcasecmp($partition->type, $expectedType) !== 0) {
+            return null;
+        }
+        if (is_string($partition->expr)) {
+            return $partition->expr;
+        }
+        $raw = $partition->expr->expr;
+
+        return is_string($raw) ? substr($raw, 1, -1) : null;
+    }
+
+    private function isSymbol(SqlToken $token, string $symbol): bool
+    {
+        if ($token->kind !== SqlTokenKind::Symbol) {
+            return false;
+        }
+
+        return $token->text === $symbol;
+    }
+}

--- a/packages/ztd-query-mysql/src/MySqlPartitioningParser.php
+++ b/packages/ztd-query-mysql/src/MySqlPartitioningParser.php
@@ -53,7 +53,10 @@ final class MySqlPartitioningParser
 
         $open = $tokens[1] ?? null;
         $close = $tokens[count($tokens) - 1] ?? null;
-        if (!$open instanceof SqlToken || !$close instanceof SqlToken) {
+        if (!$open instanceof SqlToken) {
+            return null;
+        }
+        if (!$close instanceof SqlToken) {
             return null;
         }
         if (!$this->isSymbol($open, '(') || !$this->isSymbol($close, ')')) {
@@ -158,10 +161,6 @@ final class MySqlPartitioningParser
 
     private function isSymbol(SqlToken $token, string $symbol): bool
     {
-        if ($token->kind !== SqlTokenKind::Symbol) {
-            return false;
-        }
-
-        return $token->text === $symbol;
+        return $token->kind === SqlTokenKind::Symbol && $token->text === $symbol;
     }
 }

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -188,7 +188,8 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
      *     columnTypes: array<string, \ZtdQuery\Schema\ColumnType>,
      *     columnDefaults: array<string, string>,
      *     identityStrategies: array<string, \ZtdQuery\Schema\IdentityGenerationStrategy>,
-     *     generatedExpressions: array<string, string>
+     *     generatedExpressions: array<string, string>,
+     *     partitioning: \ZtdQuery\Schema\TablePartitioning|null
      * }>
      */
     private function buildTableContext(): array
@@ -222,6 +223,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'columnDefaults' => $columnDefaults,
                 'identityStrategies' => $identityStrategies,
                 'generatedExpressions' => $generatedExpressions,
+                'partitioning' => $definition?->partitioning,
                 'primaryKeys' => $definition !== null ? $definition->primaryKeys : [],
                 'candidateKeys' => $definition !== null ? $definition->candidateKeys()->keys() : [],
             ];
@@ -240,6 +242,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'columnDefaults' => $definition->columnDefaults,
                 'identityStrategies' => $definition->identityStrategies,
                 'generatedExpressions' => $definition->generatedExpressions,
+                'partitioning' => $definition->partitioning,
                 'primaryKeys' => $definition->primaryKeys,
                 'candidateKeys' => $definition->candidateKeys()->keys(),
             ];

--- a/packages/ztd-query-mysql/src/MySqlSchemaParser.php
+++ b/packages/ztd-query-mysql/src/MySqlSchemaParser.php
@@ -54,6 +54,9 @@ final class MySqlSchemaParser implements SchemaParser
         $uniqueConstraints = [];
         $uniqueIndex = 0;
         $foreignKeys = (new MySqlForeignKeyDefinitionParser())->parseCreateTable($createTableSql);
+        $partitioning = is_string($stmt->partitionBy)
+            ? (new MySqlPartitioningParser())->parse($stmt)
+            : null;
 
         foreach ($stmt->fields as $field) {
             $name = $field->name ?? null;
@@ -146,6 +149,7 @@ final class MySqlSchemaParser implements SchemaParser
             $identityStrategies,
             $generatedExpressions,
             $foreignKeys,
+            $partitioning,
         );
     }
 

--- a/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
+++ b/packages/ztd-query-mysql/src/Transformer/SelectTransformer.php
@@ -7,6 +7,7 @@ namespace ZtdQuery\Platform\MySql\Transformer;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlTypeSemantics;
+use ZtdQuery\Platform\MySql\MySqlPartitionSelectionRewriter;
 use ZtdQuery\Platform\CastRenderer;
 use ZtdQuery\Platform\IdentifierQuoter;
 use ZtdQuery\Platform\ValueRenderer;
@@ -30,6 +31,7 @@ final class SelectTransformer implements SqlTransformer
     private MySqlTypeSemantics $typeSemantics;
     private MySqlCteShadowComposer $cteComposer;
     private MySqlGeneratedColumnProjector $generatedColumnProjector;
+    private MySqlPartitionSelectionRewriter $partitionSelectionRewriter;
 
     public function __construct(
         ?CastRenderer $castRenderer = null,
@@ -42,6 +44,7 @@ final class SelectTransformer implements SqlTransformer
         $this->typeSemantics = new MySqlTypeSemantics();
         $this->cteComposer = new MySqlCteShadowComposer();
         $this->generatedColumnProjector = new MySqlGeneratedColumnProjector();
+        $this->partitionSelectionRewriter = new MySqlPartitionSelectionRewriter();
     }
 
     /**
@@ -49,6 +52,9 @@ final class SelectTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
+        if (stripos($sql, 'PARTITION') !== false) {
+            $sql = $this->partitionSelectionRewriter->rewrite($sql, $tables);
+        }
         $sql = $this->typeSemantics->rewrite($sql, $tables);
         $sql = $this->rewriteSetOrderBy($sql, $tables);
 

--- a/packages/ztd-query-mysql/tests/Unit/Mutation/AlterTableMutationTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Mutation/AlterTableMutationTest.php
@@ -16,6 +16,7 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\Mutation\AlterTableMutation;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlSchemaParser;
+use ZtdQuery\Platform\MySql\MySqlPartitioningParser;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\TableDefinition;
@@ -26,6 +27,7 @@ use ZtdQuery\Shadow\ShadowStore;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser::class)]
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
+#[UsesClass(MySqlPartitioningParser::class)]
 final class AlterTableMutationTest extends TestCase
 {
     public function testApplyAddColumnAddsNewColumn(): void
@@ -71,6 +73,30 @@ final class AlterTableMutationTest extends TestCase
         self::assertSame(['id'], $foreignKey->referencedColumns);
         self::assertSame('CASCADE', $foreignKey->onDelete->value);
         self::assertSame('CASCADE', $foreignKey->onUpdate->value);
+    }
+
+    public function testApplyAddColumnPreservesPartitionMetadata(): void
+    {
+        $schemaParser = new MySqlSchemaParser(new MySqlParser());
+        $registry = new TableDefinitionRegistry();
+        $definition = $schemaParser->parse('CREATE TABLE events (id INT, event_date DATE) '
+            . 'PARTITION BY RANGE (YEAR(event_date)) ('
+            . 'PARTITION p2024 VALUES LESS THAN (2025), PARTITION pmax VALUES LESS THAN MAXVALUE)');
+        self::assertNotNull($definition);
+        $registry->register('events', $definition);
+
+        $parser = new Parser('ALTER TABLE events ADD COLUMN label VARCHAR(255)');
+        $alterStmt = $parser->statements[0] ?? null;
+        self::assertInstanceOf(AlterStatement::class, $alterStmt);
+        (new AlterTableMutation('events', $alterStmt, $registry, $schemaParser))->apply(new ShadowStore(), []);
+
+        $newDefinition = $registry->get('events');
+        self::assertNotNull($newDefinition);
+        self::assertContains('label', $newDefinition->columns);
+        self::assertSame(
+            '((YEAR(event_date)) >= 2025)',
+            $newDefinition->partitioning?->predicateFor(['pmax']),
+        );
     }
 
     public function testApplyAddColumnPreservesQuotedForeignKeyIdentifiers(): void

--- a/packages/ztd-query-mysql/tests/Unit/Mutation/AlterTableMutationTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Mutation/AlterTableMutationTest.php
@@ -94,8 +94,8 @@ final class AlterTableMutationTest extends TestCase
         self::assertNotNull($newDefinition);
         self::assertContains('label', $newDefinition->columns);
         self::assertSame(
-            '((YEAR(event_date)) >= 2025)',
-            $newDefinition->partitioning?->predicateFor(['pmax']),
+            ['(YEAR(event_date)) >= 2025'],
+            $newDefinition->partitioning?->predicatesFor(['pmax']),
         );
     }
 

--- a/packages/ztd-query-mysql/tests/Unit/MySqlPartitionSelectionRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlPartitionSelectionRewriterTest.php
@@ -101,6 +101,24 @@ final class MySqlPartitionSelectionRewriterTest extends TestCase
         );
     }
 
+    public function testIgnoresClosingParenthesesBeforeThePartitionClause(): void
+    {
+        self::assertSame(
+            'SELECT COALESCE(NULL, 0) FROM (SELECT * FROM events WHERE (id < 10)) AS events',
+            (new MySqlPartitionSelectionRewriter())->rewrite(
+                'SELECT COALESCE(NULL, 0) FROM events PARTITION (p0)',
+                [
+                    'events' => [
+                        'rows' => [],
+                        'columns' => ['id'],
+                        'columnTypes' => [],
+                        'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+                    ],
+                ],
+            ),
+        );
+    }
+
     public function testRejectsUnknownPartitionName(): void
     {
         self::expectException(UnsupportedSqlException::class);
@@ -165,6 +183,7 @@ final class MySqlPartitionSelectionRewriterTest extends TestCase
     public function testRejectsPartitionClauseWithoutOpeningParenthesis(): void
     {
         self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage('PARTITION selection opening parenthesis');
 
         (new MySqlPartitionSelectionRewriter())->rewrite(
             'SELECT * FROM events PARTITION p0',
@@ -172,9 +191,28 @@ final class MySqlPartitionSelectionRewriterTest extends TestCase
         );
     }
 
+    public function testRejectsBracketsInPlaceOfPartitionParentheses(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage('PARTITION selection opening parenthesis');
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION [p0]',
+            [
+                'events' => [
+                    'rows' => [],
+                    'columns' => ['id'],
+                    'columnTypes' => [],
+                    'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+                ],
+            ],
+        );
+    }
+
     public function testRejectsPartitionClauseWithoutClosingParenthesis(): void
     {
         self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage('PARTITION selection closing parenthesis');
 
         (new MySqlPartitionSelectionRewriter())->rewrite(
             'SELECT * FROM events PARTITION (p0',

--- a/packages/ztd-query-mysql/tests/Unit/MySqlPartitionSelectionRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlPartitionSelectionRewriterTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\MySql\MySqlPartitionSelectionRewriter;
+use ZtdQuery\Schema\TablePartitioning;
+
+#[CoversClass(MySqlPartitionSelectionRewriter::class)]
+final class MySqlPartitionSelectionRewriterTest extends TestCase
+{
+    public function testRewritesNamedPartitionAsFilteredDerivedTable(): void
+    {
+        $tables = [
+            'EVENTS' => [
+                'rows' => [],
+                'columns' => ['id', 'event_date'],
+                'columnTypes' => [],
+                'partitioning' => new TablePartitioning([
+                    'p2024' => 'YEAR(event_date) >= 2024 AND YEAR(event_date) < 2025',
+                ]),
+            ],
+        ];
+
+        self::assertSame(
+            'SELECT events.id FROM (SELECT * FROM events WHERE (YEAR(event_date) >= 2024 AND YEAR(event_date) < 2025)) AS events',
+            (new MySqlPartitionSelectionRewriter())->rewrite(
+                'SELECT events.id FROM events PARTITION (p2024)',
+                $tables,
+            ),
+        );
+        self::assertSame(
+            'SELECT EVENTS.id FROM (SELECT * FROM EVENTS WHERE (YEAR(event_date) >= 2024 AND YEAR(event_date) < 2025)) AS EVENTS',
+            (new MySqlPartitionSelectionRewriter())->rewrite(
+                'SELECT EVENTS.id FROM EVENTS PARTITION (p2024)',
+                $tables,
+            ),
+        );
+    }
+
+    public function testPreservesAliasesAndRewritesEachJoinSource(): void
+    {
+        $tables = [
+            'events' => [
+                'rows' => [],
+                'columns' => ['id'],
+                'columnTypes' => [],
+                'partitioning' => new TablePartitioning([
+                    'p0' => 'id < 10',
+                    'p1' => 'id >= 10',
+                ]),
+            ],
+        ];
+
+        self::assertSame(
+            'SELECT a.id FROM (SELECT * FROM `events` WHERE (id < 10) OR (id >= 10)) AS a '
+            . 'JOIN (SELECT * FROM events WHERE (id >= 10)) b ON b.id = a.id',
+            (new MySqlPartitionSelectionRewriter())->rewrite(
+                'SELECT a.id FROM app.`events` PARTITION (`p0`, p1) AS a '
+                . 'JOIN events PARTITION (p1) b ON b.id = a.id',
+                $tables,
+            ),
+        );
+    }
+
+    public function testLeavesOrdinarySelectUnchanged(): void
+    {
+        $sql = 'SELECT * FROM events';
+
+        self::assertSame($sql, (new MySqlPartitionSelectionRewriter())->rewrite($sql, []));
+    }
+
+    public function testContinuesAfterOrdinarySourceAndAddsAliasBeforeJoinClause(): void
+    {
+        $tables = [
+            'events' => [
+                'rows' => [],
+                'columns' => ['id'],
+                'columnTypes' => [],
+                'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+            ],
+        ];
+
+        self::assertSame(
+            'SELECT * FROM users JOIN (SELECT * FROM events WHERE (id < 10)) AS events ON events.id = users.id',
+            (new MySqlPartitionSelectionRewriter())->rewrite(
+                'SELECT * FROM users JOIN events PARTITION (p0) ON events.id = users.id',
+                $tables,
+            ),
+        );
+        self::assertSame(
+            'SELECT * FROM (SELECT * FROM events WHERE (id < 10)) AS events join users ON users.id = events.id',
+            (new MySqlPartitionSelectionRewriter())->rewrite(
+                'SELECT * FROM events PARTITION (p0) join users ON users.id = events.id',
+                $tables,
+            ),
+        );
+    }
+
+    public function testRejectsUnknownPartitionName(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION (missing)',
+            [
+                'events' => [
+                    'rows' => [],
+                    'columns' => ['id'],
+                    'columnTypes' => [],
+                    'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+                ],
+            ],
+        );
+    }
+
+    public function testRejectsSelectionWithoutPartitionMetadata(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION (p0)',
+            ['events' => ['rows' => [], 'columns' => ['id'], 'columnTypes' => []]],
+        );
+    }
+
+    public function testRejectsPartitionSelectionWithIndexHint(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION (p0) USE INDEX (PRIMARY)',
+            [
+                'events' => [
+                    'rows' => [],
+                    'columns' => ['id'],
+                    'columnTypes' => [],
+                    'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+                ],
+            ],
+        );
+    }
+
+    public function testRejectsEmptyPartitionList(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION ()',
+            [
+                'events' => [
+                    'rows' => [],
+                    'columns' => ['id'],
+                    'columnTypes' => [],
+                    'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+                ],
+            ],
+        );
+    }
+
+    public function testRejectsPartitionClauseWithoutOpeningParenthesis(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION p0',
+            ['events' => ['rows' => [], 'columns' => ['id'], 'columnTypes' => []]],
+        );
+    }
+
+    public function testRejectsPartitionClauseWithoutClosingParenthesis(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION (p0',
+            ['events' => ['rows' => [], 'columns' => ['id'], 'columnTypes' => []]],
+        );
+    }
+
+    public function testRejectsMalformedPartitionNameList(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION (p0 extra)',
+            [
+                'events' => [
+                    'rows' => [],
+                    'columns' => ['id'],
+                    'columnTypes' => [],
+                    'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+                ],
+            ],
+        );
+    }
+
+    public function testRejectsForceIndexHint(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION (p0) force INDEX (PRIMARY)',
+            [
+                'events' => [
+                    'rows' => [],
+                    'columns' => ['id'],
+                    'columnTypes' => [],
+                    'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+                ],
+            ],
+        );
+    }
+
+    public function testRejectsIgnoreIndexHint(): void
+    {
+        self::expectException(UnsupportedSqlException::class);
+
+        (new MySqlPartitionSelectionRewriter())->rewrite(
+            'SELECT * FROM events PARTITION (p0) IGNORE INDEX (PRIMARY)',
+            [
+                'events' => [
+                    'rows' => [],
+                    'columns' => ['id'],
+                    'columnTypes' => [],
+                    'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+                ],
+            ],
+        );
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlPartitionSelectionRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlPartitionSelectionRewriterTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\MySql\MySqlPartitionSelectionRewriter;
+use ZtdQuery\Platform\MySql\MySqlSelectRelationParser;
 use ZtdQuery\Schema\TablePartitioning;
 
 #[CoversClass(MySqlPartitionSelectionRewriter::class)]
+#[UsesClass(MySqlSelectRelationParser::class)]
 final class MySqlPartitionSelectionRewriterTest extends TestCase
 {
     public function testRewritesNamedPartitionAsFilteredDerivedTable(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlPartitioningParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlPartitioningParserTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PhpMyAdmin\SqlParser\Parser;
+use PhpMyAdmin\SqlParser\Statements\CreateStatement;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MySql\MySqlPartitioningParser;
+
+#[CoversClass(MySqlPartitioningParser::class)]
+final class MySqlPartitioningParserTest extends TestCase
+{
+    public function testParsesRangePartitionBoundariesIncludingNullAndMaximum(): void
+    {
+        $parser = new Parser('CREATE TABLE events (event_date DATE) '
+            . 'PARTITION BY RANGE (YEAR(event_date)) ('
+            . 'PARTITION p2023 VALUES LESS THAN (2024), '
+            . 'PARTITION p2024 VALUES LESS THAN (2025), '
+            . 'PARTITION pmax VALUES LESS THAN MAXVALUE)');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertSame(
+            '((YEAR(event_date)) IS NULL OR (YEAR(event_date)) < 2024)',
+            $partitioning->predicateFor(['p2023']),
+        );
+        self::assertSame(
+            '((YEAR(event_date)) >= 2024 AND (YEAR(event_date)) < 2025)',
+            $partitioning->predicateFor(['p2024']),
+        );
+        self::assertSame(
+            '((YEAR(event_date)) >= 2025)',
+            $partitioning->predicateFor(['pmax']),
+        );
+    }
+
+    public function testParsesListPartitionValuesIncludingNull(): void
+    {
+        $parser = new Parser('CREATE TABLE regions (region_id INT) '
+            . 'PARTITION BY LIST (region_id) ('
+            . 'PARTITION pwest VALUES IN (NULL, 1, 2), '
+            . 'PARTITION peast VALUES IN (3, 4))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertSame(
+            '(((region_id) IN (1, 2) OR (region_id) IS NULL))',
+            $partitioning->predicateFor(['pwest']),
+        );
+        self::assertSame('((region_id) IN (3, 4))', $partitioning->predicateFor(['peast']));
+    }
+
+    public function testParsesNullOnlyListPartition(): void
+    {
+        $parser = new Parser('CREATE TABLE regions (region_id INT) '
+            . 'PARTITION BY LIST (region_id) (PARTITION pnull VALUES IN (NULL))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertSame('((region_id) IS NULL)', $partitioning->predicateFor(['pnull']));
+    }
+
+    public function testParsesSingleMaximumRangePartition(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) '
+            . 'PARTITION BY RANGE (id) (PARTITION pall VALUES LESS THAN MAXVALUE)');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertSame('(TRUE)', $partitioning->predicateFor(['pall']));
+    }
+
+    public function testMarksHashPartitionSelectionUnsupported(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) PARTITION BY HASH(id) PARTITIONS 4');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+
+    public function testReturnsNullForUnpartitionedTable(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT)');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+
+        self::assertNull((new MySqlPartitioningParser())->parse($statement));
+    }
+
+    public function testMarksRangeWithoutDefinitionsUnsupported(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) PARTITION BY RANGE (id) '
+            . '(PARTITION p0 VALUES LESS THAN (10))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+        $statement->partitions = null;
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+
+    public function testRejectsRangeDefinitionWithListValueType(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) PARTITION BY RANGE (id) '
+            . '(PARTITION p0 VALUES LESS THAN (10))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+        self::assertIsArray($statement->partitions);
+        $statement->partitions[0]->type = 'IN';
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+
+    public function testRejectsListDefinitionWithRangeValueType(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) PARTITION BY LIST (id) '
+            . '(PARTITION p0 VALUES IN (10))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+        self::assertIsArray($statement->partitions);
+        $statement->partitions[0]->type = 'LESS THAN';
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+
+    public function testRejectsRangeColumnsWithoutGuessingTupleSemantics(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT, created_at DATE) '
+            . 'PARTITION BY RANGE COLUMNS(id, created_at) ('
+            . "PARTITION p0 VALUES LESS THAN (10, '2025-01-01'))");
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlPartitioningParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlPartitioningParserTest.php
@@ -97,6 +97,62 @@ final class MySqlPartitioningParserTest extends TestCase
         self::assertNull($partitioning->predicateFor(['p0']));
     }
 
+    public function testMarksHashPartitionExpressionWithValidDelimitersUnsupported(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) PARTITION BY RANGE (id) '
+            . '(PARTITION p0 VALUES LESS THAN (10))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+        $statement->partitionBy = 'HASH (id)';
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+
+    public function testMarksBracketsInPlaceOfPartitionParenthesesUnsupported(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) PARTITION BY RANGE (id) '
+            . '(PARTITION p0 VALUES LESS THAN (10))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+        $statement->partitionBy = 'RANGE [id]';
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+
+    public function testMarksPartitionExpressionWithoutParenthesesUnsupported(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) PARTITION BY RANGE (id) '
+            . '(PARTITION p0 VALUES LESS THAN (10))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+        $statement->partitionBy = 'RANGE id';
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+
+    public function testMarksPartitionExpressionWithoutClosingParenthesisUnsupported(): void
+    {
+        $parser = new Parser('CREATE TABLE events (id INT) PARTITION BY RANGE (id) '
+            . '(PARTITION p0 VALUES LESS THAN (10))');
+        $statement = $parser->statements[0] ?? null;
+        self::assertInstanceOf(CreateStatement::class, $statement);
+        $statement->partitionBy = 'RANGE (id';
+
+        $partitioning = (new MySqlPartitioningParser())->parse($statement);
+
+        self::assertNotNull($partitioning);
+        self::assertNull($partitioning->predicateFor(['p0']));
+    }
+
     public function testReturnsNullForUnpartitionedTable(): void
     {
         $parser = new Parser('CREATE TABLE events (id INT)');

--- a/packages/ztd-query-mysql/tests/Unit/MySqlPartitioningParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlPartitioningParserTest.php
@@ -27,16 +27,16 @@ final class MySqlPartitioningParserTest extends TestCase
 
         self::assertNotNull($partitioning);
         self::assertSame(
-            '((YEAR(event_date)) IS NULL OR (YEAR(event_date)) < 2024)',
-            $partitioning->predicateFor(['p2023']),
+            ['(YEAR(event_date)) IS NULL OR (YEAR(event_date)) < 2024'],
+            $partitioning->predicatesFor(['p2023']),
         );
         self::assertSame(
-            '((YEAR(event_date)) >= 2024 AND (YEAR(event_date)) < 2025)',
-            $partitioning->predicateFor(['p2024']),
+            ['(YEAR(event_date)) >= 2024 AND (YEAR(event_date)) < 2025'],
+            $partitioning->predicatesFor(['p2024']),
         );
         self::assertSame(
-            '((YEAR(event_date)) >= 2025)',
-            $partitioning->predicateFor(['pmax']),
+            ['(YEAR(event_date)) >= 2025'],
+            $partitioning->predicatesFor(['pmax']),
         );
     }
 
@@ -53,10 +53,10 @@ final class MySqlPartitioningParserTest extends TestCase
 
         self::assertNotNull($partitioning);
         self::assertSame(
-            '(((region_id) IN (1, 2) OR (region_id) IS NULL))',
-            $partitioning->predicateFor(['pwest']),
+            ['((region_id) IN (1, 2) OR (region_id) IS NULL)'],
+            $partitioning->predicatesFor(['pwest']),
         );
-        self::assertSame('((region_id) IN (3, 4))', $partitioning->predicateFor(['peast']));
+        self::assertSame(['(region_id) IN (3, 4)'], $partitioning->predicatesFor(['peast']));
     }
 
     public function testParsesNullOnlyListPartition(): void
@@ -69,7 +69,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertSame('((region_id) IS NULL)', $partitioning->predicateFor(['pnull']));
+        self::assertSame(['(region_id) IS NULL'], $partitioning->predicatesFor(['pnull']));
     }
 
     public function testParsesSingleMaximumRangePartition(): void
@@ -82,7 +82,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertSame('(TRUE)', $partitioning->predicateFor(['pall']));
+        self::assertSame(['TRUE'], $partitioning->predicatesFor(['pall']));
     }
 
     public function testMarksHashPartitionSelectionUnsupported(): void
@@ -94,7 +94,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 
     public function testMarksHashPartitionExpressionWithValidDelimitersUnsupported(): void
@@ -108,7 +108,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 
     public function testMarksBracketsInPlaceOfPartitionParenthesesUnsupported(): void
@@ -122,7 +122,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 
     public function testMarksPartitionExpressionWithoutParenthesesUnsupported(): void
@@ -136,7 +136,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 
     public function testMarksPartitionExpressionWithoutClosingParenthesisUnsupported(): void
@@ -150,7 +150,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 
     public function testReturnsNullForUnpartitionedTable(): void
@@ -173,7 +173,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 
     public function testRejectsRangeDefinitionWithListValueType(): void
@@ -188,7 +188,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 
     public function testRejectsListDefinitionWithRangeValueType(): void
@@ -203,7 +203,7 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 
     public function testRejectsRangeColumnsWithoutGuessingTupleSemantics(): void
@@ -217,6 +217,6 @@ final class MySqlPartitioningParserTest extends TestCase
         $partitioning = (new MySqlPartitioningParser())->parse($statement);
 
         self::assertNotNull($partitioning);
-        self::assertNull($partitioning->predicateFor(['p0']));
+        self::assertNull($partitioning->predicatesFor(['p0']));
     }
 }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -14,6 +14,8 @@ use ZtdQuery\Platform\MySql\InsertSelectSourceExtractor;
 use ZtdQuery\Platform\MySql\Mutation\AlterTableMutation;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
 use ZtdQuery\Platform\MySql\MySqlParser;
+use ZtdQuery\Platform\MySql\MySqlPartitioningParser;
+use ZtdQuery\Platform\MySql\MySqlPartitionSelectionRewriter;
 use ZtdQuery\Platform\MySql\MySqlQueryGuard;
 use ZtdQuery\Platform\MySql\MySqlRewriter;
 use ZtdQuery\Platform\MySql\MySqlSchemaParser;
@@ -52,6 +54,8 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
+#[UsesClass(MySqlPartitioningParser::class)]
+#[UsesClass(MySqlPartitionSelectionRewriter::class)]
 #[UsesClass(MySqlUpsertAssignmentExtractor::class)]
 #[UsesClass(MySqlQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlReadOnlyDiagnosticStatement::class)]
@@ -81,6 +85,53 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 final class MySqlRewriterTest extends RewriterContractTest
 {
+    public function testPartitionSelectionUsesRegisteredPartitionMetadata(): void
+    {
+        $store = new ShadowStore();
+        $store->set('events', [
+            ['id' => 1, 'event_date' => '2023-06-01'],
+            ['id' => 2, 'event_date' => '2024-06-01'],
+        ]);
+        $registry = new TableDefinitionRegistry();
+        $definition = $this->createSchemaParser()->parse(
+            'CREATE TABLE events (id INT, event_date DATE) '
+            . 'PARTITION BY RANGE (YEAR(event_date)) ('
+            . 'PARTITION p2023 VALUES LESS THAN (2024), '
+            . 'PARTITION p2024 VALUES LESS THAN (2025), '
+            . 'PARTITION pmax VALUES LESS THAN MAXVALUE)',
+        );
+        self::assertNotNull($definition);
+        $registry->register('events', $definition);
+
+        $sql = $this->createRewriter($store, $registry)
+            ->rewrite('SELECT id FROM events PARTITION (p2024)')
+            ->sql();
+
+        self::assertStringStartsWith('WITH `events` AS', $sql);
+        self::assertStringContainsString(
+            'FROM (SELECT * FROM events WHERE ((YEAR(event_date)) >= 2024 AND (YEAR(event_date)) < 2025)) AS events',
+            $sql,
+        );
+    }
+
+    public function testPartitionSelectionUsesDefinitionWithoutMaterializedRows(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $definition = $this->createSchemaParser()->parse(
+            'CREATE TABLE events (id INT) PARTITION BY RANGE (id) ('
+            . 'PARTITION p0 VALUES LESS THAN (10), PARTITION pmax VALUES LESS THAN MAXVALUE)',
+        );
+        self::assertNotNull($definition);
+        $registry->register('events', $definition);
+
+        $sql = $this->createRewriter(new ShadowStore(), $registry)
+            ->rewrite('SELECT id FROM events PARTITION (p0)')
+            ->sql();
+
+        self::assertStringContainsString('FROM (SELECT * FROM events WHERE ((id) IS NULL OR (id) < 10)) AS events', $sql);
+    }
+
+
     public function testGeneratedExpressionIsPresentBeforeTheFirstShadowWrite(): void
     {
         $store = new ShadowStore();

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
@@ -69,8 +69,8 @@ final class MySqlSchemaParserTest extends SchemaParserContractTest
 
         self::assertNotNull($definition);
         self::assertSame(
-            '((YEAR(event_date)) IS NULL OR (YEAR(event_date)) < 2025)',
-            $definition->partitioning?->predicateFor(['p2024']),
+            ['(YEAR(event_date)) IS NULL OR (YEAR(event_date)) < 2025'],
+            $definition->partitioning?->predicatesFor(['p2024']),
         );
     }
 

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSchemaParserTest.php
@@ -12,10 +12,12 @@ use ZtdQuery\Platform\MySql\MySqlSchemaParser;
 use ZtdQuery\Platform\SchemaParser;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
+use ZtdQuery\Platform\MySql\MySqlPartitioningParser;
 
 #[CoversClass(MySqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser::class)]
 #[UsesClass(MySqlParser::class)]
+#[UsesClass(MySqlPartitioningParser::class)]
 final class MySqlSchemaParserTest extends SchemaParserContractTest
 {
     protected function createParser(): SchemaParser
@@ -54,6 +56,22 @@ final class MySqlSchemaParserTest extends SchemaParserContractTest
             'total' => '(qty * unit_price)',
             'label' => '(CONCAT(qty, unit_price))',
         ], $definition->generatedExpressions);
+    }
+
+    public function testParsesPartitionMetadataWithTableSchema(): void
+    {
+        $definition = (new MySqlSchemaParser(new MySqlParser()))->parse(
+            'CREATE TABLE events (id INT, event_date DATE) '
+            . 'PARTITION BY RANGE (YEAR(event_date)) ('
+            . 'PARTITION p2024 VALUES LESS THAN (2025), '
+            . 'PARTITION pmax VALUES LESS THAN MAXVALUE)',
+        );
+
+        self::assertNotNull($definition);
+        self::assertSame(
+            '((YEAR(event_date)) IS NULL OR (YEAR(event_date)) < 2025)',
+            $definition->partitioning?->predicateFor(['p2024']),
+        );
     }
 
     public function testParseSimpleCreateTable(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/SelectTransformerTest.php
@@ -13,10 +13,12 @@ use ZtdQuery\Platform\ValueRenderer;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
 use ZtdQuery\Platform\MySql\MySqlTypeSemantics;
+use ZtdQuery\Platform\MySql\MySqlPartitionSelectionRewriter;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Rewrite\SqlTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Schema\TablePartitioning;
 
 #[CoversClass(SelectTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
@@ -26,8 +28,27 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
+#[UsesClass(MySqlPartitionSelectionRewriter::class)]
 final class SelectTransformerTest extends TransformerContractTest
 {
+    public function testTransformsPartitionSelectionBeforeComposingShadowCte(): void
+    {
+        $result = (new SelectTransformer())->transform('SELECT id FROM events PARTITION (p0)', [
+            'events' => [
+                'rows' => [['id' => 1], ['id' => 11]],
+                'columns' => ['id'],
+                'columnTypes' => [],
+                'partitioning' => new TablePartitioning(['p0' => 'id < 10']),
+            ],
+        ]);
+
+        self::assertStringStartsWith('WITH `events` AS', $result);
+        self::assertStringContainsString(
+            'SELECT id FROM (SELECT * FROM events WHERE (id < 10)) AS events',
+            $result,
+        );
+    }
+
     public function testGeneratedColumnsAreRecomputedFromBaseRow(): void
     {
         $result = (new SelectTransformer())->transform('SELECT total FROM orders', [

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliCteShadowingTest.php
@@ -1004,4 +1004,34 @@ final class MysqliCteShadowingTest extends TestCase
             $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
         }
     }
+
+    public function testRangePartitionSelectionMatchesShadowRows(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $rawMysqli->query('CREATE TABLE events (id INT NOT NULL, event_date DATE NOT NULL, '
+            . 'PRIMARY KEY (id, event_date)) PARTITION BY RANGE (YEAR(event_date)) ('
+            . 'PARTITION p2023 VALUES LESS THAN (2024), '
+            . 'PARTITION p2024 VALUES LESS THAN (2025), '
+            . 'PARTITION pmax VALUES LESS THAN MAXVALUE)');
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli, null);
+
+        try {
+            self::assertNotFalse($ztdMysqli->query("INSERT INTO events VALUES "
+                . "(1, '2023-06-01'), (2, '2024-01-15'), (3, '2024-11-20'), (4, '2025-02-01')"));
+
+            $selected = $ztdMysqli->query('SELECT id FROM events PARTITION (p2024) ORDER BY id');
+            self::assertInstanceOf(\mysqli_result::class, $selected);
+            self::assertSame([['id' => 2], ['id' => 3]], $selected->fetch_all(MYSQLI_ASSOC));
+
+            $combined = $ztdMysqli->query('SELECT e.id FROM events PARTITION (p2023, pmax) e ORDER BY e.id');
+            self::assertInstanceOf(\mysqli_result::class, $combined);
+            self::assertSame([['id' => 1], ['id' => 4]], $combined->fetch_all(MYSQLI_ASSOC));
+
+            $physical = $rawMysqli->query('SELECT COUNT(*) AS total FROM events');
+            self::assertInstanceOf(\mysqli_result::class, $physical);
+            self::assertSame([['total' => '0']], $physical->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/PartitionSelectionTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/PartitionSelectionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_mysql
+ * @group integration
+ * @group mysql
+ */
+#[CoversNothing]
+#[Large]
+final class PartitionSelectionTest extends TestCase
+{
+    public function testRangePartitionSelectionMatchesShadowRows(): void
+    {
+        [$databaseName, $pdo] = MySqlContainer::createTestDatabase();
+
+        try {
+            $pdo->exec('CREATE TABLE events (id INT NOT NULL, event_date DATE NOT NULL, '
+                . 'PRIMARY KEY (id, event_date)) PARTITION BY RANGE (YEAR(event_date)) ('
+                . 'PARTITION p2023 VALUES LESS THAN (2024), '
+                . 'PARTITION p2024 VALUES LESS THAN (2025), '
+                . 'PARTITION pmax VALUES LESS THAN MAXVALUE)');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+            self::assertSame(4, $ztdPdo->exec("INSERT INTO events VALUES "
+                . "(1, '2023-06-01'), (2, '2024-01-15'), (3, '2024-11-20'), (4, '2025-02-01')"));
+
+            $selected = $ztdPdo->query('SELECT id FROM events PARTITION (p2024) ORDER BY id');
+            self::assertNotFalse($selected);
+            self::assertSame([2, 3], $selected->fetchAll(\PDO::FETCH_COLUMN));
+
+            $combined = $ztdPdo->query('SELECT e.id FROM events PARTITION (p2023, pmax) AS e ORDER BY e.id');
+            self::assertNotFalse($combined);
+            self::assertSame([1, 4], $combined->fetchAll(\PDO::FETCH_COLUMN));
+
+            $physical = $pdo->query('SELECT COUNT(*) FROM events');
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- parse explicit PARTITION clauses structurally for SELECT, INSERT, UPDATE, and DELETE
- constrain shadow reads and mutations to the named partitions
- add SQLFaker coverage, unit regressions, and real MySQL integration coverage

Closes #158