### PR TITLE
feat(postgres): pass through anonymous do blocks

### DIFF
--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -111,6 +111,15 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function doStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('DoStmt', [
+            'dostmt_opt_list' => [ProductionPattern::exactly('dostmt_opt_item')],
+            'dostmt_opt_item' => [ProductionPattern::exactly('Sconst')],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -453,6 +453,14 @@ final class PostgreSqlProvider extends Base
         return $this->sql->generate(GenerationPlans::tableSampleStatement()->withMaxDepth($maxDepth));
     }
 
+    /** @return non-empty-string */
+    public function doStatement(): string
+    {
+        $id = $this->rsg->integerString(1, 2147483647);
+
+        return "DO \$ztd\$ BEGIN INSERT INTO users (id, name) VALUES ($id, 'fuzz'); END \$ztd\$";
+    }
+
     /**
      * @template TRequiresNonEmpty of bool
      * @param GenerationPlan<TRequiresNonEmpty> $plan

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -454,11 +454,9 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function doStatement(): string
+    public function doStatement(int $maxDepth = 40): string
     {
-        $id = $this->rsg->integerString(1, 2147483647);
-
-        return "DO \$ztd\$ BEGIN INSERT INTO users (id, name) VALUES ($id, 'fuzz'); END \$ztd\$";
+        return $this->sql->generate(GenerationPlans::doStatement()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -127,4 +127,13 @@ final class GenerationPlansTest extends TestCase
             $plan->patternAt('table_ref', 0)?->matches(['relation_expr', 'tablesample_clause']) ?? false,
         );
     }
+
+    public function testDoPlanRequiresASingleStringBlock(): void
+    {
+        $plan = GenerationPlans::doStatement();
+
+        self::assertSame('DoStmt', $plan->startRule());
+        self::assertTrue($plan->patternAt('dostmt_opt_list', 0)?->matches(['dostmt_opt_item']) ?? false);
+        self::assertTrue($plan->patternAt('dostmt_opt_item', 0)?->matches(['Sconst']) ?? false);
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -912,13 +912,36 @@ final class PostgreSqlProviderTest extends TestCase
 
     public function testDoStatementTargetsFuzzFixture(): void
     {
-        $faker = Factory::create();
-        $faker->seed(12345);
-        $provider = new PostgreSqlProvider($faker);
+        $maximum = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return is_int($int2) ? $int2 : 2147483647;
+            }
+        };
+        $minimum = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return is_int($int1) ? $int1 : 1;
+            }
+        };
 
-        self::assertMatchesRegularExpression(
-            '/^DO \$ztd\$ BEGIN INSERT INTO users \(id, name\) VALUES \([1-9][0-9]*, \'fuzz\'\); END \$ztd\$$/',
-            $provider->doStatement(),
+        self::assertSame(
+            "DO \$ztd\$ BEGIN INSERT INTO users (id, name) VALUES (2147483647, 'fuzz'); END \$ztd\$",
+            (new PostgreSqlProvider($maximum))->doStatement(),
+        );
+        self::assertSame(
+            "DO \$ztd\$ BEGIN INSERT INTO users (id, name) VALUES (1, 'fuzz'); END \$ztd\$",
+            (new PostgreSqlProvider($minimum))->doStatement(),
         );
     }
 

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -910,6 +910,18 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('TABLESAMPLE', $tokens);
     }
 
+    public function testDoStatementTargetsFuzzFixture(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new PostgreSqlProvider($faker);
+
+        self::assertMatchesRegularExpression(
+            '/^DO \$ztd\$ BEGIN INSERT INTO users \(id, name\) VALUES \([1-9][0-9]*, \'fuzz\'\); END \$ztd\$$/',
+            $provider->doStatement(),
+        );
+    }
+
     #[DataProvider('providerNullableSimpleStatementSeed')]
     public function testSimpleStatementReturnsNonEmpty(int $seed): void
     {

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -910,38 +910,23 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('TABLESAMPLE', $tokens);
     }
 
-    public function testDoStatementTargetsFuzzFixture(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testDoStatementDerivesAnonymousBlockFromGrammar(int $seed): void
     {
-        $maximum = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return is_int($int2) ? $int2 : 2147483647;
-            }
-        };
-        $minimum = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return is_int($int1) ? $int1 : 1;
-            }
-        };
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->doStatement();
+        $faker->seed($seed);
+        $defaultDepth = (new \ReflectionMethod(PostgreSqlProvider::class, 'doStatement'))
+            ->getParameters()[0]
+            ->getDefaultValue();
 
+        self::assertSame(40, $defaultDepth);
+        self::assertSame($sql, $provider->doStatement(40));
         self::assertSame(
-            "DO \$ztd\$ BEGIN INSERT INTO users (id, name) VALUES (2147483647, 'fuzz'); END \$ztd\$",
-            (new PostgreSqlProvider($maximum))->doStatement(),
-        );
-        self::assertSame(
-            "DO \$ztd\$ BEGIN INSERT INTO users (id, name) VALUES (1, 'fuzz'); END \$ztd\$",
-            (new PostgreSqlProvider($minimum))->doStatement(),
+            ['DO', 'SCONST'],
+            (new LexicalGrammar($faker, 'pg-17.2', true))->tokenize($sql),
         );
     }
 

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/DoBlockTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/DoBlockTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class DoBlockTest extends TestCase
+{
+    public function testDoBlockPassesThroughAndLaterShadowDmlStillWorks(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            self::assertSame(0, $ztdPdo->exec(
+                "DO \$block\$ BEGIN INSERT INTO items VALUES (1, 'physical'); END \$block\$",
+            ));
+            self::assertSame(1, $ztdPdo->exec("INSERT INTO items VALUES (2, 'shadow')"));
+
+            $shadow = $ztdPdo->query('SELECT id, name FROM items ORDER BY id');
+            self::assertNotFalse($shadow);
+            self::assertSame([['id' => 2, 'name' => 'shadow']], $shadow->fetchAll());
+
+            $physical = $pdo->query('SELECT id, name FROM items ORDER BY id');
+            self::assertNotFalse($physical);
+            self::assertSame([['id' => 1, 'name' => 'physical']], $physical->fetchAll());
+        } finally {
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
@@ -62,6 +62,7 @@ final class ClassifyTarget
             fn (): string => $this->provider->dropTableStatement(maxDepth: 3),
             fn (): string => $this->provider->partitionOfStatement(),
             fn (): string => $this->provider->tableSampleStatement(),
+            fn (): string => $this->provider->doStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -146,6 +146,7 @@ final class RewriteTarget
             fn (): string => $this->provider->foreignKeyCascadeStatement(),
             fn (): string => $this->provider->partitionOfStatement(),
             fn (): string => $this->provider->tableSampleStatement(),
+            fn (): string => $this->provider->doStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
@@ -190,6 +190,7 @@ final class RobustnessTarget
             fn (): string => 'SELECT * FROM public.users',
             fn (): string => $this->provider->partitionOfStatement(),
             fn (): string => $this->provider->tableSampleStatement(),
+            fn (): string => $this->provider->doStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -22,7 +22,7 @@ final class PgSqlParser
      * Classify a SQL statement type.
      *
      * @return string|null One of: 'SELECT', 'INSERT', 'UPDATE', 'DELETE',
-     *                     'TRUNCATE', 'CREATE_TABLE', 'DROP_TABLE', 'ALTER_TABLE', or null.
+     *                     'TRUNCATE', 'CREATE_TABLE', 'DROP_TABLE', 'ALTER_TABLE', 'DO', or null.
      */
     public function classifyStatement(string $sql): ?string
     {
@@ -633,6 +633,9 @@ final class PgSqlParser
         }
         if (preg_match('/^ALTER\s+TABLE\b/i', $trimmed) === 1) {
             return 'ALTER_TABLE';
+        }
+        if (preg_match('/^DO(?:\s|$)/i', $trimmed) === 1) {
+            return 'DO';
         }
 
         if (preg_match('/^(?:BEGIN|START\s+TRANSACTION|COMMIT|ROLLBACK|SAVEPOINT|RELEASE\s+SAVEPOINT|SET\s+TRANSACTION)\b/i', $trimmed) === 1) {

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -21,8 +21,7 @@ final class PgSqlParser
     /**
      * Classify a SQL statement type.
      *
-     * @return string|null One of: 'SELECT', 'INSERT', 'UPDATE', 'DELETE',
-     *                     'TRUNCATE', 'CREATE_TABLE', 'DROP_TABLE', 'ALTER_TABLE', 'DO', or null.
+     * @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|'TRUNCATE'|'CREATE_TABLE'|'DROP_TABLE'|'ALTER_TABLE'|'DO'|'TCL'|null
      */
     public function classifyStatement(string $sql): ?string
     {
@@ -536,6 +535,7 @@ final class PgSqlParser
         return (new PgSqlSelectRelationParser())->tableNames($sql);
     }
 
+    /** @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|null */
     private function classifyWithStatement(string $sql): ?string
     {
         $stripped = $this->stripStringLiterals($sql);
@@ -606,6 +606,7 @@ final class PgSqlParser
         return null;
     }
 
+    /** @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|'TRUNCATE'|'CREATE_TABLE'|'DROP_TABLE'|'ALTER_TABLE'|'DO'|'TCL'|null */
     private function classifySimpleStatement(string $sql): ?string
     {
         $trimmed = ltrim($sql);

--- a/packages/ztd-query-postgres/src/PgSqlQueryGuard.php
+++ b/packages/ztd-query-postgres/src/PgSqlQueryGuard.php
@@ -33,6 +33,7 @@ final class PgSqlQueryGuard
 
         return match ($type) {
             'SELECT' => QueryKind::READ,
+            'DO' => QueryKind::READ,
             'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE' => QueryKind::WRITE_SIMULATED,
             'CREATE_TABLE', 'DROP_TABLE', 'ALTER_TABLE' => QueryKind::DDL_SIMULATED,
             'TCL' => QueryKind::SKIPPED,

--- a/packages/ztd-query-postgres/src/PgSqlQueryGuard.php
+++ b/packages/ztd-query-postgres/src/PgSqlQueryGuard.php
@@ -37,7 +37,6 @@ final class PgSqlQueryGuard
             'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE' => QueryKind::WRITE_SIMULATED,
             'CREATE_TABLE', 'DROP_TABLE', 'ALTER_TABLE' => QueryKind::DDL_SIMULATED,
             'TCL' => QueryKind::SKIPPED,
-            default => null,
         };
     }
 }

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -132,8 +132,11 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             return new RewritePlan($sql, QueryKind::SKIPPED);
         }
 
-        $tableContext = $this->buildTableContext();
         $statementType = $this->parser->classifyStatement($sql);
+        if ($statementType === 'DO') {
+            return new RewritePlan($sql, QueryKind::READ);
+        }
+        $tableContext = $this->buildTableContext();
 
         if ($kind === QueryKind::READ) {
             if ($this->hasSchemaContext()) {

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -15,6 +15,17 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(PostgreSqlLexicalMasker::class)]
 final class PgSqlParserTest extends TestCase
 {
+    public function testClassifiesAnonymousDoBlockWithoutSplittingItsBody(): void
+    {
+        $parser = new PgSqlParser();
+        $sql = "DO \$body\$ BEGIN INSERT INTO users VALUES (1); UPDATE users SET id = 2; END \$body\$";
+
+        self::assertSame('DO', $parser->classifyStatement($sql));
+        self::assertSame([$sql], $parser->splitStatements($sql));
+        self::assertSame('DO', $parser->classifyStatement('do language plpgsql $$ begin null; end $$'));
+        self::assertNull($parser->classifyStatement('DOUBLE PRECISION'));
+    }
+
     public function testExtractsOnConflictUpdateWhereAfterInsertSelectWhere(): void
     {
         $parser = new PgSqlParser();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -24,6 +24,7 @@ final class PgSqlParserTest extends TestCase
         self::assertSame([$sql], $parser->splitStatements($sql));
         self::assertSame('DO', $parser->classifyStatement('do language plpgsql $$ begin null; end $$'));
         self::assertNull($parser->classifyStatement('DOUBLE PRECISION'));
+        self::assertNull($parser->classifyStatement('INVALID DO $$ BEGIN NULL; END $$'));
     }
 
     public function testExtractsOnConflictUpdateWhereAfterInsertSelectWhere(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlQueryGuardTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlQueryGuardTest.php
@@ -124,6 +124,16 @@ final class PgSqlQueryGuardTest extends QueryClassifierContractTest
         self::assertNull($guard->classify('CREATE DATABASE test'));
     }
 
+    public function testDoBlockClassifiesAsPassthroughRead(): void
+    {
+        $guard = new PgSqlQueryGuard(new PgSqlParser());
+
+        self::assertSame(
+            QueryKind::READ,
+            $guard->classify("DO \$\$ BEGIN INSERT INTO users VALUES (1); END \$\$"),
+        );
+    }
+
     public function testWithSelectClassifiesAsRead(): void
     {
         $guard = new PgSqlQueryGuard(new PgSqlParser());

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -76,6 +76,16 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlPartitionPredicateRenderer::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
+    public function testDoBlockPassesThroughWithoutInspectingBodyTables(): void
+    {
+        $sql = "DO \$body\$ BEGIN INSERT INTO physical_only VALUES (1); END \$body\$ LANGUAGE plpgsql";
+        $plan = $this->createRewriter(new ShadowStore(), new TableDefinitionRegistry())->rewrite($sql);
+
+        self::assertSame(QueryKind::READ, $plan->kind());
+        self::assertSame($sql, $plan->sql());
+        self::assertNull($plan->mutation());
+    }
+
     public function testChildPartitionSelectUsesFilteredParentShadowSource(): void
     {
         $store = new ShadowStore();


### PR DESCRIPTION
## Summary
- classify PostgreSQL anonymous DO blocks as executable passthrough statements
- preserve dollar-quoted bodies without treating contained DML as separate statements
- add SQLFaker generation plus parser, guard, rewriter, fuzz, and real PostgreSQL regressions

Closes #161