### PR TITLE
feat(postgres): simulate merge statements

### DIFF
--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -120,6 +120,25 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function mergeStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('MergeStmt', [
+            'merge_when_list' => [
+                ProductionPattern::exactly('merge_when_list', 'merge_when_clause'),
+                ProductionPattern::exactly('merge_when_list', 'merge_when_clause'),
+                ProductionPattern::exactly('merge_when_list', 'merge_when_clause'),
+                ProductionPattern::exactly('merge_when_clause'),
+            ],
+            'merge_when_clause' => [
+                ProductionPattern::containing('merge_when_tgt_matched', 'merge_delete'),
+                ProductionPattern::containing('merge_when_tgt_matched', 'DO', 'NOTHING'),
+                ProductionPattern::containing('merge_when_tgt_matched', 'merge_update'),
+                ProductionPattern::containing('merge_when_tgt_not_matched', 'merge_insert'),
+            ],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -460,24 +460,9 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
-    public function mergeStatement(): string
+    public function mergeStatement(int $maxDepth = 40): string
     {
-        $id = $this->rsg->integerString(1, 2147483647);
-        $remove = $this->generator->boolean() ? 'TRUE' : 'FALSE';
-        $source = "(VALUES ($id, 'fuzz', $remove)) AS source(id, name, remove_row)";
-        $prefix = '';
-        if ($this->generator->boolean()) {
-            $prefix = "WITH incoming(id, name, remove_row) AS (VALUES ($id, 'fuzz', $remove)) ";
-            $source = 'incoming AS source';
-        }
-
-        return $prefix . 'MERGE INTO users AS target USING ' . $source
-            . ' ON target.id = source.id'
-            . ' WHEN MATCHED AND source.remove_row THEN DELETE'
-            . ' WHEN MATCHED AND source.name IS NULL THEN DO NOTHING'
-            . ' WHEN MATCHED THEN UPDATE SET name = source.name'
-            . ' WHEN NOT MATCHED THEN INSERT (id, name, status)'
-            . " VALUES (source.id, source.name, 'active')";
+        return $this->sql->generate(GenerationPlans::mergeStatement()->withMaxDepth($maxDepth));
     }
 
     /**

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -459,6 +459,27 @@ final class PostgreSqlProvider extends Base
         return $this->sql->generate(GenerationPlans::doStatement()->withMaxDepth($maxDepth));
     }
 
+    /** @return non-empty-string */
+    public function mergeStatement(): string
+    {
+        $id = $this->rsg->integerString(1, 2147483647);
+        $remove = $this->generator->boolean() ? 'TRUE' : 'FALSE';
+        $source = "(VALUES ($id, 'fuzz', $remove)) AS source(id, name, remove_row)";
+        $prefix = '';
+        if ($this->generator->boolean()) {
+            $prefix = "WITH incoming(id, name, remove_row) AS (VALUES ($id, 'fuzz', $remove)) ";
+            $source = 'incoming AS source';
+        }
+
+        return $prefix . 'MERGE INTO users AS target USING ' . $source
+            . ' ON target.id = source.id'
+            . ' WHEN MATCHED AND source.remove_row THEN DELETE'
+            . ' WHEN MATCHED AND source.name IS NULL THEN DO NOTHING'
+            . ' WHEN MATCHED THEN UPDATE SET name = source.name'
+            . ' WHEN NOT MATCHED THEN INSERT (id, name, status)'
+            . " VALUES (source.id, source.name, 'active')";
+    }
+
     /**
      * @template TRequiresNonEmpty of bool
      * @param GenerationPlan<TRequiresNonEmpty> $plan

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -142,7 +142,27 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::mergeStatement();
 
         self::assertSame('MergeStmt', $plan->startRule());
-        self::assertNotNull($plan->patternAt('merge_when_list', 3));
-        self::assertNotNull($plan->patternAt('merge_when_clause', 3));
+        self::assertTrue(
+            $plan->patternAt('merge_when_list', 0)?->matches(['merge_when_list', 'merge_when_clause']) ?? false,
+        );
+        self::assertTrue(
+            $plan->patternAt('merge_when_list', 1)?->matches(['merge_when_list', 'merge_when_clause']) ?? false,
+        );
+        self::assertTrue(
+            $plan->patternAt('merge_when_list', 2)?->matches(['merge_when_list', 'merge_when_clause']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('merge_when_list', 3)?->matches(['merge_when_clause']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('merge_when_clause', 0)?->matches(['merge_when_tgt_matched', 'merge_delete']) ?? false,
+        );
+        self::assertTrue(
+            $plan->patternAt('merge_when_clause', 1)?->matches(['merge_when_tgt_matched', 'DO', 'NOTHING']) ?? false,
+        );
+        self::assertTrue(
+            $plan->patternAt('merge_when_clause', 2)?->matches(['merge_when_tgt_matched', 'merge_update']) ?? false,
+        );
+        self::assertTrue(
+            $plan->patternAt('merge_when_clause', 3)?->matches(['merge_when_tgt_not_matched', 'merge_insert']) ?? false,
+        );
     }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -136,4 +136,13 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('dostmt_opt_list', 0)?->matches(['dostmt_opt_item']) ?? false);
         self::assertTrue($plan->patternAt('dostmt_opt_item', 0)?->matches(['Sconst']) ?? false);
     }
+
+    public function testMergePlanRequiresAllMutationBranches(): void
+    {
+        $plan = GenerationPlans::mergeStatement();
+
+        self::assertSame('MergeStmt', $plan->startRule());
+        self::assertNotNull($plan->patternAt('merge_when_list', 3));
+        self::assertNotNull($plan->patternAt('merge_when_clause', 3));
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -930,6 +930,21 @@ final class PostgreSqlProviderTest extends TestCase
         );
     }
 
+    public function testMergeStatementTargetsFuzzFixtureAndCoversEveryAction(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new PostgreSqlProvider($faker);
+
+        $sql = $provider->mergeStatement();
+
+        self::assertStringContainsString('MERGE INTO users AS target USING', $sql);
+        self::assertStringContainsString('WHEN MATCHED AND source.remove_row THEN DELETE', $sql);
+        self::assertStringContainsString('WHEN MATCHED AND source.name IS NULL THEN DO NOTHING', $sql);
+        self::assertStringContainsString('WHEN MATCHED THEN UPDATE SET name = source.name', $sql);
+        self::assertStringContainsString('WHEN NOT MATCHED THEN INSERT', $sql);
+    }
+
     #[DataProvider('providerNullableSimpleStatementSeed')]
     public function testSimpleStatementReturnsNonEmpty(int $seed): void
     {

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -930,72 +930,34 @@ final class PostgreSqlProviderTest extends TestCase
         );
     }
 
-    public function testMergeStatementTargetsFuzzFixtureAndCoversEveryAction(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testMergeStatementDerivesEveryActionFromGrammar(int $seed): void
     {
-        $maximum = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return is_int($int2) ? $int2 : 2147483647;
-            }
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->mergeStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'pg-17.2', true))->tokenize($sql);
+        $normalized = implode(' ', $tokens);
+        $delete = strpos($normalized, 'WHEN MATCHED THEN DELETE_P');
+        $nothing = strpos($normalized, 'WHEN MATCHED THEN DO NOTHING');
+        $update = strpos($normalized, 'WHEN MATCHED THEN UPDATE');
+        $insert = strpos($normalized, 'WHEN NOT MATCHED THEN INSERT');
 
-            /**
-             * @param string $method
-             * @param array<mixed> $attributes
-             */
-            #[\Override]
-            public function __call($method, $attributes): bool
-            {
-                return true;
-            }
-        };
-        $minimum = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return is_int($int1) ? $int1 : 1;
-            }
-
-            /**
-             * @param string $method
-             * @param array<mixed> $attributes
-             */
-            #[\Override]
-            public function __call($method, $attributes): bool
-            {
-                return false;
-            }
-        };
-
-        self::assertSame(
-            "WITH incoming(id, name, remove_row) AS (VALUES (2147483647, 'fuzz', TRUE)) "
-            . 'MERGE INTO users AS target USING incoming AS source'
-            . ' ON target.id = source.id'
-            . ' WHEN MATCHED AND source.remove_row THEN DELETE'
-            . ' WHEN MATCHED AND source.name IS NULL THEN DO NOTHING'
-            . ' WHEN MATCHED THEN UPDATE SET name = source.name'
-            . ' WHEN NOT MATCHED THEN INSERT (id, name, status)'
-            . " VALUES (source.id, source.name, 'active')",
-            (new PostgreSqlProvider($maximum))->mergeStatement(),
+        self::assertSame($sql, $provider->mergeStatement(40));
+        self::assertContains('MERGE', $tokens);
+        self::assertGreaterThanOrEqual(
+            4,
+            count(array_filter($tokens, static fn (string $token): bool => $token === 'WHEN')),
         );
-        self::assertSame(
-            "MERGE INTO users AS target USING (VALUES (1, 'fuzz', FALSE)) AS source(id, name, remove_row)"
-            . ' ON target.id = source.id'
-            . ' WHEN MATCHED AND source.remove_row THEN DELETE'
-            . ' WHEN MATCHED AND source.name IS NULL THEN DO NOTHING'
-            . ' WHEN MATCHED THEN UPDATE SET name = source.name'
-            . ' WHEN NOT MATCHED THEN INSERT (id, name, status)'
-            . " VALUES (source.id, source.name, 'active')",
-            (new PostgreSqlProvider($minimum))->mergeStatement(),
-        );
+        self::assertIsInt($delete);
+        self::assertIsInt($nothing);
+        self::assertIsInt($update);
+        self::assertIsInt($insert);
+        self::assertLessThan($nothing, $delete);
+        self::assertLessThan($update, $nothing);
+        self::assertLessThan($insert, $update);
     }
 
     #[DataProvider('providerNullableSimpleStatementSeed')]

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -932,17 +932,70 @@ final class PostgreSqlProviderTest extends TestCase
 
     public function testMergeStatementTargetsFuzzFixtureAndCoversEveryAction(): void
     {
-        $faker = Factory::create();
-        $faker->seed(12345);
-        $provider = new PostgreSqlProvider($faker);
+        $maximum = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return is_int($int2) ? $int2 : 2147483647;
+            }
 
-        $sql = $provider->mergeStatement();
+            /**
+             * @param string $method
+             * @param array<mixed> $attributes
+             */
+            #[\Override]
+            public function __call($method, $attributes): bool
+            {
+                return true;
+            }
+        };
+        $minimum = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return is_int($int1) ? $int1 : 1;
+            }
 
-        self::assertStringContainsString('MERGE INTO users AS target USING', $sql);
-        self::assertStringContainsString('WHEN MATCHED AND source.remove_row THEN DELETE', $sql);
-        self::assertStringContainsString('WHEN MATCHED AND source.name IS NULL THEN DO NOTHING', $sql);
-        self::assertStringContainsString('WHEN MATCHED THEN UPDATE SET name = source.name', $sql);
-        self::assertStringContainsString('WHEN NOT MATCHED THEN INSERT', $sql);
+            /**
+             * @param string $method
+             * @param array<mixed> $attributes
+             */
+            #[\Override]
+            public function __call($method, $attributes): bool
+            {
+                return false;
+            }
+        };
+
+        self::assertSame(
+            "WITH incoming(id, name, remove_row) AS (VALUES (2147483647, 'fuzz', TRUE)) "
+            . 'MERGE INTO users AS target USING incoming AS source'
+            . ' ON target.id = source.id'
+            . ' WHEN MATCHED AND source.remove_row THEN DELETE'
+            . ' WHEN MATCHED AND source.name IS NULL THEN DO NOTHING'
+            . ' WHEN MATCHED THEN UPDATE SET name = source.name'
+            . ' WHEN NOT MATCHED THEN INSERT (id, name, status)'
+            . " VALUES (source.id, source.name, 'active')",
+            (new PostgreSqlProvider($maximum))->mergeStatement(),
+        );
+        self::assertSame(
+            "MERGE INTO users AS target USING (VALUES (1, 'fuzz', FALSE)) AS source(id, name, remove_row)"
+            . ' ON target.id = source.id'
+            . ' WHEN MATCHED AND source.remove_row THEN DELETE'
+            . ' WHEN MATCHED AND source.name IS NULL THEN DO NOTHING'
+            . ' WHEN MATCHED THEN UPDATE SET name = source.name'
+            . ' WHEN NOT MATCHED THEN INSERT (id, name, status)'
+            . " VALUES (source.id, source.name, 'active')",
+            (new PostgreSqlProvider($minimum))->mergeStatement(),
+        );
     }
 
     #[DataProvider('providerNullableSimpleStatementSeed')]

--- a/packages/ztd-query-core/src/Rewrite/ShadowIdentityAllocator.php
+++ b/packages/ztd-query-core/src/Rewrite/ShadowIdentityAllocator.php
@@ -75,6 +75,33 @@ final class ShadowIdentityAllocator
         return $starts;
     }
 
+    /**
+     * Allocate expressions for identity columns omitted from, or set to DEFAULT in, a projected row.
+     *
+     * @param array<string, IdentityGenerationStrategy> $strategies
+     * @param list<string> $insertColumns
+     * @param list<string> $values
+     * @param array<int, array<string, mixed>> $existingRows
+     * @return array<string, string>
+     */
+    public function allocateSelectExpressionsForValues(
+        string $table,
+        array $strategies,
+        array $insertColumns,
+        array $values,
+        array $existingRows,
+    ): array {
+        $providedColumns = [];
+        foreach ($insertColumns as $index => $column) {
+            $value = $values[$index] ?? 'DEFAULT';
+            if (strcasecmp(trim($value), 'DEFAULT') !== 0) {
+                $providedColumns[] = $column;
+            }
+        }
+
+        return $this->allocateSelectExpressions($table, $strategies, $providedColumns, $existingRows);
+    }
+
     /** @param array<int, array<string, mixed>> $existingRows */
     private function nextValue(
         string $table,

--- a/packages/ztd-query-core/src/Rewrite/ShadowIdentityAllocator.php
+++ b/packages/ztd-query-core/src/Rewrite/ShadowIdentityAllocator.php
@@ -75,33 +75,6 @@ final class ShadowIdentityAllocator
         return $starts;
     }
 
-    /**
-     * Allocate expressions for identity columns omitted from, or set to DEFAULT in, a projected row.
-     *
-     * @param array<string, IdentityGenerationStrategy> $strategies
-     * @param list<string> $insertColumns
-     * @param list<string> $values
-     * @param array<int, array<string, mixed>> $existingRows
-     * @return array<string, string>
-     */
-    public function allocateSelectExpressionsForValues(
-        string $table,
-        array $strategies,
-        array $insertColumns,
-        array $values,
-        array $existingRows,
-    ): array {
-        $providedColumns = [];
-        foreach ($insertColumns as $index => $column) {
-            $value = $values[$index] ?? 'DEFAULT';
-            if (strcasecmp(trim($value), 'DEFAULT') !== 0) {
-                $providedColumns[] = $column;
-            }
-        }
-
-        return $this->allocateSelectExpressions($table, $strategies, $providedColumns, $existingRows);
-    }
-
     /** @param array<int, array<string, mixed>> $existingRows */
     private function nextValue(
         string $table,

--- a/packages/ztd-query-core/src/Schema/TableDefinition.php
+++ b/packages/ztd-query-core/src/Schema/TableDefinition.php
@@ -33,11 +33,11 @@ final class TableDefinition
     public readonly ?TablePartitionRelation $partitionRelation;
 
     /**
-     * @param array<int, string> $columns Column names in declaration order.
+     * @param list<string> $columns Column names in declaration order.
      * @param array<string, string> $columnTypes Column name => MySQL type string.
-     * @param array<int, string> $primaryKeys Primary key column names.
-     * @param array<int, string> $notNullColumns Columns with NOT NULL constraint.
-     * @param array<string, array<int, string>> $uniqueConstraints Key name => column list.
+     * @param list<string> $primaryKeys Primary key column names.
+     * @param list<string> $notNullColumns Columns with NOT NULL constraint.
+     * @param array<string, list<string>> $uniqueConstraints Key name => column list.
      * @param array<string, ColumnType> $typedColumns Column name => structured ColumnType.
      * @param array<string, string> $columnDefaults Column name => SQL default expression.
      * @param array<string, IdentityGenerationStrategy> $identityStrategies Column name => shadow generation strategy.

--- a/packages/ztd-query-core/src/Shadow/Mutation/CreateTableAsSelectMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/CreateTableAsSelectMutation.php
@@ -20,7 +20,7 @@ final class CreateTableAsSelectMutation implements ResultSetMutation
 {
     private string $tableName;
 
-    /** @var array<int, string> */
+    /** @var list<string> */
     private array $columnNames;
 
     private TableDefinitionRegistry $registry;
@@ -28,7 +28,7 @@ final class CreateTableAsSelectMutation implements ResultSetMutation
 
     /**
      * @param string $tableName The name of the new table to create.
-     * @param array<int, string> $columnNames Column names extracted from SELECT.
+     * @param list<string> $columnNames Column names extracted from SELECT.
      * @param TableDefinitionRegistry $registry The registry.
      * @param bool $ifNotExists Whether to skip if table exists.
      */

--- a/packages/ztd-query-core/src/Shadow/Mutation/MutationImpact.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/MutationImpact.php
@@ -35,6 +35,9 @@ final class MutationImpact
         if ($mode === AffectedRowsMode::Matched && $this->mutation instanceof UpdateMutation) {
             return count($this->input);
         }
+        if ($mode === AffectedRowsMode::Changed && $this->mutation instanceof SynchronizeMutation) {
+            return $this->mutation->affectedRowCount($this->before, $this->after);
+        }
 
         return max(
             count($this->difference($this->before, $this->after)),
@@ -66,6 +69,7 @@ final class MutationImpact
     {
         return $this->mutation instanceof InsertMutation
             || $this->mutation instanceof ReplaceMutation
+            || $this->mutation instanceof SynchronizeMutation
             || $this->mutation instanceof UpsertMutation;
     }
 

--- a/packages/ztd-query-core/src/Shadow/Mutation/SynchronizeMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/SynchronizeMutation.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Shadow\Mutation;
+
+use ZtdQuery\Exception\DuplicateKeyException;
+use ZtdQuery\Exception\NotNullViolationException;
+use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Shadow\ShadowStore;
+
+/**
+ * Replaces a table with a database-evaluated complete result set.
+ */
+final class SynchronizeMutation implements DataMutation
+{
+    public function __construct(
+        private readonly string $tableName,
+        private readonly ?TableDefinition $definition = null,
+        private readonly string $sql = '',
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function apply(ShadowStore $store, array $rows): void
+    {
+        if ($this->definition !== null) {
+            $validated = [];
+            foreach ($rows as $row) {
+                foreach ($this->definition->notNullColumns as $column) {
+                    if (($row[$column] ?? null) === null) {
+                        throw new NotNullViolationException($this->sql, $this->tableName, $column);
+                    }
+                }
+
+                $conflict = $this->definition->candidateKeys()->findConflict($row, $validated);
+                if ($conflict !== null) {
+                    throw new DuplicateKeyException(
+                        $this->sql,
+                        $this->tableName,
+                        $conflict->keyName,
+                        $conflict->values,
+                    );
+                }
+                $validated[] = $row;
+            }
+        }
+
+        $store->set($this->tableName, $rows);
+    }
+
+    public function tableName(): string
+    {
+        return $this->tableName;
+    }
+
+    /**
+     * Count inserted, updated, and deleted rows once each.
+     *
+     * @param array<int, array<string, mixed>> $before
+     * @param array<int, array<string, mixed>> $after
+     */
+    public function affectedRowCount(array $before, array $after): int
+    {
+        $primaryKeys = array_values($this->definition->primaryKeys ?? []);
+        if ($primaryKeys === []) {
+            return max(
+                count($this->difference($before, $after)),
+                count($this->difference($after, $before)),
+            );
+        }
+
+        $matchedAfter = [];
+        $count = 0;
+        foreach ($before as $beforeRow) {
+            $afterIndex = $this->matchingRowIndex($after, $beforeRow, $primaryKeys, $matchedAfter);
+            if ($afterIndex === null) {
+                $count++;
+                continue;
+            }
+            $matchedAfter[$afterIndex] = true;
+            if ($beforeRow !== $after[$afterIndex]) {
+                $count++;
+            }
+        }
+
+        return $count + count($after) - count($matchedAfter);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @param array<string, mixed> $identity
+     * @param list<string> $primaryKeys
+     * @param array<int, bool> $excluded
+     */
+    private function matchingRowIndex(
+        array $rows,
+        array $identity,
+        array $primaryKeys,
+        array $excluded,
+    ): ?int {
+        foreach ($rows as $index => $row) {
+            if (isset($excluded[$index])) {
+                continue;
+            }
+            $matches = true;
+            foreach ($primaryKeys as $primaryKey) {
+                if (!array_key_exists($primaryKey, $identity)
+                    || !array_key_exists($primaryKey, $row)
+                    || $identity[$primaryKey] !== $row[$primaryKey]
+                ) {
+                    $matches = false;
+                }
+            }
+            if ($matches) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $left
+     * @param array<int, array<string, mixed>> $right
+     * @return array<int, array<string, mixed>>
+     */
+    private function difference(array $left, array $right): array
+    {
+        $remaining = $right;
+        $difference = [];
+        foreach ($left as $row) {
+            $match = array_search($row, $remaining, true);
+            if ($match === false) {
+                $difference[] = $row;
+                continue;
+            }
+            unset($remaining[$match]);
+        }
+
+        return $difference;
+    }
+}

--- a/packages/ztd-query-core/src/Shadow/Mutation/SynchronizeMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/SynchronizeMutation.php
@@ -64,7 +64,7 @@ final class SynchronizeMutation implements DataMutation
      */
     public function affectedRowCount(array $before, array $after): int
     {
-        $primaryKeys = array_values($this->definition->primaryKeys ?? []);
+        $primaryKeys = $this->definition->primaryKeys ?? [];
         if ($primaryKeys === []) {
             return max(
                 count($this->difference($before, $after)),
@@ -80,7 +80,7 @@ final class SynchronizeMutation implements DataMutation
                 $count++;
                 continue;
             }
-            $matchedAfter[$afterIndex] = true;
+            $matchedAfter[] = $afterIndex;
             if ($beforeRow !== $after[$afterIndex]) {
                 $count++;
             }
@@ -93,7 +93,7 @@ final class SynchronizeMutation implements DataMutation
      * @param array<int, array<string, mixed>> $rows
      * @param array<string, mixed> $identity
      * @param list<string> $primaryKeys
-     * @param array<int, bool> $excluded
+     * @param list<int> $excluded
      */
     private function matchingRowIndex(
         array $rows,
@@ -102,7 +102,7 @@ final class SynchronizeMutation implements DataMutation
         array $excluded,
     ): ?int {
         foreach ($rows as $index => $row) {
-            if (isset($excluded[$index])) {
+            if (in_array($index, $excluded, true)) {
                 continue;
             }
             $matches = true;

--- a/packages/ztd-query-core/src/Shadow/ReferentialIntegrityEnforcer.php
+++ b/packages/ztd-query-core/src/Shadow/ReferentialIntegrityEnforcer.php
@@ -366,7 +366,7 @@ final class ReferentialIntegrityEnforcer
             return [];
         }
 
-        return array_values($referencedTable->primaryKeys);
+        return $referencedTable->primaryKeys;
     }
 
     /**
@@ -454,4 +454,5 @@ final class ReferentialIntegrityEnforcer
 
         return true;
     }
+
 }

--- a/packages/ztd-query-core/tests/Unit/Rewrite/ShadowIdentityAllocatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/ShadowIdentityAllocatorTest.php
@@ -181,27 +181,6 @@ final class ShadowIdentityAllocatorTest extends TestCase
         );
     }
 
-    public function testSelectAllocationTreatsOnlyDefaultValuesAsMissing(): void
-    {
-        self::assertSame(
-            [
-                'generated_id' => '1 + ROW_NUMBER() OVER () - 1',
-                'omitted_id' => '1 + ROW_NUMBER() OVER () - 1',
-            ],
-            (new ShadowIdentityAllocator())->allocateSelectExpressionsForValues(
-                'users',
-                [
-                    'generated_id' => IdentityGenerationStrategy::Sequence,
-                    'provided_id' => IdentityGenerationStrategy::Sequence,
-                    'omitted_id' => IdentityGenerationStrategy::Sequence,
-                ],
-                ['generated_id', 'provided_id'],
-                ['  default  ', '42'],
-                [],
-            ),
-        );
-    }
-
     public function testUncommittedPreparationDoesNotConsumeIdentity(): void
     {
         $allocator = new ShadowIdentityAllocator();

--- a/packages/ztd-query-core/tests/Unit/Rewrite/ShadowIdentityAllocatorTest.php
+++ b/packages/ztd-query-core/tests/Unit/Rewrite/ShadowIdentityAllocatorTest.php
@@ -181,6 +181,27 @@ final class ShadowIdentityAllocatorTest extends TestCase
         );
     }
 
+    public function testSelectAllocationTreatsOnlyDefaultValuesAsMissing(): void
+    {
+        self::assertSame(
+            [
+                'generated_id' => '1 + ROW_NUMBER() OVER () - 1',
+                'omitted_id' => '1 + ROW_NUMBER() OVER () - 1',
+            ],
+            (new ShadowIdentityAllocator())->allocateSelectExpressionsForValues(
+                'users',
+                [
+                    'generated_id' => IdentityGenerationStrategy::Sequence,
+                    'provided_id' => IdentityGenerationStrategy::Sequence,
+                    'omitted_id' => IdentityGenerationStrategy::Sequence,
+                ],
+                ['generated_id', 'provided_id'],
+                ['  default  ', '42'],
+                [],
+            ),
+        );
+    }
+
     public function testUncommittedPreparationDoesNotConsumeIdentity(): void
     {
         $allocator = new ShadowIdentityAllocator();

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/DataMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/DataMutationTest.php
@@ -13,6 +13,7 @@ use ZtdQuery\Shadow\Mutation\MultiDeleteMutation;
 use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
 use ZtdQuery\Shadow\Mutation\MultiUpdateMutation;
 use ZtdQuery\Shadow\Mutation\ReplaceMutation;
+use ZtdQuery\Shadow\Mutation\SynchronizeMutation;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
@@ -31,5 +32,6 @@ final class DataMutationTest extends TestCase
         self::assertInstanceOf(DataMutation::class, new MultiUpdateMutation([]));
         self::assertInstanceOf(DataMutation::class, new MultiDeleteMutation([]));
         self::assertInstanceOf(DataMutation::class, new MultiTruncateMutation([]));
+        self::assertInstanceOf(DataMutation::class, new SynchronizeMutation('items'));
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/MutationImpactTest.php
@@ -10,11 +10,13 @@ use PHPUnit\Framework\TestCase;
 use ZtdQuery\Rewrite\AffectedRowsMode;
 use ZtdQuery\Schema\CandidateKeyConflict;
 use ZtdQuery\Schema\CandidateKeySet;
+use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MutationImpact;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\Mutation\ReplaceMutation;
+use ZtdQuery\Shadow\Mutation\SynchronizeMutation;
 use ZtdQuery\Shadow\Mutation\UpsertExpression;
 use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
 use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
@@ -31,6 +33,8 @@ use ZtdQuery\Sql\SqlTokenStream;
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(MutationRowIdentity::class)]
 #[UsesClass(ReplaceMutation::class)]
+#[UsesClass(SynchronizeMutation::class)]
+#[UsesClass(TableDefinition::class)]
 #[UsesClass(UpsertExpression::class)]
 #[UsesClass(UpsertMutation::class)]
 #[UsesClass(UpdateMutation::class)]
@@ -160,6 +164,27 @@ final class MutationImpactTest extends TestCase
         );
 
         self::assertSame(3, $impact->affectedRowCount(AffectedRowsMode::Changed));
+    }
+
+    public function testSynchronizationCountsMixedOperationsOnceEach(): void
+    {
+        $definition = new TableDefinition(
+            ['id', 'name'],
+            ['id' => 'INTEGER', 'name' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+        );
+        $mutation = new SynchronizeMutation('items', $definition);
+        $impact = new MutationImpact(
+            $mutation,
+            [['id' => 1, 'name' => 'old'], ['id' => 3, 'name' => 'deleted']],
+            [['id' => 1, 'name' => 'updated'], ['id' => 2, 'name' => 'inserted']],
+            [['id' => 1, 'name' => 'updated'], ['id' => 2, 'name' => 'inserted']],
+        );
+
+        self::assertSame(3, $impact->affectedRowCount(AffectedRowsMode::Changed));
+        self::assertTrue($impact->isInsertLike());
     }
 
     public function testSkippedConditionalUpsertHasNoAffectedOrReturningRows(): void

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/SynchronizeMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/SynchronizeMutationTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shadow\Mutation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\DuplicateKeyException;
+use ZtdQuery\Exception\NotNullViolationException;
+use ZtdQuery\Schema\CandidateKeyConflict;
+use ZtdQuery\Schema\CandidateKeySet;
+use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Shadow\Mutation\SynchronizeMutation;
+use ZtdQuery\Shadow\ShadowStore;
+
+#[CoversClass(SynchronizeMutation::class)]
+#[UsesClass(CandidateKeyConflict::class)]
+#[UsesClass(CandidateKeySet::class)]
+#[UsesClass(DuplicateKeyException::class)]
+#[UsesClass(NotNullViolationException::class)]
+#[UsesClass(ShadowStore::class)]
+#[UsesClass(TableDefinition::class)]
+final class SynchronizeMutationTest extends TestCase
+{
+    public function testApplyReplacesTheCompleteTableState(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1, 'name' => 'old']]);
+        $rows = [
+            ['id' => 1, 'name' => 'updated'],
+            ['id' => 2, 'name' => 'inserted'],
+        ];
+
+        $mutation = new SynchronizeMutation('users');
+        $mutation->apply($store, $rows);
+
+        self::assertSame($rows, $store->get('users'));
+        self::assertSame('users', $mutation->tableName());
+    }
+
+    public function testApplyRejectsDuplicateCandidateKeys(): void
+    {
+        $definition = new TableDefinition(
+            ['id', 'email'],
+            ['id' => 'INTEGER', 'email' => 'TEXT'],
+            ['id'],
+            ['id'],
+            ['users_email_key' => ['email']],
+        );
+        $mutation = new SynchronizeMutation('users', $definition, 'MERGE INTO users');
+
+        $this->expectException(DuplicateKeyException::class);
+
+        $mutation->apply(new ShadowStore(), [
+            ['id' => 1, 'email' => 'same@example.com'],
+            ['id' => 2, 'email' => 'same@example.com'],
+        ]);
+    }
+
+    public function testApplyRejectsNullInNotNullColumn(): void
+    {
+        $definition = new TableDefinition(
+            ['id'],
+            ['id' => 'INTEGER'],
+            ['id'],
+            ['id'],
+            [],
+        );
+        $mutation = new SynchronizeMutation('users', $definition, 'MERGE INTO users');
+
+        $this->expectException(NotNullViolationException::class);
+
+        $mutation->apply(new ShadowStore(), [['id' => null]]);
+    }
+
+    public function testAffectedRowsCountsMixedInsertUpdateAndDelete(): void
+    {
+        $definition = new TableDefinition(
+            ['id', 'name'],
+            ['id' => 'INTEGER', 'name' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+        );
+        $mutation = new SynchronizeMutation('users', $definition);
+
+        self::assertSame(3, $mutation->affectedRowCount(
+            [
+                ['id' => 3, 'name' => 'deleted'],
+                ['id' => 1, 'name' => 'old'],
+                ['id' => 4, 'name' => 'unchanged'],
+            ],
+            [
+                ['id' => 1, 'name' => 'updated'],
+                ['id' => 2, 'name' => 'inserted'],
+                ['id' => 4, 'name' => 'unchanged'],
+            ],
+        ));
+    }
+
+    public function testAffectedRowsUsesMultisetDifferenceWithoutPrimaryKey(): void
+    {
+        $mutation = new SynchronizeMutation('logs');
+
+        self::assertSame(2, $mutation->affectedRowCount(
+            [['message' => 'same'], ['message' => 'old-one'], ['message' => 'old-two']],
+            [['message' => 'same'], ['message' => 'new-one'], ['message' => 'new-two']],
+        ));
+    }
+
+    public function testAffectedRowsWithoutPrimaryKeyIgnoresRowOrdering(): void
+    {
+        $mutation = new SynchronizeMutation('logs');
+
+        self::assertSame(0, $mutation->affectedRowCount(
+            [['message' => 'first'], ['message' => 'second']],
+            [['message' => 'second'], ['message' => 'first']],
+        ));
+    }
+
+    public function testAffectedRowsMatchesEveryPrimaryKeyAfterAnEarlierMatch(): void
+    {
+        $definition = new TableDefinition(
+            ['id'],
+            ['id' => 'INTEGER'],
+            ['id'],
+            ['id'],
+            [],
+        );
+        $mutation = new SynchronizeMutation('users', $definition);
+        $rows = [['id' => 1], ['id' => 2]];
+
+        self::assertSame(0, $mutation->affectedRowCount($rows, $rows));
+        self::assertSame(2, $mutation->affectedRowCount([['name' => 'missing']], [['id' => 1]]));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
@@ -20,6 +20,7 @@ use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
 use ZtdQuery\Shadow\Mutation\SynchronizeMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
+use ZtdQuery\Shadow\Mutation\ShadowMutation;
 use ZtdQuery\Shadow\ReferentialIntegrityEnforcer;
 use ZtdQuery\Shadow\ShadowStore;
 
@@ -39,6 +40,43 @@ use ZtdQuery\Shadow\ShadowStore;
 #[UsesClass(ShadowStore::class)]
 final class ReferentialIntegrityEnforcerTest extends TestCase
 {
+    public function testSchemaMutationSkipsRowIntegrityChecks(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['parent_id'], 'parents', ['id'])],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', []);
+        $store->set('children', [['id' => 1, 'parent_id' => 99]]);
+        $mutation = new class () implements ShadowMutation {
+            public function apply(ShadowStore $store, array $rows): void
+            {
+            }
+
+            public function tableName(): string
+            {
+                return 'children';
+            }
+        };
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $store->snapshot(),
+            $store,
+            $mutation,
+            [],
+            'CREATE TABLE',
+        );
+
+        self::assertSame([['id' => 1, 'parent_id' => 99]], $store->get('children'));
+    }
+
     public function testSynchronizationCascadesDeletedRows(): void
     {
         $registry = new TableDefinitionRegistry();
@@ -96,6 +134,46 @@ final class ReferentialIntegrityEnforcerTest extends TestCase
             [['id' => 1, 'parent_id' => 99]],
             'INSERT',
         );
+    }
+
+    public function testAcceptsExplicitReferenceToNonPrimaryCandidateKey(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $registry->register('parents', new TableDefinition(
+            ['id', 'code'],
+            ['id' => 'INT', 'code' => 'TEXT'],
+            ['id'],
+            ['id', 'code'],
+            ['parents_code_key' => ['code']],
+        ));
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_code'],
+            ['id' => 'INT', 'parent_code' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent_code' => new ForeignKeyDefinition(
+                ['parent_code'],
+                'parents',
+                ['code'],
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 1, 'code' => 'parent-a']]);
+        $store->set('children', []);
+        $before = $store->snapshot();
+        $mutation = new InsertMutation('children');
+        $mutation->apply($store, [['id' => 10, 'parent_code' => 'parent-a']]);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize(
+            $before,
+            $store,
+            $mutation,
+            [['id' => 10, 'parent_code' => 'parent-a']],
+            'INSERT',
+        );
+
+        self::assertSame([['id' => 10, 'parent_code' => 'parent-a']], $store->get('children'));
     }
 
     public function testDeleteCascadePropagatesAcrossMultipleLevels(): void
@@ -939,33 +1017,6 @@ final class ReferentialIntegrityEnforcerTest extends TestCase
         );
 
         self::assertSame([['id' => 1, 'parent_id' => null]], $after->get('nodes'));
-    }
-
-    public function testSparsePrimaryKeyMetadataIsNormalizedForViolationDetails(): void
-    {
-        $registry = new TableDefinitionRegistry();
-        $registry->register('parents', new TableDefinition(['id'], ['id' => 'INT'], [3 => 'id'], ['id'], []));
-        $registry->register('children', new TableDefinition(
-            ['id', 'parent_id'],
-            ['id' => 'INT', 'parent_id' => 'INT'],
-            ['id'],
-            ['id'],
-            [],
-            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(['parent_id'], 'parents', [])],
-        ));
-        $store = new ShadowStore();
-        $store->set('parents', []);
-        $store->set('children', [['id' => 1, 'parent_id' => 99]]);
-
-        $this->expectException(ForeignKeyViolationException::class);
-        $this->expectExceptionMessage("referenced row not found in 'parents.id'");
-        (new ReferentialIntegrityEnforcer($registry))->synchronize(
-            $store->snapshot(),
-            $store,
-            new InsertMutation('children'),
-            [],
-            'INSERT',
-        );
     }
 
     public function testCascadeNormalizesSparseChildRowIndexes(): void

--- a/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
@@ -17,6 +17,7 @@ use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
+use ZtdQuery\Shadow\Mutation\SynchronizeMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\MutationRowIdentity;
 use ZtdQuery\Shadow\ReferentialIntegrityEnforcer;
@@ -32,11 +33,42 @@ use ZtdQuery\Shadow\ShadowStore;
 #[UsesClass(CreateTableMutation::class)]
 #[UsesClass(InsertMutation::class)]
 #[UsesClass(MultiTruncateMutation::class)]
+#[UsesClass(SynchronizeMutation::class)]
 #[UsesClass(UpdateMutation::class)]
 #[UsesClass(MutationRowIdentity::class)]
 #[UsesClass(ShadowStore::class)]
 final class ReferentialIntegrityEnforcerTest extends TestCase
 {
+    public function testSynchronizationCascadesDeletedRows(): void
+    {
+        $registry = new TableDefinitionRegistry();
+        $parent = new TableDefinition(['id'], ['id' => 'INT'], ['id'], ['id'], []);
+        $registry->register('parents', $parent);
+        $registry->register('children', new TableDefinition(
+            ['id', 'parent_id'],
+            ['id' => 'INT', 'parent_id' => 'INT'],
+            ['id'],
+            ['id'],
+            [],
+            foreignKeys: ['fk_parent' => new ForeignKeyDefinition(
+                ['parent_id'],
+                'parents',
+                ['id'],
+                onDelete: ReferentialAction::Cascade,
+            )],
+        ));
+        $store = new ShadowStore();
+        $store->set('parents', [['id' => 1]]);
+        $store->set('children', [['id' => 10, 'parent_id' => 1]]);
+        $before = $store->snapshot();
+        $mutation = new SynchronizeMutation('parents', $parent);
+        $mutation->apply($store, []);
+
+        (new ReferentialIntegrityEnforcer($registry))->synchronize($before, $store, $mutation, [], 'MERGE');
+
+        self::assertSame([], $store->get('children'));
+    }
+
     public function testRejectsInsertWhoseParentDoesNotExist(): void
     {
         $registry = new TableDefinitionRegistry();

--- a/packages/ztd-query-mysql/src/MySqlMutationResolver.php
+++ b/packages/ztd-query-mysql/src/MySqlMutationResolver.php
@@ -360,7 +360,7 @@ final class MySqlMutationResolver
     /**
      * Extract column names from a SELECT statement for CREATE TABLE AS SELECT.
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     private function extractSelectColumnNames(\PhpMyAdmin\SqlParser\Statements\SelectStatement $selectStatement): array
     {

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/MergeTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/MergeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class MergeTest extends TestCase
+{
+    public function testMergeSimulatesEveryActionSourceShapeAndPreparedParameter(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $pdo->exec('CREATE TABLE merge_target (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+            $pdo->exec('CREATE TABLE merge_source (id INTEGER PRIMARY KEY, name TEXT NOT NULL, remove_row BOOLEAN NOT NULL)');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+            self::assertSame(2, $ztdPdo->exec(
+                "INSERT INTO merge_target VALUES (1, 'old'), (3, 'deleted')",
+            ));
+            self::assertSame(3, $ztdPdo->exec(
+                "INSERT INTO merge_source VALUES (1, 'updated', FALSE), (2, 'inserted', FALSE), (3, 'unused', TRUE)",
+            ));
+
+            self::assertSame(3, $ztdPdo->exec(
+                'MERGE INTO merge_target AS target USING merge_source AS source '
+                . 'ON target.id = source.id '
+                . 'WHEN MATCHED AND source.remove_row THEN DELETE '
+                . 'WHEN MATCHED THEN UPDATE SET name = source.name '
+                . 'WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)',
+            ));
+            $afterMixedActions = $ztdPdo->query('SELECT id, name FROM merge_target ORDER BY id');
+            self::assertNotFalse($afterMixedActions);
+            self::assertSame([
+                ['id' => 1, 'name' => 'updated'],
+                ['id' => 2, 'name' => 'inserted'],
+            ], $afterMixedActions->fetchAll());
+
+            self::assertSame(0, $ztdPdo->exec(
+                "MERGE INTO merge_target AS target USING (VALUES (2, TRUE)) AS source(id, skip_row) "
+                . 'ON target.id = source.id '
+                . 'WHEN MATCHED AND source.skip_row THEN DO NOTHING '
+                . 'WHEN MATCHED THEN DELETE',
+            ));
+
+            $prepared = $ztdPdo->prepare(
+                'MERGE INTO merge_target AS target '
+                . 'USING (VALUES ($1::INTEGER, $2::TEXT, $3::BOOLEAN)) AS source(id, name, remove_row) '
+                . 'ON target.id = source.id '
+                . 'WHEN MATCHED AND source.remove_row THEN DELETE '
+                . 'WHEN MATCHED THEN UPDATE SET name = source.name '
+                . 'WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)',
+            );
+            self::assertInstanceOf(\PDOStatement::class, $prepared);
+            self::assertTrue($prepared->execute([1, 'ignored', true]));
+            self::assertSame(1, $prepared->rowCount());
+            self::assertTrue($prepared->execute([4, 'prepared', false]));
+            self::assertSame(1, $prepared->rowCount());
+
+            self::assertSame(1, $ztdPdo->exec(
+                "WITH incoming(id, name) AS (VALUES (5, 'cte')) "
+                . 'MERGE INTO merge_target AS target USING incoming AS source '
+                . 'ON target.id = source.id '
+                . 'WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)',
+            ));
+
+            $final = $ztdPdo->query('SELECT id, name FROM merge_target ORDER BY id');
+            self::assertNotFalse($final);
+            self::assertSame([
+                ['id' => 2, 'name' => 'inserted'],
+                ['id' => 4, 'name' => 'prepared'],
+                ['id' => 5, 'name' => 'cte'],
+            ], $final->fetchAll(PDO::FETCH_ASSOC));
+
+            $physical = $pdo->query(
+                'SELECT (SELECT COUNT(*) FROM merge_target) + (SELECT COUNT(*) FROM merge_source)',
+            );
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
@@ -63,6 +63,7 @@ final class ClassifyTarget
             fn (): string => $this->provider->partitionOfStatement(),
             fn (): string => $this->provider->tableSampleStatement(),
             fn (): string => $this->provider->doStatement(),
+            fn (): string => $this->provider->mergeStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -147,6 +147,7 @@ final class RewriteTarget
             fn (): string => $this->provider->partitionOfStatement(),
             fn (): string => $this->provider->tableSampleStatement(),
             fn (): string => $this->provider->doStatement(),
+            fn (): string => $this->provider->mergeStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
@@ -191,6 +191,7 @@ final class RobustnessTarget
             fn (): string => $this->provider->partitionOfStatement(),
             fn (): string => $this->provider->tableSampleStatement(),
             fn (): string => $this->provider->doStatement(),
+            fn (): string => $this->provider->mergeStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlMergeActionKind.php
+++ b/packages/ztd-query-postgres/src/PgSqlMergeActionKind.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+enum PgSqlMergeActionKind: string
+{
+    case Update = 'UPDATE';
+    case Insert = 'INSERT';
+    case Delete = 'DELETE';
+    case DoNothing = 'DO NOTHING';
+}

--- a/packages/ztd-query-postgres/src/PgSqlMergeClause.php
+++ b/packages/ztd-query-postgres/src/PgSqlMergeClause.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+final class PgSqlMergeClause
+{
+    /**
+     * @param array<string, string> $assignments
+     * @param list<string> $insertColumns
+     * @param list<string> $insertValues
+     */
+    public function __construct(
+        public readonly PgSqlMergeMatchKind $matchKind,
+        public readonly ?string $conditionSql,
+        public readonly PgSqlMergeActionKind $actionKind,
+        public readonly array $assignments = [],
+        public readonly array $insertColumns = [],
+        public readonly array $insertValues = [],
+    ) {
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlMergeMatchKind.php
+++ b/packages/ztd-query-postgres/src/PgSqlMergeMatchKind.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+enum PgSqlMergeMatchKind: string
+{
+    case Matched = 'MATCHED';
+    case NotMatched = 'NOT MATCHED';
+}

--- a/packages/ztd-query-postgres/src/PgSqlMergeParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlMergeParser.php
@@ -5,18 +5,17 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Postgres;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
-use ZtdQuery\Rewrite\CteShadowComposer;
 use ZtdQuery\Sql\SqlToken;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
 final class PgSqlMergeParser
 {
-    private CteShadowComposer $cteComposer;
+    private PgSqlCteShadowComposer $cteComposer;
 
     public function __construct()
     {
-        $this->cteComposer = new CteShadowComposer();
+        $this->cteComposer = new PgSqlCteShadowComposer();
     }
 
     public function parse(string $sql): PgSqlMergeStatement

--- a/packages/ztd-query-postgres/src/PgSqlMergeParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlMergeParser.php
@@ -21,17 +21,23 @@ final class PgSqlMergeParser
 
     public function parse(string $sql): PgSqlMergeStatement
     {
-        $statementSql = trim($this->cteComposer->statementSql($sql));
+        $statementSql = $this->cteComposer->statementSql($sql);
         $tokens = SqlTokenStream::tokenize($statementSql)->significantTokens();
         $index = 0;
-        if (($tokens[$index] ?? null)?->isKeyword('MERGE') !== true) {
+        $first = $tokens[$index] ?? null;
+        if ($first === null) {
+            throw new UnsupportedSqlException($sql, 'Malformed MERGE statement');
+        }
+        if (!$first->isKeyword('MERGE')) {
             throw new UnsupportedSqlException($sql, 'Malformed MERGE statement');
         }
         $index++;
-        if (($tokens[$index] ?? null)?->isKeyword('INTO') === true) {
+        $next = $tokens[$index] ?? null;
+        if ($next !== null && $next->isKeyword('INTO')) {
             $index++;
+            $next = $tokens[$index] ?? null;
         }
-        if (($tokens[$index] ?? null)?->isKeyword('ONLY') === true) {
+        if ($next !== null && $next->isKeyword('ONLY')) {
             $index++;
         }
 
@@ -41,45 +47,50 @@ final class PgSqlMergeParser
         }
         $index = $target['next'];
         if ($this->isSymbol($tokens[$index] ?? null, '*')) {
+            $target['last'] = $tokens[$index];
             $index++;
         }
 
-        $usingIndex = $this->keywordIndex($tokens, 'USING', $index);
+        $usingIndex = $this->keywordIndexAfter($tokens, 'USING', $target['last']);
         if ($usingIndex === null) {
             throw new UnsupportedSqlException($sql, 'MERGE requires USING');
         }
         $targetAlias = $this->targetAlias($sql, $tokens, $index, $usingIndex, $target['name']);
 
-        $whenIndices = $this->mergeWhenIndices($tokens, $usingIndex + 1);
-        $firstWhen = $whenIndices[0] ?? null;
+        $usingToken = $tokens[$usingIndex];
+        $whenTokens = $this->mergeWhenTokens($tokens);
+        $firstWhen = $whenTokens[0] ?? null;
         if ($firstWhen === null) {
             throw new UnsupportedSqlException($sql, 'MERGE requires a WHEN clause');
         }
-        $onIndex = $this->lastKeywordIndex($tokens, 'ON', $usingIndex + 1, $firstWhen);
-        if ($onIndex === null) {
+        $onToken = $this->lastKeywordBetween($tokens, 'ON', $usingToken, $firstWhen);
+        if ($onToken === null) {
             throw new UnsupportedSqlException($sql, 'MERGE requires an ON condition');
         }
 
         $sourceSql = trim(substr(
             $statementSql,
-            $tokens[$usingIndex]->endOffset(),
-            $tokens[$onIndex]->offset - $tokens[$usingIndex]->endOffset(),
+            $usingToken->endOffset(),
+            $onToken->offset - $usingToken->endOffset(),
         ));
         $joinConditionSql = trim(substr(
             $statementSql,
-            $tokens[$onIndex]->endOffset(),
-            $tokens[$firstWhen]->offset - $tokens[$onIndex]->endOffset(),
+            $onToken->endOffset(),
+            $firstWhen->offset - $onToken->endOffset(),
         ));
-        if ($sourceSql === '' || $joinConditionSql === '') {
+        if ($sourceSql === '') {
+            throw new UnsupportedSqlException($sql, 'MERGE requires a source and join condition');
+        }
+        if ($joinConditionSql === '') {
             throw new UnsupportedSqlException($sql, 'MERGE requires a source and join condition');
         }
 
         $clauses = [];
-        foreach ($whenIndices as $clauseIndex => $whenIndex) {
-            $end = isset($whenIndices[$clauseIndex + 1])
-                ? $tokens[$whenIndices[$clauseIndex + 1]]->offset
+        foreach ($whenTokens as $clauseIndex => $whenToken) {
+            $end = isset($whenTokens[$clauseIndex + 1])
+                ? $whenTokens[$clauseIndex + 1]->offset
                 : strlen($statementSql);
-            $clauseSql = trim(substr($statementSql, $tokens[$whenIndex]->offset, $end - $tokens[$whenIndex]->offset));
+            $clauseSql = substr($statementSql, $whenToken->offset, $end - $whenToken->offset);
             $clauses[] = $this->parseClause($sql, $clauseSql);
         }
         if ($clauses === []) {
@@ -98,7 +109,7 @@ final class PgSqlMergeParser
 
     /**
      * @param list<SqlToken> $tokens
-     * @return array{name: string, sql: string, next: int}|null
+     * @return array{name: string, sql: string, next: int, last: SqlToken}|null
      */
     private function relationAt(string $sql, array $tokens, int $index): ?array
     {
@@ -110,15 +121,20 @@ final class PgSqlMergeParser
 
         $start = $first->offset;
         $end = $first->endOffset();
+        $last = $first;
         $index++;
         while ($this->isSymbol($tokens[$index] ?? null, '.')) {
             $component = $tokens[$index + 1] ?? null;
-            $componentName = $component !== null ? $this->identifierName($component) : null;
-            if ($component === null || $componentName === null) {
+            if ($component === null) {
+                return null;
+            }
+            $componentName = $this->identifierName($component);
+            if ($componentName === null) {
                 return null;
             }
             $name = $componentName;
             $end = $component->endOffset();
+            $last = $component;
             $index += 2;
         }
 
@@ -126,6 +142,7 @@ final class PgSqlMergeParser
             'name' => $name,
             'sql' => substr($sql, $start, $end - $start),
             'next' => $index,
+            'last' => $last,
         ];
     }
 
@@ -140,7 +157,7 @@ final class PgSqlMergeParser
         if ($start === $end) {
             return $default;
         }
-        if (($tokens[$start] ?? null)?->isKeyword('AS') === true) {
+        if ($tokens[$start]->isKeyword('AS')) {
             $start++;
         }
         if ($start + 1 !== $end) {
@@ -160,25 +177,28 @@ final class PgSqlMergeParser
         $tokens = SqlTokenStream::tokenize($clauseSql)->significantTokens();
         $index = 1;
         $matchKind = PgSqlMergeMatchKind::Matched;
-        if (($tokens[$index] ?? null)?->isKeyword('NOT') === true) {
+        $matchToken = $tokens[$index];
+        if ($matchToken->isKeyword('NOT')) {
             $matchKind = PgSqlMergeMatchKind::NotMatched;
             $index++;
+            $matchToken = $tokens[$index];
         }
-        if (($tokens[$index] ?? null)?->isKeyword('MATCHED') !== true) {
+        if (!$matchToken->isKeyword('MATCHED')) {
             throw new UnsupportedSqlException($originalSql, 'Malformed MERGE WHEN clause');
         }
         $index++;
-        if (($tokens[$index] ?? null)?->isKeyword('BY') === true) {
+        $modifier = $tokens[$index] ?? null;
+        if ($modifier !== null && $modifier->isKeyword('BY')) {
             throw new UnsupportedSqlException($originalSql, 'MERGE BY SOURCE and BY TARGET are not supported');
         }
 
-        $thenIndex = $this->keywordIndexOutsideCase($tokens, 'THEN', $index);
+        $thenIndex = $this->keywordIndexOutsideCase($tokens, 'THEN');
         if ($thenIndex === null) {
             throw new UnsupportedSqlException($originalSql, 'MERGE WHEN clause requires THEN');
         }
         $conditionSql = null;
         if ($index !== $thenIndex) {
-            if (($tokens[$index] ?? null)?->isKeyword('AND') !== true) {
+            if (!$tokens[$index]->isKeyword('AND')) {
                 throw new UnsupportedSqlException($originalSql, 'Malformed MERGE WHEN condition');
             }
             $conditionSql = trim(substr(
@@ -191,19 +211,24 @@ final class PgSqlMergeParser
             }
         }
 
-        $actionSql = trim(substr($clauseSql, $tokens[$thenIndex]->endOffset()));
+        $actionSql = substr($clauseSql, $tokens[$thenIndex]->endOffset());
         $actionTokens = SqlTokenStream::tokenize($actionSql)->significantTokens();
         $first = $actionTokens[0] ?? null;
-        if ($first?->isKeyword('DO') === true
-            && ($actionTokens[1] ?? null)?->isKeyword('NOTHING') === true
-            && count($actionTokens) === 2
-        ) {
-            return new PgSqlMergeClause($matchKind, $conditionSql, PgSqlMergeActionKind::DoNothing);
+        if ($first === null) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE action is not supported');
         }
-        if ($matchKind === PgSqlMergeMatchKind::Matched && $first?->isKeyword('DELETE') === true && count($actionTokens) === 1) {
+        if ($first->isKeyword('DO')) {
+            $second = $actionTokens[1] ?? null;
+            if ($second !== null && $second->isKeyword('NOTHING')) {
+                if (count($actionTokens) === 2) {
+                    return new PgSqlMergeClause($matchKind, $conditionSql, PgSqlMergeActionKind::DoNothing);
+                }
+            }
+        }
+        if ($matchKind === PgSqlMergeMatchKind::Matched && $first->isKeyword('DELETE') && count($actionTokens) === 1) {
             return new PgSqlMergeClause($matchKind, $conditionSql, PgSqlMergeActionKind::Delete);
         }
-        if ($matchKind === PgSqlMergeMatchKind::Matched && $first?->isKeyword('UPDATE') === true) {
+        if ($matchKind === PgSqlMergeMatchKind::Matched && $first->isKeyword('UPDATE')) {
             return new PgSqlMergeClause(
                 $matchKind,
                 $conditionSql,
@@ -211,7 +236,7 @@ final class PgSqlMergeParser
                 $this->parseAssignments($originalSql, $actionSql, $actionTokens),
             );
         }
-        if ($matchKind === PgSqlMergeMatchKind::NotMatched && $first?->isKeyword('INSERT') === true) {
+        if ($matchKind === PgSqlMergeMatchKind::NotMatched && $first->isKeyword('INSERT')) {
             $insert = $this->parseInsert($originalSql, $actionSql, $actionTokens);
 
             return new PgSqlMergeClause(
@@ -233,10 +258,14 @@ final class PgSqlMergeParser
      */
     private function parseAssignments(string $originalSql, string $actionSql, array $tokens): array
     {
-        if (($tokens[1] ?? null)?->isKeyword('SET') !== true) {
+        $set = $tokens[1] ?? null;
+        if ($set === null) {
             throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE requires SET');
         }
-        $setSql = trim(substr($actionSql, $tokens[1]->endOffset()));
+        if (!$set->isKeyword('SET')) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE requires SET');
+        }
+        $setSql = substr($actionSql, $set->endOffset());
         $assignments = [];
         foreach (SqlTokenStream::tokenize($setSql)->splitTopLevel() as $assignmentSql) {
             $assignmentTokens = SqlTokenStream::tokenize($assignmentSql)->significantTokens();
@@ -297,19 +326,25 @@ final class PgSqlMergeParser
             $index = $list['next'];
         }
 
-        if (($tokens[$index] ?? null)?->isKeyword('DEFAULT') === true
-            && ($tokens[$index + 1] ?? null)?->isKeyword('VALUES') === true
-            && $index + 2 === count($tokens)
-        ) {
+        $insertAction = $tokens[$index] ?? null;
+        $afterAction = $tokens[$index + 1] ?? null;
+        if ($insertAction !== null && $insertAction->isKeyword('DEFAULT')) {
+            if ($afterAction === null || !$afterAction->isKeyword('VALUES') || $index + 2 !== count($tokens)) {
+                throw new UnsupportedSqlException($originalSql, 'MERGE INSERT requires VALUES');
+            }
             if ($columns !== []) {
                 throw new UnsupportedSqlException($originalSql, 'MERGE INSERT DEFAULT VALUES cannot name columns');
             }
 
             return ['columns' => [], 'values' => []];
         }
-        if (($tokens[$index] ?? null)?->isKeyword('VALUES') !== true
-            || !$this->isSymbol($tokens[$index + 1] ?? null, '(')
-        ) {
+        if ($insertAction === null) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE INSERT requires VALUES');
+        }
+        if (!$insertAction->isKeyword('VALUES')) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE INSERT requires VALUES');
+        }
+        if (!$this->isSymbol($afterAction, '(')) {
             throw new UnsupportedSqlException($originalSql, 'MERGE INSERT requires VALUES');
         }
 
@@ -335,15 +370,23 @@ final class PgSqlMergeParser
         int $openIndex,
     ): array {
         $open = $tokens[$openIndex];
+        $afterOpen = false;
         foreach ($tokens as $closeIndex => $token) {
-            if ($closeIndex <= $openIndex
-                || !$this->isSymbol($token, ')')
-                || $token->depth !== $open->depth
-            ) {
+            if ($token === $open) {
+                $afterOpen = true;
                 continue;
             }
-            $listSql = trim(substr($sql, $open->endOffset(), $token->offset - $open->endOffset()));
-            $items = $listSql === '' ? [] : SqlTokenStream::tokenize($listSql)->splitTopLevel();
+            if (!$afterOpen) {
+                continue;
+            }
+            if (!$this->isSymbol($token, ')')) {
+                continue;
+            }
+            if ($token->depth !== $open->depth) {
+                continue;
+            }
+            $listSql = substr($sql, $open->endOffset(), $token->offset - $open->endOffset());
+            $items = SqlTokenStream::tokenize($listSql)->splitTopLevel();
 
             return ['items' => $items, 'next' => $closeIndex + 1];
         }
@@ -352,10 +395,15 @@ final class PgSqlMergeParser
     }
 
     /** @param list<SqlToken> $tokens */
-    private function keywordIndex(array $tokens, string $keyword, int $start): ?int
+    private function keywordIndexAfter(array $tokens, string $keyword, SqlToken $anchor): ?int
     {
+        $afterAnchor = false;
         foreach ($tokens as $index => $token) {
-            if ($index >= $start && $token->isTopLevel() && $token->isKeyword($keyword)) {
+            if ($token === $anchor) {
+                $afterAnchor = true;
+                continue;
+            }
+            if ($afterAnchor && $token->isTopLevel() && $token->isKeyword($keyword)) {
                 return $index;
             }
         }
@@ -364,15 +412,24 @@ final class PgSqlMergeParser
     }
 
     /** @param list<SqlToken> $tokens */
-    private function lastKeywordIndex(array $tokens, string $keyword, int $start, int $end): ?int
-    {
+    private function lastKeywordBetween(
+        array $tokens,
+        string $keyword,
+        SqlToken $start,
+        SqlToken $end,
+    ): ?SqlToken {
         $found = null;
-        foreach ($tokens as $index => $token) {
-            if ($index >= $end) {
+        $withinRange = false;
+        foreach ($tokens as $token) {
+            if ($token === $start) {
+                $withinRange = true;
+                continue;
+            }
+            if ($token === $end) {
                 break;
             }
-            if ($index >= $start && $token->isTopLevel() && $token->isKeyword($keyword)) {
-                $found = $index;
+            if ($withinRange && $token->isTopLevel() && $token->isKeyword($keyword)) {
+                $found = $token;
             }
         }
 
@@ -381,54 +438,69 @@ final class PgSqlMergeParser
 
     /**
      * @param list<SqlToken> $tokens
-     * @return list<int>
+     * @return list<SqlToken>
      */
-    private function mergeWhenIndices(array $tokens, int $start): array
+    private function mergeWhenTokens(array $tokens): array
     {
-        $indices = [];
+        $whenTokens = [];
         $caseDepth = 0;
         foreach ($tokens as $index => $token) {
-            if ($index < $start || !$token->isTopLevel()) {
+            if (!$token->isTopLevel()) {
                 continue;
             }
             if ($token->isKeyword('CASE')) {
                 $caseDepth++;
                 continue;
             }
-            if ($token->isKeyword('END') && $caseDepth > 0) {
-                $caseDepth--;
-                continue;
+            if ($token->isKeyword('END')) {
+                if ($caseDepth !== 0) {
+                    $caseDepth--;
+                    continue;
+                }
             }
             if ($caseDepth !== 0 || !$token->isKeyword('WHEN')) {
                 continue;
             }
             $next = $tokens[$index + 1] ?? null;
+            if ($next === null) {
+                continue;
+            }
+            if ($next->isKeyword('MATCHED')) {
+                $whenTokens[] = $token;
+                continue;
+            }
+            if (!$next->isKeyword('NOT')) {
+                continue;
+            }
             $afterNext = $tokens[$index + 2] ?? null;
-            if ($next?->isKeyword('MATCHED') === true
-                || ($next?->isKeyword('NOT') === true && $afterNext?->isKeyword('MATCHED') === true)
-            ) {
-                $indices[] = $index;
+            if ($afterNext === null) {
+                continue;
+            }
+            if ($afterNext->isKeyword('MATCHED')) {
+                $whenTokens[] = $token;
             }
         }
 
-        return $indices;
+        return $whenTokens;
     }
 
     /** @param list<SqlToken> $tokens */
-    private function keywordIndexOutsideCase(array $tokens, string $keyword, int $start): ?int
+    private function keywordIndexOutsideCase(array $tokens, string $keyword): ?int
     {
         $caseDepth = 0;
         foreach ($tokens as $index => $token) {
-            if ($index < $start || !$token->isTopLevel()) {
+            if (!$token->isTopLevel()) {
                 continue;
             }
             if ($token->isKeyword('CASE')) {
                 $caseDepth++;
                 continue;
             }
-            if ($token->isKeyword('END') && $caseDepth > 0) {
-                $caseDepth--;
-                continue;
+            if ($token->isKeyword('END')) {
+                if ($caseDepth !== 0) {
+                    $caseDepth--;
+                    continue;
+                }
             }
             if ($caseDepth === 0 && $token->isKeyword($keyword)) {
                 return $index;
@@ -452,8 +524,9 @@ final class PgSqlMergeParser
 
     private function isSymbol(?SqlToken $token, string $symbol): bool
     {
-        return $token instanceof SqlToken
-            && $token->kind === SqlTokenKind::Symbol
-            && $token->text === $symbol;
+        if ($token === null) {
+            return false;
+        }
+        return $token->text === $symbol;
     }
 }

--- a/packages/ztd-query-postgres/src/PgSqlMergeParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlMergeParser.php
@@ -1,0 +1,459 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PgSqlMergeParser
+{
+    private CteShadowComposer $cteComposer;
+
+    public function __construct()
+    {
+        $this->cteComposer = new CteShadowComposer();
+    }
+
+    public function parse(string $sql): PgSqlMergeStatement
+    {
+        $statementSql = trim($this->cteComposer->statementSql($sql));
+        $tokens = SqlTokenStream::tokenize($statementSql)->significantTokens();
+        $index = 0;
+        if (($tokens[$index] ?? null)?->isKeyword('MERGE') !== true) {
+            throw new UnsupportedSqlException($sql, 'Malformed MERGE statement');
+        }
+        $index++;
+        if (($tokens[$index] ?? null)?->isKeyword('INTO') === true) {
+            $index++;
+        }
+        if (($tokens[$index] ?? null)?->isKeyword('ONLY') === true) {
+            $index++;
+        }
+
+        $target = $this->relationAt($statementSql, $tokens, $index);
+        if ($target === null) {
+            throw new UnsupportedSqlException($sql, 'Cannot resolve MERGE target');
+        }
+        $index = $target['next'];
+        if ($this->isSymbol($tokens[$index] ?? null, '*')) {
+            $index++;
+        }
+
+        $usingIndex = $this->keywordIndex($tokens, 'USING', $index);
+        if ($usingIndex === null) {
+            throw new UnsupportedSqlException($sql, 'MERGE requires USING');
+        }
+        $targetAlias = $this->targetAlias($sql, $tokens, $index, $usingIndex, $target['name']);
+
+        $whenIndices = $this->mergeWhenIndices($tokens, $usingIndex + 1);
+        $firstWhen = $whenIndices[0] ?? null;
+        if ($firstWhen === null) {
+            throw new UnsupportedSqlException($sql, 'MERGE requires a WHEN clause');
+        }
+        $onIndex = $this->lastKeywordIndex($tokens, 'ON', $usingIndex + 1, $firstWhen);
+        if ($onIndex === null) {
+            throw new UnsupportedSqlException($sql, 'MERGE requires an ON condition');
+        }
+
+        $sourceSql = trim(substr(
+            $statementSql,
+            $tokens[$usingIndex]->endOffset(),
+            $tokens[$onIndex]->offset - $tokens[$usingIndex]->endOffset(),
+        ));
+        $joinConditionSql = trim(substr(
+            $statementSql,
+            $tokens[$onIndex]->endOffset(),
+            $tokens[$firstWhen]->offset - $tokens[$onIndex]->endOffset(),
+        ));
+        if ($sourceSql === '' || $joinConditionSql === '') {
+            throw new UnsupportedSqlException($sql, 'MERGE requires a source and join condition');
+        }
+
+        $clauses = [];
+        foreach ($whenIndices as $clauseIndex => $whenIndex) {
+            $end = isset($whenIndices[$clauseIndex + 1])
+                ? $tokens[$whenIndices[$clauseIndex + 1]]->offset
+                : strlen($statementSql);
+            $clauseSql = trim(substr($statementSql, $tokens[$whenIndex]->offset, $end - $tokens[$whenIndex]->offset));
+            $clauses[] = $this->parseClause($sql, $clauseSql);
+        }
+        if ($clauses === []) {
+            throw new UnsupportedSqlException($sql, 'MERGE requires a WHEN clause');
+        }
+
+        return new PgSqlMergeStatement(
+            $target['name'],
+            $target['sql'],
+            $targetAlias,
+            $sourceSql,
+            $joinConditionSql,
+            $clauses,
+        );
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{name: string, sql: string, next: int}|null
+     */
+    private function relationAt(string $sql, array $tokens, int $index): ?array
+    {
+        $first = $tokens[$index] ?? null;
+        $name = $first !== null ? $this->identifierName($first) : null;
+        if ($first === null || $name === null) {
+            return null;
+        }
+
+        $start = $first->offset;
+        $end = $first->endOffset();
+        $index++;
+        while ($this->isSymbol($tokens[$index] ?? null, '.')) {
+            $component = $tokens[$index + 1] ?? null;
+            $componentName = $component !== null ? $this->identifierName($component) : null;
+            if ($component === null || $componentName === null) {
+                return null;
+            }
+            $name = $componentName;
+            $end = $component->endOffset();
+            $index += 2;
+        }
+
+        return [
+            'name' => $name,
+            'sql' => substr($sql, $start, $end - $start),
+            'next' => $index,
+        ];
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function targetAlias(
+        string $sql,
+        array $tokens,
+        int $start,
+        int $end,
+        string $default,
+    ): string {
+        if ($start === $end) {
+            return $default;
+        }
+        if (($tokens[$start] ?? null)?->isKeyword('AS') === true) {
+            $start++;
+        }
+        if ($start + 1 !== $end) {
+            throw new UnsupportedSqlException($sql, 'Malformed MERGE target alias');
+        }
+        $alias = $this->identifierName($tokens[$start]);
+        if ($alias === null) {
+            throw new UnsupportedSqlException($sql, 'Malformed MERGE target alias');
+        }
+
+        return $alias;
+    }
+
+    private function parseClause(string $originalSql, string $clauseSql): PgSqlMergeClause
+    {
+        $clauseSql = rtrim($clauseSql, "; \t\n\r\0\x0B");
+        $tokens = SqlTokenStream::tokenize($clauseSql)->significantTokens();
+        $index = 1;
+        $matchKind = PgSqlMergeMatchKind::Matched;
+        if (($tokens[$index] ?? null)?->isKeyword('NOT') === true) {
+            $matchKind = PgSqlMergeMatchKind::NotMatched;
+            $index++;
+        }
+        if (($tokens[$index] ?? null)?->isKeyword('MATCHED') !== true) {
+            throw new UnsupportedSqlException($originalSql, 'Malformed MERGE WHEN clause');
+        }
+        $index++;
+        if (($tokens[$index] ?? null)?->isKeyword('BY') === true) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE BY SOURCE and BY TARGET are not supported');
+        }
+
+        $thenIndex = $this->keywordIndexOutsideCase($tokens, 'THEN', $index);
+        if ($thenIndex === null) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE WHEN clause requires THEN');
+        }
+        $conditionSql = null;
+        if ($index !== $thenIndex) {
+            if (($tokens[$index] ?? null)?->isKeyword('AND') !== true) {
+                throw new UnsupportedSqlException($originalSql, 'Malformed MERGE WHEN condition');
+            }
+            $conditionSql = trim(substr(
+                $clauseSql,
+                $tokens[$index]->endOffset(),
+                $tokens[$thenIndex]->offset - $tokens[$index]->endOffset(),
+            ));
+            if ($conditionSql === '') {
+                throw new UnsupportedSqlException($originalSql, 'MERGE WHEN condition cannot be empty');
+            }
+        }
+
+        $actionSql = trim(substr($clauseSql, $tokens[$thenIndex]->endOffset()));
+        $actionTokens = SqlTokenStream::tokenize($actionSql)->significantTokens();
+        $first = $actionTokens[0] ?? null;
+        if ($first?->isKeyword('DO') === true
+            && ($actionTokens[1] ?? null)?->isKeyword('NOTHING') === true
+            && count($actionTokens) === 2
+        ) {
+            return new PgSqlMergeClause($matchKind, $conditionSql, PgSqlMergeActionKind::DoNothing);
+        }
+        if ($matchKind === PgSqlMergeMatchKind::Matched && $first?->isKeyword('DELETE') === true && count($actionTokens) === 1) {
+            return new PgSqlMergeClause($matchKind, $conditionSql, PgSqlMergeActionKind::Delete);
+        }
+        if ($matchKind === PgSqlMergeMatchKind::Matched && $first?->isKeyword('UPDATE') === true) {
+            return new PgSqlMergeClause(
+                $matchKind,
+                $conditionSql,
+                PgSqlMergeActionKind::Update,
+                $this->parseAssignments($originalSql, $actionSql, $actionTokens),
+            );
+        }
+        if ($matchKind === PgSqlMergeMatchKind::NotMatched && $first?->isKeyword('INSERT') === true) {
+            $insert = $this->parseInsert($originalSql, $actionSql, $actionTokens);
+
+            return new PgSqlMergeClause(
+                $matchKind,
+                $conditionSql,
+                PgSqlMergeActionKind::Insert,
+                [],
+                $insert['columns'],
+                $insert['values'],
+            );
+        }
+
+        throw new UnsupportedSqlException($originalSql, 'MERGE action is not supported');
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array<string, string>
+     */
+    private function parseAssignments(string $originalSql, string $actionSql, array $tokens): array
+    {
+        if (($tokens[1] ?? null)?->isKeyword('SET') !== true) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE requires SET');
+        }
+        $setSql = trim(substr($actionSql, $tokens[1]->endOffset()));
+        $assignments = [];
+        foreach (SqlTokenStream::tokenize($setSql)->splitTopLevel() as $assignmentSql) {
+            $assignmentTokens = SqlTokenStream::tokenize($assignmentSql)->significantTokens();
+            $equals = [];
+            foreach ($assignmentTokens as $assignmentIndex => $token) {
+                if ($this->isSymbol($token, '=') && $token->isTopLevel()) {
+                    $equals[] = $assignmentIndex;
+                }
+            }
+            if (count($equals) !== 1) {
+                throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE requires simple column assignments');
+            }
+            $equalsIndex = $equals[0];
+            if ($equalsIndex !== 1 || count($assignmentTokens) < 3) {
+                throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE requires simple column assignments');
+            }
+            $column = $this->identifierName($assignmentTokens[0]);
+            if ($column === null) {
+                throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE target must be a column');
+            }
+            $value = trim(substr($assignmentSql, $assignmentTokens[$equalsIndex]->endOffset()));
+            if ($value === '') {
+                throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE value cannot be empty');
+            }
+            if (array_key_exists($column, $assignments)) {
+                throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE cannot assign a column more than once');
+            }
+            $assignments[$column] = $value;
+        }
+        if ($assignments === []) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE UPDATE requires assignments');
+        }
+
+        return $assignments;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{columns: list<string>, values: list<string>}
+     */
+    private function parseInsert(string $originalSql, string $actionSql, array $tokens): array
+    {
+        $index = 1;
+        $columns = [];
+        if ($this->isSymbol($tokens[$index] ?? null, '(')) {
+            $list = $this->parenthesizedList($originalSql, $actionSql, $tokens, $index);
+            foreach ($list['items'] as $columnSql) {
+                $columnTokens = SqlTokenStream::tokenize($columnSql)->significantTokens();
+                $column = count($columnTokens) === 1 ? $this->identifierName($columnTokens[0]) : null;
+                if ($column === null) {
+                    throw new UnsupportedSqlException($originalSql, 'MERGE INSERT columns must be identifiers');
+                }
+                if (in_array($column, $columns, true)) {
+                    throw new UnsupportedSqlException($originalSql, 'MERGE INSERT cannot name a column more than once');
+                }
+                $columns[] = $column;
+            }
+            $index = $list['next'];
+        }
+
+        if (($tokens[$index] ?? null)?->isKeyword('DEFAULT') === true
+            && ($tokens[$index + 1] ?? null)?->isKeyword('VALUES') === true
+            && $index + 2 === count($tokens)
+        ) {
+            if ($columns !== []) {
+                throw new UnsupportedSqlException($originalSql, 'MERGE INSERT DEFAULT VALUES cannot name columns');
+            }
+
+            return ['columns' => [], 'values' => []];
+        }
+        if (($tokens[$index] ?? null)?->isKeyword('VALUES') !== true
+            || !$this->isSymbol($tokens[$index + 1] ?? null, '(')
+        ) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE INSERT requires VALUES');
+        }
+
+        $values = $this->parenthesizedList($originalSql, $actionSql, $tokens, $index + 1);
+        if ($values['next'] !== count($tokens)) {
+            throw new UnsupportedSqlException($originalSql, 'Malformed MERGE INSERT values');
+        }
+        if ($columns !== [] && count($columns) !== count($values['items'])) {
+            throw new UnsupportedSqlException($originalSql, 'MERGE INSERT values count does not match column count');
+        }
+
+        return ['columns' => $columns, 'values' => $values['items']];
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return array{items: list<string>, next: int}
+     */
+    private function parenthesizedList(
+        string $originalSql,
+        string $sql,
+        array $tokens,
+        int $openIndex,
+    ): array {
+        $open = $tokens[$openIndex];
+        foreach ($tokens as $closeIndex => $token) {
+            if ($closeIndex <= $openIndex
+                || !$this->isSymbol($token, ')')
+                || $token->depth !== $open->depth
+            ) {
+                continue;
+            }
+            $listSql = trim(substr($sql, $open->endOffset(), $token->offset - $open->endOffset()));
+            $items = $listSql === '' ? [] : SqlTokenStream::tokenize($listSql)->splitTopLevel();
+
+            return ['items' => $items, 'next' => $closeIndex + 1];
+        }
+
+        throw new UnsupportedSqlException($originalSql, 'Malformed MERGE parenthesized list');
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function keywordIndex(array $tokens, string $keyword, int $start): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if ($index >= $start && $token->isTopLevel() && $token->isKeyword($keyword)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function lastKeywordIndex(array $tokens, string $keyword, int $start, int $end): ?int
+    {
+        $found = null;
+        foreach ($tokens as $index => $token) {
+            if ($index >= $end) {
+                break;
+            }
+            if ($index >= $start && $token->isTopLevel() && $token->isKeyword($keyword)) {
+                $found = $index;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     * @return list<int>
+     */
+    private function mergeWhenIndices(array $tokens, int $start): array
+    {
+        $indices = [];
+        $caseDepth = 0;
+        foreach ($tokens as $index => $token) {
+            if ($index < $start || !$token->isTopLevel()) {
+                continue;
+            }
+            if ($token->isKeyword('CASE')) {
+                $caseDepth++;
+                continue;
+            }
+            if ($token->isKeyword('END') && $caseDepth > 0) {
+                $caseDepth--;
+                continue;
+            }
+            if ($caseDepth !== 0 || !$token->isKeyword('WHEN')) {
+                continue;
+            }
+            $next = $tokens[$index + 1] ?? null;
+            $afterNext = $tokens[$index + 2] ?? null;
+            if ($next?->isKeyword('MATCHED') === true
+                || ($next?->isKeyword('NOT') === true && $afterNext?->isKeyword('MATCHED') === true)
+            ) {
+                $indices[] = $index;
+            }
+        }
+
+        return $indices;
+    }
+
+    /** @param list<SqlToken> $tokens */
+    private function keywordIndexOutsideCase(array $tokens, string $keyword, int $start): ?int
+    {
+        $caseDepth = 0;
+        foreach ($tokens as $index => $token) {
+            if ($index < $start || !$token->isTopLevel()) {
+                continue;
+            }
+            if ($token->isKeyword('CASE')) {
+                $caseDepth++;
+                continue;
+            }
+            if ($token->isKeyword('END') && $caseDepth > 0) {
+                $caseDepth--;
+                continue;
+            }
+            if ($caseDepth === 0 && $token->isKeyword($keyword)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private function identifierName(SqlToken $token): ?string
+    {
+        if ($token->kind === SqlTokenKind::Word) {
+            return strtolower($token->text);
+        }
+        if ($token->kind !== SqlTokenKind::QuotedIdentifier || strlen($token->text) <= 2) {
+            return null;
+        }
+
+        return str_replace('""', '"', substr($token->text, 1, -1));
+    }
+
+    private function isSymbol(?SqlToken $token, string $symbol): bool
+    {
+        return $token instanceof SqlToken
+            && $token->kind === SqlTokenKind::Symbol
+            && $token->text === $symbol;
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlMergeStatement.php
+++ b/packages/ztd-query-postgres/src/PgSqlMergeStatement.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+final class PgSqlMergeStatement
+{
+    /** @param non-empty-list<PgSqlMergeClause> $clauses */
+    public function __construct(
+        public readonly string $targetTable,
+        public readonly string $targetSql,
+        public readonly string $targetAlias,
+        public readonly string $sourceSql,
+        public readonly string $joinConditionSql,
+        public readonly array $clauses,
+    ) {
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -17,6 +17,7 @@ use ZtdQuery\Shadow\Mutation\DropTableMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
 use ZtdQuery\Shadow\Mutation\ShadowMutation;
+use ZtdQuery\Shadow\Mutation\SynchronizeMutation;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
@@ -59,6 +60,7 @@ final class PgSqlMutationResolver
             'INSERT' => $this->resolveInsert($sql),
             'UPDATE' => $this->resolveUpdate($sql),
             'DELETE' => $this->resolveDelete($sql),
+            'MERGE' => $this->resolveMerge($sql),
             'TRUNCATE' => $this->resolveTruncate($sql),
             'CREATE_TABLE' => $this->resolveCreateTable($sql),
             'DROP_TABLE' => $this->resolveDropTable($sql),
@@ -163,6 +165,23 @@ final class PgSqlMutationResolver
         $primaryKeys = $definition !== null ? $definition->primaryKeys : [];
 
         return new DeleteMutation($storageTable, $primaryKeys);
+    }
+
+    private function resolveMerge(string $sql): ShadowMutation
+    {
+        $statement = (new PgSqlMergeParser())->parse($sql);
+        $definition = $this->registry->get($statement->targetTable);
+        if ($definition === null
+            && $this->shadowStore->state($statement->targetTable) !== ShadowTableState::Initialized
+        ) {
+            throw new UnknownSchemaException($sql, $statement->targetTable, 'table');
+        }
+
+        return new SynchronizeMutation(
+            $this->storageTable($statement->targetTable),
+            $definition,
+            $sql,
+        );
     }
 
     private function resolveTruncate(string $sql): ShadowMutation

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -535,7 +535,7 @@ final class PgSqlParser
         return (new PgSqlSelectRelationParser())->tableNames($sql);
     }
 
-    /** @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|null */
+    /** @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|'MERGE'|null */
     private function classifyWithStatement(string $sql): ?string
     {
         $stripped = $this->stripStringLiterals($sql);
@@ -607,7 +607,7 @@ final class PgSqlParser
         return null;
     }
 
-    /** @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|'TRUNCATE'|'CREATE_TABLE'|'DROP_TABLE'|'ALTER_TABLE'|'DO'|'TCL'|null */
+    /** @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|'MERGE'|'TRUNCATE'|'CREATE_TABLE'|'DROP_TABLE'|'ALTER_TABLE'|'DO'|'TCL'|null */
     private function classifySimpleStatement(string $sql): ?string
     {
         $trimmed = ltrim($sql);

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -21,7 +21,7 @@ final class PgSqlParser
     /**
      * Classify a SQL statement type.
      *
-     * @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|'TRUNCATE'|'CREATE_TABLE'|'DROP_TABLE'|'ALTER_TABLE'|'DO'|'TCL'|null
+     * @return 'SELECT'|'INSERT'|'UPDATE'|'DELETE'|'MERGE'|'TRUNCATE'|'CREATE_TABLE'|'DROP_TABLE'|'ALTER_TABLE'|'DO'|'TCL'|null
      */
     public function classifyStatement(string $sql): ?string
     {
@@ -593,6 +593,7 @@ final class PgSqlParser
                 'INSERT' => 'INSERT',
                 'UPDATE' => 'UPDATE',
                 'DELETE' => 'DELETE',
+                'MERGE' => 'MERGE',
                 default => null,
             };
 
@@ -622,6 +623,9 @@ final class PgSqlParser
         }
         if (preg_match('/^DELETE\b/i', $trimmed) === 1) {
             return 'DELETE';
+        }
+        if (preg_match('/^MERGE\b/i', $trimmed) === 1) {
+            return 'MERGE';
         }
         if (preg_match('/^TRUNCATE\b/i', $trimmed) === 1) {
             return 'TRUNCATE';

--- a/packages/ztd-query-postgres/src/PgSqlQueryGuard.php
+++ b/packages/ztd-query-postgres/src/PgSqlQueryGuard.php
@@ -34,7 +34,7 @@ final class PgSqlQueryGuard
         return match ($type) {
             'SELECT' => QueryKind::READ,
             'DO' => QueryKind::READ,
-            'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE' => QueryKind::WRITE_SIMULATED,
+            'INSERT', 'UPDATE', 'DELETE', 'MERGE', 'TRUNCATE' => QueryKind::WRITE_SIMULATED,
             'CREATE_TABLE', 'DROP_TABLE', 'ALTER_TABLE' => QueryKind::DDL_SIMULATED,
             'TCL' => QueryKind::SKIPPED,
         };

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -185,7 +185,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             QueryKind::WRITE_SIMULATED,
             $mutation,
             $this->returningProjectionParser->parse($sql),
-            AffectedRowsMode::Matched,
+            $statementType === 'MERGE' ? AffectedRowsMode::Changed : AffectedRowsMode::Matched,
         );
     }
 

--- a/packages/ztd-query-postgres/src/PgSqlTransformer.php
+++ b/packages/ztd-query-postgres/src/PgSqlTransformer.php
@@ -7,6 +7,7 @@ namespace ZtdQuery\Platform\Postgres;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\InsertTransformer;
+use ZtdQuery\Platform\Postgres\Transformer\MergeTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 use ZtdQuery\Rewrite\SqlTransformer;
@@ -24,6 +25,7 @@ final class PgSqlTransformer implements SqlTransformer
     private InsertTransformer $insertTransformer;
     private UpdateTransformer $updateTransformer;
     private DeleteTransformer $deleteTransformer;
+    private ?MergeTransformer $mergeTransformer = null;
 
     public function __construct(
         PgSqlParser $parser,
@@ -51,6 +53,7 @@ final class PgSqlTransformer implements SqlTransformer
             'INSERT' => $this->insertTransformer->transform($sql, $tables),
             'UPDATE' => $this->updateTransformer->transform($sql, $tables),
             'DELETE' => $this->deleteTransformer->transform($sql, $tables),
+            'MERGE' => $this->mergeTransformer()->transform($sql, $tables),
             default => throw new UnsupportedSqlException($sql, 'Statement type not supported by transformer'),
         };
     }
@@ -58,5 +61,15 @@ final class PgSqlTransformer implements SqlTransformer
     public function commitRewriteState(): void
     {
         $this->insertTransformer->commitRewriteState();
+        $this->mergeTransformer?->commitRewriteState();
+    }
+
+    private function mergeTransformer(): MergeTransformer
+    {
+        if ($this->mergeTransformer === null) {
+            $this->mergeTransformer = new MergeTransformer(new PgSqlMergeParser(), $this->selectTransformer);
+        }
+
+        return $this->mergeTransformer;
     }
 }

--- a/packages/ztd-query-postgres/src/PgSqlTransformer.php
+++ b/packages/ztd-query-postgres/src/PgSqlTransformer.php
@@ -61,7 +61,6 @@ final class PgSqlTransformer implements SqlTransformer
     public function commitRewriteState(): void
     {
         $this->insertTransformer->commitRewriteState();
-        $this->mergeTransformer?->commitRewriteState();
     }
 
     private function mergeTransformer(): MergeTransformer

--- a/packages/ztd-query-postgres/src/Transformer/InsertSelectRenderer.php
+++ b/packages/ztd-query-postgres/src/Transformer/InsertSelectRenderer.php
@@ -43,7 +43,7 @@ final class InsertSelectRenderer
             if ($sourceIndex !== null) {
                 $expression = $this->quoter->quote('__ztd_insert_' . $sourceIndex);
             } elseif ($generatedIdentityStart !== null) {
-                $expression = $generatedIdentityStart . ' + ROW_NUMBER() OVER () - 1';
+                $expression = $this->renderGeneratedIdentity($generatedIdentityStart);
             } else {
                 $expression = $projection->defaultExpressionValue() ?? 'NULL';
             }
@@ -54,5 +54,14 @@ final class InsertSelectRenderer
 
         return 'WITH ' . $sourceName . ' (' . implode(', ', $sourceColumns) . ') AS ('
             . $selectSql . ') SELECT ' . implode(', ', $selects) . ' FROM ' . $sourceName;
+    }
+
+    public function renderGeneratedIdentity(int $start): string
+    {
+        if ($start < 1) {
+            throw new \InvalidArgumentException('Generated identity start must be positive.');
+        }
+
+        return $start . ' + ROW_NUMBER() OVER () - 1';
     }
 }

--- a/packages/ztd-query-postgres/src/Transformer/MergeTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/MergeTransformer.php
@@ -6,32 +6,33 @@ namespace ZtdQuery\Platform\Postgres\Transformer;
 
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
+use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
+use ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector;
 use ZtdQuery\Platform\Postgres\PgSqlMergeActionKind;
 use ZtdQuery\Platform\Postgres\PgSqlMergeClause;
 use ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind;
 use ZtdQuery\Platform\Postgres\PgSqlMergeParser;
 use ZtdQuery\Platform\Postgres\PgSqlMergeStatement;
-use ZtdQuery\Rewrite\CteShadowComposer;
-use ZtdQuery\Rewrite\GeneratedColumnProjector;
-use ZtdQuery\Rewrite\InsertRowProjector;
 use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
 
 final class MergeTransformer implements SqlTransformer
 {
     private PgSqlIdentifierQuoter $quoter;
-    private InsertRowProjector $rowProjector;
-    private GeneratedColumnProjector $generatedColumnProjector;
-    private CteShadowComposer $cteComposer;
+    private InsertRowRenderer $rowRenderer;
+    private PgSqlGeneratedColumnProjector $generatedColumnProjector;
+    private PgSqlCteShadowComposer $cteComposer;
+    private InsertSelectRenderer $insertSelectRenderer;
 
     public function __construct(
         private readonly PgSqlMergeParser $parser,
         private readonly SelectTransformer $selectTransformer,
     ) {
         $this->quoter = new PgSqlIdentifierQuoter();
-        $this->rowProjector = new InsertRowProjector();
-        $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
-        $this->cteComposer = new CteShadowComposer();
+        $this->rowRenderer = new InsertRowRenderer();
+        $this->generatedColumnProjector = new PgSqlGeneratedColumnProjector();
+        $this->cteComposer = new PgSqlCteShadowComposer();
+        $this->insertSelectRenderer = new InsertSelectRenderer();
     }
 
     /**
@@ -228,24 +229,21 @@ final class MergeTransformer implements SqlTransformer
             }
         }
 
-        $generatedValues = (new ShadowIdentityAllocator())->allocateSelectExpressionsForValues(
-            $statement->targetTable,
-            $identityStrategies,
-            $sourceColumns,
-            $clause->insertValues,
-            $existingRows,
-        );
         try {
-            $projected = $this->rowProjector->project(
-                $columns,
-                $sourceColumns,
-                $clause->insertValues,
-                $defaults,
-                $generatedValues,
-            );
+            $providedExpressions = $this->rowRenderer->providedExpressions($sourceColumns, $clause->insertValues);
         } catch (\InvalidArgumentException) {
             throw new UnsupportedSqlException($sql, 'MERGE INSERT values count does not match column count');
         }
+        $generatedStarts = (new ShadowIdentityAllocator())->allocateSelectStarts(
+            $statement->targetTable,
+            $identityStrategies,
+            array_keys($providedExpressions),
+            $existingRows,
+        );
+        foreach ($generatedStarts as $column => $start) {
+            $providedExpressions[$column] = $this->insertSelectRenderer->renderGeneratedIdentity($start);
+        }
+        $projected = $this->rowRenderer->render($columns, $providedExpressions, $defaults);
 
         $selects = [];
         foreach ($projected as $column => $expression) {

--- a/packages/ztd-query-postgres/src/Transformer/MergeTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/MergeTransformer.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres\Transformer;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
+use ZtdQuery\Platform\Postgres\PgSqlMergeActionKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeClause;
+use ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeParser;
+use ZtdQuery\Platform\Postgres\PgSqlMergeStatement;
+use ZtdQuery\Rewrite\CteShadowComposer;
+use ZtdQuery\Rewrite\GeneratedColumnProjector;
+use ZtdQuery\Rewrite\InsertRowProjector;
+use ZtdQuery\Rewrite\ShadowIdentityAllocator;
+use ZtdQuery\Rewrite\SqlTransformer;
+
+final class MergeTransformer implements SqlTransformer
+{
+    private PgSqlIdentifierQuoter $quoter;
+    private InsertRowProjector $rowProjector;
+    private ShadowIdentityAllocator $identityAllocator;
+    private GeneratedColumnProjector $generatedColumnProjector;
+    private CteShadowComposer $cteComposer;
+
+    public function __construct(
+        private readonly PgSqlMergeParser $parser,
+        private readonly SelectTransformer $selectTransformer,
+    ) {
+        $this->quoter = new PgSqlIdentifierQuoter();
+        $this->rowProjector = new InsertRowProjector();
+        $this->identityAllocator = new ShadowIdentityAllocator();
+        $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
+        $this->cteComposer = new CteShadowComposer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function transform(string $sql, array $tables): string
+    {
+        $this->identityAllocator->beginProjection();
+        $statement = $this->parser->parse($sql);
+        $table = $tables[$statement->targetTable] ?? null;
+        if ($table === null || isset($table['viewSql'])) {
+            throw new UnsupportedSqlException($sql, 'Cannot resolve MERGE target schema');
+        }
+
+        $columns = self::orderedValues($table['columns']);
+        if ($columns === []) {
+            throw new UnsupportedSqlException($sql, 'Cannot determine MERGE target columns');
+        }
+        if (($table['storageTable'] ?? $statement->targetTable) !== $statement->targetTable) {
+            throw new UnsupportedSqlException($sql, 'MERGE into a child partition is not supported');
+        }
+
+        $defaults = $table['columnDefaults'] ?? [];
+        $identityStrategies = $table['identityStrategies'] ?? [];
+        $existingRows = $table['rows'];
+        $generatedExpressions = $table['generatedExpressions'] ?? [];
+        $effectiveConditions = $this->effectiveConditions($statement);
+        $parts = [];
+        $parts[] = $this->unchangedRows($statement, $columns, $effectiveConditions);
+
+        foreach ($statement->clauses as $index => $clause) {
+            $effective = $effectiveConditions[$index];
+            if ($clause->actionKind === PgSqlMergeActionKind::Update) {
+                $parts[] = $this->updatedRows($sql, $statement, $clause, $columns, $defaults, $effective);
+            }
+            if ($clause->actionKind === PgSqlMergeActionKind::Insert) {
+                $parts[] = $this->insertedRows(
+                    $sql,
+                    $statement,
+                    $clause,
+                    $columns,
+                    $defaults,
+                    $identityStrategies,
+                    $existingRows,
+                    $effective,
+                );
+            }
+        }
+
+        $resultSql = implode(' UNION ALL ', $parts);
+        $resultSql = $this->generatedColumnProjector->project($resultSql, $columns, $generatedExpressions);
+        $resultSql = $this->cteComposer->carryPrefix($sql, $resultSql);
+
+        return $this->selectTransformer->transform($resultSql, $tables);
+    }
+
+    public function commitRewriteState(): void
+    {
+        $this->identityAllocator->commitProjection();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function effectiveConditions(PgSqlMergeStatement $statement): array
+    {
+        $priorMatched = [];
+        $priorNotMatched = [];
+        $effective = [];
+        foreach ($statement->clauses as $clause) {
+            $prior = $clause->matchKind === PgSqlMergeMatchKind::Matched
+                ? $priorMatched
+                : $priorNotMatched;
+            $condition = $clause->conditionSql ?? 'TRUE';
+            $predicate = '(' . $condition . ')';
+            if ($prior !== []) {
+                $excluded = array_map(
+                    static fn (string $previous): string => 'COALESCE((' . $previous . '), FALSE)',
+                    $prior,
+                );
+                $predicate .= ' AND NOT (' . implode(' OR ', $excluded) . ')';
+            }
+            $effective[] = $predicate;
+            if ($clause->matchKind === PgSqlMergeMatchKind::Matched) {
+                $priorMatched[] = $condition;
+            } else {
+                $priorNotMatched[] = $condition;
+            }
+        }
+
+        return $effective;
+    }
+
+    /**
+     * @param list<string> $columns
+     * @param list<string> $effectiveConditions
+     */
+    private function unchangedRows(
+        PgSqlMergeStatement $statement,
+        array $columns,
+        array $effectiveConditions,
+    ): string {
+        $qualifier = $this->quoter->quote($statement->targetAlias);
+        $selects = [];
+        foreach ($columns as $column) {
+            $quoted = $this->quoter->quote($column);
+            $selects[] = $qualifier . '.' . $quoted . ' AS ' . $quoted;
+        }
+
+        $modifications = [];
+        foreach ($statement->clauses as $index => $clause) {
+            if ($clause->matchKind !== PgSqlMergeMatchKind::Matched
+                || !in_array($clause->actionKind, [PgSqlMergeActionKind::Update, PgSqlMergeActionKind::Delete], true)
+            ) {
+                continue;
+            }
+            $modifications[] = 'EXISTS (SELECT 1 FROM ' . $statement->sourceSql
+                . ' WHERE (' . $statement->joinConditionSql . ') AND (' . $effectiveConditions[$index] . '))';
+        }
+
+        $sql = 'SELECT ' . implode(', ', $selects)
+            . ' FROM ' . $statement->targetSql . ' AS ' . $qualifier;
+        if ($modifications !== []) {
+            $sql .= ' WHERE NOT (' . implode(' OR ', $modifications) . ')';
+        }
+
+        return $sql;
+    }
+
+    /**
+     * @param list<string> $columns
+     * @param array<string, string> $defaults
+     */
+    private function updatedRows(
+        string $sql,
+        PgSqlMergeStatement $statement,
+        PgSqlMergeClause $clause,
+        array $columns,
+        array $defaults,
+        string $effectiveCondition,
+    ): string {
+        foreach (array_keys($clause->assignments) as $column) {
+            if (!in_array($column, $columns, true)) {
+                throw new UnsupportedSqlException($sql, 'MERGE UPDATE references an unknown target column');
+            }
+        }
+
+        $qualifier = $this->quoter->quote($statement->targetAlias);
+        $selects = [];
+        foreach ($columns as $column) {
+            $quoted = $this->quoter->quote($column);
+            $expression = $clause->assignments[$column] ?? null;
+            if ($expression === null) {
+                $expression = $qualifier . '.' . $quoted;
+            } elseif (strcasecmp(trim($expression), 'DEFAULT') === 0) {
+                $expression = $defaults[$column] ?? 'NULL';
+            }
+            $selects[] = $expression . ' AS ' . $quoted;
+        }
+
+        return 'SELECT ' . implode(', ', $selects)
+            . ' FROM ' . $statement->targetSql . ' AS ' . $qualifier
+            . ' JOIN ' . $statement->sourceSql
+            . ' ON (' . $statement->joinConditionSql . ')'
+            . ' WHERE ' . $effectiveCondition;
+    }
+
+    /**
+     * @param list<string> $columns
+     * @param array<string, string> $defaults
+     * @param array<string, \ZtdQuery\Schema\IdentityGenerationStrategy> $identityStrategies
+     * @param array<int, array<string, mixed>> $existingRows
+     */
+    private function insertedRows(
+        string $sql,
+        PgSqlMergeStatement $statement,
+        PgSqlMergeClause $clause,
+        array $columns,
+        array $defaults,
+        array $identityStrategies,
+        array $existingRows,
+        string $effectiveCondition,
+    ): string {
+        $sourceColumns = $clause->insertColumns !== [] || $clause->insertValues === []
+            ? $clause->insertColumns
+            : $columns;
+        foreach ($sourceColumns as $column) {
+            if (!in_array($column, $columns, true)) {
+                throw new UnsupportedSqlException($sql, 'MERGE INSERT references an unknown target column');
+            }
+        }
+
+        $providedIdentityColumns = [];
+        foreach ($sourceColumns as $index => $column) {
+            $value = $clause->insertValues[$index] ?? 'DEFAULT';
+            if (strcasecmp(trim($value), 'DEFAULT') !== 0) {
+                $providedIdentityColumns[] = $column;
+            }
+        }
+        $generatedValues = $this->identityAllocator->allocateSelectExpressions(
+            $statement->targetTable,
+            $identityStrategies,
+            $providedIdentityColumns,
+            $existingRows,
+        );
+        try {
+            $projected = $this->rowProjector->project(
+                $columns,
+                $sourceColumns,
+                $clause->insertValues,
+                $defaults,
+                $generatedValues,
+            );
+        } catch (\InvalidArgumentException) {
+            throw new UnsupportedSqlException($sql, 'MERGE INSERT values count does not match column count');
+        }
+
+        $selects = [];
+        foreach ($projected as $column => $expression) {
+            $selects[] = $expression . ' AS ' . $this->quoter->quote($column);
+        }
+        $targetAlias = $this->quoter->quote($statement->targetAlias);
+
+        return 'SELECT ' . implode(', ', $selects)
+            . ' FROM ' . $statement->sourceSql
+            . ' WHERE NOT EXISTS (SELECT 1 FROM ' . $statement->targetSql . ' AS ' . $targetAlias
+            . ' WHERE ' . $statement->joinConditionSql . ')'
+            . ' AND (' . $effectiveCondition . ')';
+    }
+
+    /**
+     * @template T
+     * @param array<array-key, T> $values
+     * @return list<T>
+     */
+    private static function orderedValues(array $values): array
+    {
+        return array_values($values);
+    }
+}

--- a/packages/ztd-query-postgres/src/Transformer/MergeTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/MergeTransformer.php
@@ -21,7 +21,6 @@ final class MergeTransformer implements SqlTransformer
 {
     private PgSqlIdentifierQuoter $quoter;
     private InsertRowProjector $rowProjector;
-    private ShadowIdentityAllocator $identityAllocator;
     private GeneratedColumnProjector $generatedColumnProjector;
     private CteShadowComposer $cteComposer;
 
@@ -31,7 +30,6 @@ final class MergeTransformer implements SqlTransformer
     ) {
         $this->quoter = new PgSqlIdentifierQuoter();
         $this->rowProjector = new InsertRowProjector();
-        $this->identityAllocator = new ShadowIdentityAllocator();
         $this->generatedColumnProjector = new GeneratedColumnProjector($this->quoter);
         $this->cteComposer = new CteShadowComposer();
     }
@@ -41,14 +39,19 @@ final class MergeTransformer implements SqlTransformer
      */
     public function transform(string $sql, array $tables): string
     {
-        $this->identityAllocator->beginProjection();
         $statement = $this->parser->parse($sql);
         $table = $tables[$statement->targetTable] ?? null;
-        if ($table === null || isset($table['viewSql'])) {
+        if ($table === null) {
+            throw new UnsupportedSqlException($sql, 'Cannot resolve MERGE target schema');
+        }
+        if (isset($table['viewSql'])) {
             throw new UnsupportedSqlException($sql, 'Cannot resolve MERGE target schema');
         }
 
-        $columns = self::orderedValues($table['columns']);
+        $columns = $table['columns'];
+        if (!array_is_list($columns)) {
+            throw new UnsupportedSqlException($sql, 'MERGE target columns must preserve declaration order');
+        }
         if ($columns === []) {
             throw new UnsupportedSqlException($sql, 'Cannot determine MERGE target columns');
         }
@@ -88,11 +91,6 @@ final class MergeTransformer implements SqlTransformer
         $resultSql = $this->cteComposer->carryPrefix($sql, $resultSql);
 
         return $this->selectTransformer->transform($resultSql, $tables);
-    }
-
-    public function commitRewriteState(): void
-    {
-        $this->identityAllocator->commitProjection();
     }
 
     /**
@@ -188,7 +186,7 @@ final class MergeTransformer implements SqlTransformer
             $expression = $clause->assignments[$column] ?? null;
             if ($expression === null) {
                 $expression = $qualifier . '.' . $quoted;
-            } elseif (strcasecmp(trim($expression), 'DEFAULT') === 0) {
+            } elseif (strcasecmp($expression, 'DEFAULT') === 0) {
                 $expression = $defaults[$column] ?? 'NULL';
             }
             $selects[] = $expression . ' AS ' . $quoted;
@@ -217,26 +215,24 @@ final class MergeTransformer implements SqlTransformer
         array $existingRows,
         string $effectiveCondition,
     ): string {
-        $sourceColumns = $clause->insertColumns !== [] || $clause->insertValues === []
-            ? $clause->insertColumns
-            : $columns;
+        if ($clause->insertColumns !== []) {
+            $sourceColumns = $clause->insertColumns;
+        } elseif ($clause->insertValues === []) {
+            $sourceColumns = [];
+        } else {
+            $sourceColumns = $columns;
+        }
         foreach ($sourceColumns as $column) {
             if (!in_array($column, $columns, true)) {
                 throw new UnsupportedSqlException($sql, 'MERGE INSERT references an unknown target column');
             }
         }
 
-        $providedIdentityColumns = [];
-        foreach ($sourceColumns as $index => $column) {
-            $value = $clause->insertValues[$index] ?? 'DEFAULT';
-            if (strcasecmp(trim($value), 'DEFAULT') !== 0) {
-                $providedIdentityColumns[] = $column;
-            }
-        }
-        $generatedValues = $this->identityAllocator->allocateSelectExpressions(
+        $generatedValues = (new ShadowIdentityAllocator())->allocateSelectExpressionsForValues(
             $statement->targetTable,
             $identityStrategies,
-            $providedIdentityColumns,
+            $sourceColumns,
+            $clause->insertValues,
             $existingRows,
         );
         try {
@@ -264,13 +260,4 @@ final class MergeTransformer implements SqlTransformer
             . ' AND (' . $effectiveCondition . ')';
     }
 
-    /**
-     * @template T
-     * @param array<array-key, T> $values
-     * @return list<T>
-     */
-    private static function orderedValues(array $values): array
-    {
-        return array_values($values);
-    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMergeActionKindTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMergeActionKindTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlMergeActionKind;
+
+#[CoversClass(PgSqlMergeActionKind::class)]
+final class PgSqlMergeActionKindTest extends TestCase
+{
+    public function testCasesPreservePostgreSqlKeywords(): void
+    {
+        self::assertSame('UPDATE', PgSqlMergeActionKind::Update->value);
+        self::assertSame('INSERT', PgSqlMergeActionKind::Insert->value);
+        self::assertSame('DELETE', PgSqlMergeActionKind::Delete->value);
+        self::assertSame('DO NOTHING', PgSqlMergeActionKind::DoNothing->value);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMergeClauseTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMergeClauseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlMergeActionKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeClause;
+use ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind;
+
+#[CoversClass(PgSqlMergeClause::class)]
+#[UsesClass(PgSqlMergeActionKind::class)]
+#[UsesClass(PgSqlMergeMatchKind::class)]
+final class PgSqlMergeClauseTest extends TestCase
+{
+    public function testCarriesTypedClauseData(): void
+    {
+        $clause = new PgSqlMergeClause(
+            PgSqlMergeMatchKind::Matched,
+            'source.enabled',
+            PgSqlMergeActionKind::Update,
+            ['name' => 'source.name'],
+        );
+
+        self::assertSame(PgSqlMergeMatchKind::Matched, $clause->matchKind);
+        self::assertSame('source.enabled', $clause->conditionSql);
+        self::assertSame(PgSqlMergeActionKind::Update, $clause->actionKind);
+        self::assertSame(['name' => 'source.name'], $clause->assignments);
+        self::assertSame([], $clause->insertColumns);
+        self::assertSame([], $clause->insertValues);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMergeMatchKindTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMergeMatchKindTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind;
+
+#[CoversClass(PgSqlMergeMatchKind::class)]
+final class PgSqlMergeMatchKindTest extends TestCase
+{
+    public function testCasesPreservePostgreSqlKeywords(): void
+    {
+        self::assertSame('MATCHED', PgSqlMergeMatchKind::Matched->value);
+        self::assertSame('NOT MATCHED', PgSqlMergeMatchKind::NotMatched->value);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMergeParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMergeParserTest.php
@@ -107,6 +107,94 @@ final class PgSqlMergeParserTest extends TestCase
         self::assertSame(['name' => 'source.name'], $statement->clauses[0]->assignments);
     }
 
+    public function testPreservesEscapedQuotedIdentifiersAndNestedLists(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'MERGE INTO audit."A""B" AS target USING source ON target.id = source.id '
+            . 'WHEN NOT MATCHED THEN INSERT (id, payload) VALUES ((source.id), jsonb_build_array(1, 2))',
+        );
+
+        self::assertSame('A"B', $statement->targetTable);
+        self::assertSame('audit."A""B"', $statement->targetSql);
+        self::assertSame(['id', 'payload'], $statement->clauses[0]->insertColumns);
+        self::assertSame(['(source.id)', 'jsonb_build_array(1, 2)'], $statement->clauses[0]->insertValues);
+    }
+
+    public function testIgnoresOnAndWhenKeywordsOutsideMergeClauseBoundaries(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'MERGE INTO using.on.audit.users target '
+            . "USING (SELECT CASE WHEN matched THEN 'ON' ELSE 'off' END AS value) source "
+            . 'ON target.id = source.id '
+            . 'WHEN MATCHED AND on THEN DO NOTHING '
+            . 'WHEN NOT MATCHED THEN INSERT (id) VALUES (source.id)',
+        );
+
+        self::assertSame('using.on.audit.users', $statement->targetSql);
+        self::assertSame("(SELECT CASE WHEN matched THEN 'ON' ELSE 'off' END AS value) source", $statement->sourceSql);
+        self::assertSame('target.id = source.id', $statement->joinConditionSql);
+        self::assertSame('on', $statement->clauses[0]->conditionSql);
+        self::assertCount(2, $statement->clauses);
+    }
+
+    #[TestWith(['', 'Malformed MERGE statement'])]
+    #[TestWith(['SELECT 1', 'Malformed MERGE statement'])]
+    #[TestWith(['MERGE INTO public."" USING source ON TRUE WHEN MATCHED THEN DELETE', 'Cannot resolve MERGE target'])]
+    #[TestWith(['MERGE INTO users USING ON TRUE WHEN MATCHED THEN DELETE', 'MERGE requires a source and join condition'])]
+    #[TestWith(['MERGE INTO users USING source ON WHEN MATCHED THEN DELETE', 'MERGE requires a source and join condition'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN MATCHED BY SOURCE THEN DELETE', 'MERGE BY SOURCE and BY TARGET are not supported'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN MATCHED THEN DO UPDATE', 'MERGE action is not supported'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN MATCHED THEN DO NOTHING EXTRA', 'MERGE action is not supported'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN UPDATE SET name = source.name', 'MERGE action is not supported'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN MATCHED THEN UPDATE', 'MERGE UPDATE requires SET'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN MATCHED THEN UPDATE USING name = source.name', 'MERGE UPDATE requires SET'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN MATCHED THEN UPDATE SET target.name = source.name', 'MERGE UPDATE requires simple column assignments'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN MATCHED THEN UPDATE SET name =', 'MERGE UPDATE requires simple column assignments'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN INSERT', 'MERGE INSERT requires VALUES'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN INSERT FOO VALUES', 'MERGE INSERT requires VALUES'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN INSERT FOO (source.id)', 'MERGE INSERT requires VALUES'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN INSERT DEFAULT FOO', 'MERGE INSERT requires VALUES'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN INSERT DEFAULT VALUES EXTRA', 'MERGE INSERT requires VALUES'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN INSERT (id) DEFAULT VALUES', 'MERGE INSERT DEFAULT VALUES cannot name columns'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN INSERT VALUES', 'MERGE INSERT requires VALUES'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT MATCHED THEN INSERT VALUES id', 'MERGE INSERT requires VALUES'])]
+    #[TestWith(['MERGE INTO on.users USING source WHEN MATCHED THEN DELETE', 'MERGE requires an ON condition'])]
+    #[TestWith(['MERGE INTO users USING source ON TRUE WHEN NOT FOO THEN DELETE', 'MERGE requires a WHEN clause'])]
+    public function testRejectsMalformedMergeWithSpecificReason(string $sql, string $reason): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+        $this->expectExceptionMessage($reason);
+
+        (new PgSqlMergeParser())->parse($sql);
+    }
+
+    public function testEndIdentifierDoesNotCloseANonexistentCaseExpression(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'MERGE INTO users USING end ON users.id = end.id '
+            . 'WHEN MATCHED AND end THEN DELETE',
+        );
+
+        self::assertSame('end', $statement->sourceSql);
+        self::assertSame('end', $statement->clauses[0]->conditionSql);
+        self::assertSame(PgSqlMergeActionKind::Delete, $statement->clauses[0]->actionKind);
+    }
+
+    public function testSimpleCaseWhenMatchedExpressionIsNotAMergeClause(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'MERGE INTO users USING source ON users.id = source.id '
+            . 'WHEN MATCHED AND CASE source.kind WHEN matched THEN TRUE ELSE FALSE END THEN DELETE',
+        );
+
+        self::assertCount(1, $statement->clauses);
+        self::assertSame(
+            'CASE source.kind WHEN matched THEN TRUE ELSE FALSE END',
+            $statement->clauses[0]->conditionSql,
+        );
+        self::assertSame(PgSqlMergeActionKind::Delete, $statement->clauses[0]->actionKind);
+    }
+
     #[TestWith(['SELECT 1'])]
     #[TestWith(['MERGE INTO users USING source WHEN MATCHED THEN DELETE'])]
     #[TestWith(['MERGE INTO users USING source ON users.id = source.id'])]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMergeParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMergeParserTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlMergeActionKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeClause;
+use ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeParser;
+use ZtdQuery\Platform\Postgres\PgSqlMergeStatement;
+
+#[CoversClass(PgSqlMergeParser::class)]
+#[UsesClass(PgSqlMergeActionKind::class)]
+#[UsesClass(PgSqlMergeClause::class)]
+#[UsesClass(PgSqlMergeMatchKind::class)]
+#[UsesClass(PgSqlMergeStatement::class)]
+final class PgSqlMergeParserTest extends TestCase
+{
+    public function testParsesMatchedUpdateAndNotMatchedInsert(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'MERGE INTO target AS t USING source AS s ON t.id = s.id '
+            . 'WHEN MATCHED AND s.enabled THEN UPDATE SET name = s.name, value = s.value '
+            . 'WHEN NOT MATCHED THEN INSERT (id, name, value) VALUES (s.id, s.name, $1);',
+        );
+
+        self::assertSame('target', $statement->targetTable);
+        self::assertSame('target', $statement->targetSql);
+        self::assertSame('t', $statement->targetAlias);
+        self::assertSame('source AS s', $statement->sourceSql);
+        self::assertSame('t.id = s.id', $statement->joinConditionSql);
+        self::assertCount(2, $statement->clauses);
+        self::assertSame(PgSqlMergeMatchKind::Matched, $statement->clauses[0]->matchKind);
+        self::assertSame('s.enabled', $statement->clauses[0]->conditionSql);
+        self::assertSame(PgSqlMergeActionKind::Update, $statement->clauses[0]->actionKind);
+        self::assertSame(['name' => 's.name', 'value' => 's.value'], $statement->clauses[0]->assignments);
+        self::assertSame(PgSqlMergeMatchKind::NotMatched, $statement->clauses[1]->matchKind);
+        self::assertSame(PgSqlMergeActionKind::Insert, $statement->clauses[1]->actionKind);
+        self::assertSame(['id', 'name', 'value'], $statement->clauses[1]->insertColumns);
+        self::assertSame(['s.id', 's.name', '$1'], $statement->clauses[1]->insertValues);
+    }
+
+    public function testParsesCteQualifiedTargetJoinSourceAndQuotedAlias(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'WITH incoming AS (SELECT 1 AS id) '
+            . 'MERGE INTO ONLY public."Target" * AS "T" '
+            . 'USING incoming JOIN flags ON flags.id = incoming.id AS source '
+            . 'ON "T".id = source.id '
+            . 'WHEN MATCHED AND CASE WHEN source.id > 0 THEN TRUE ELSE FALSE END '
+            . 'THEN DELETE '
+            . 'WHEN MATCHED THEN DO NOTHING',
+        );
+
+        self::assertSame('Target', $statement->targetTable);
+        self::assertSame('public."Target"', $statement->targetSql);
+        self::assertSame('T', $statement->targetAlias);
+        self::assertSame('incoming JOIN flags ON flags.id = incoming.id AS source', $statement->sourceSql);
+        self::assertSame('"T".id = source.id', $statement->joinConditionSql);
+        self::assertSame(PgSqlMergeActionKind::Delete, $statement->clauses[0]->actionKind);
+        self::assertSame('CASE WHEN source.id > 0 THEN TRUE ELSE FALSE END', $statement->clauses[0]->conditionSql);
+        self::assertSame(PgSqlMergeActionKind::DoNothing, $statement->clauses[1]->actionKind);
+    }
+
+    public function testParsesValuesSourceAndDefaultValues(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'MERGE users USING (VALUES ($1, $2)) AS s(id, name) ON users.id = s.id '
+            . 'WHEN NOT MATCHED AND s.name IS NOT NULL THEN INSERT DEFAULT VALUES',
+        );
+
+        self::assertSame('users', $statement->targetAlias);
+        self::assertSame('(VALUES ($1, $2)) AS s(id, name)', $statement->sourceSql);
+        self::assertSame('s.name IS NOT NULL', $statement->clauses[0]->conditionSql);
+        self::assertSame([], $statement->clauses[0]->insertColumns);
+        self::assertSame([], $statement->clauses[0]->insertValues);
+    }
+
+    public function testParsesDefaultUpdateAndInsertWithoutColumnList(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'MERGE INTO users u USING source s ON u.id = s.id '
+            . 'WHEN MATCHED THEN UPDATE SET name = DEFAULT '
+            . 'WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.name)',
+        );
+
+        self::assertSame(['name' => 'DEFAULT'], $statement->clauses[0]->assignments);
+        self::assertSame([], $statement->clauses[1]->insertColumns);
+        self::assertSame(['s.id', 's.name'], $statement->clauses[1]->insertValues);
+    }
+
+    public function testFoldsUnquotedTargetAliasAndAssignmentIdentifiers(): void
+    {
+        $statement = (new PgSqlMergeParser())->parse(
+            'MERGE INTO Users AS Target USING source ON Target.ID = source.id '
+            . 'WHEN MATCHED THEN UPDATE SET Name = source.name',
+        );
+
+        self::assertSame('users', $statement->targetTable);
+        self::assertSame('target', $statement->targetAlias);
+        self::assertSame(['name' => 'source.name'], $statement->clauses[0]->assignments);
+    }
+
+    #[TestWith(['SELECT 1'])]
+    #[TestWith(['MERGE INTO users USING source WHEN MATCHED THEN DELETE'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id WHEN MATCHED BY SOURCE THEN DELETE'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id WHEN MATCHED THEN UPDATE (name, value) = (source.name, source.value)'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id WHEN NOT MATCHED THEN INSERT (id) VALUES (source.id, source.name)'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id WHEN MATCHED THEN INSERT (id) VALUES (source.id)'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id WHEN NOT MATCHED THEN DELETE'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id WHEN MATCHED THEN DELETE RETURNING *'])]
+    #[TestWith(['MERGE INTO "" USING source ON TRUE WHEN MATCHED THEN DELETE'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id WHEN MATCHED THEN UPDATE SET name = source.name, Name = source.other_name'])]
+    #[TestWith(['MERGE INTO users USING source ON users.id = source.id WHEN NOT MATCHED THEN INSERT (id, ID) VALUES (1, 2)'])]
+    public function testRejectsMalformedOrUnsupportedMergeShapes(string $sql): void
+    {
+        $this->expectException(UnsupportedSqlException::class);
+
+        (new PgSqlMergeParser())->parse($sql);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMergeParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMergeParserTest.php
@@ -20,6 +20,7 @@ use ZtdQuery\Platform\Postgres\PgSqlMergeStatement;
 #[UsesClass(PgSqlMergeClause::class)]
 #[UsesClass(PgSqlMergeMatchKind::class)]
 #[UsesClass(PgSqlMergeStatement::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class PgSqlMergeParserTest extends TestCase
 {
     public function testParsesMatchedUpdateAndNotMatchedInsert(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMergeStatementTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMergeStatementTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlMergeActionKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeClause;
+use ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeStatement;
+
+#[CoversClass(PgSqlMergeStatement::class)]
+#[UsesClass(PgSqlMergeActionKind::class)]
+#[UsesClass(PgSqlMergeClause::class)]
+#[UsesClass(PgSqlMergeMatchKind::class)]
+final class PgSqlMergeStatementTest extends TestCase
+{
+    public function testCarriesTypedStatementData(): void
+    {
+        $clause = new PgSqlMergeClause(
+            PgSqlMergeMatchKind::NotMatched,
+            null,
+            PgSqlMergeActionKind::Insert,
+            [],
+            ['id'],
+            ['source.id'],
+        );
+        $statement = new PgSqlMergeStatement(
+            'users',
+            'public.users',
+            'target',
+            'source AS source',
+            'target.id = source.id',
+            [$clause],
+        );
+
+        self::assertSame('users', $statement->targetTable);
+        self::assertSame('public.users', $statement->targetSql);
+        self::assertSame('target', $statement->targetAlias);
+        self::assertSame('source AS source', $statement->sourceSql);
+        self::assertSame('target.id = source.id', $statement->joinConditionSql);
+        self::assertSame([$clause], $statement->clauses);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlMutationResolver;
+use ZtdQuery\Platform\Postgres\PgSqlMergeParser;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\PgSqlSchemaParser;
 use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
@@ -21,6 +22,7 @@ use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\DropTableMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\Mutation\MultiTruncateMutation;
+use ZtdQuery\Shadow\Mutation\SynchronizeMutation;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\Mutation\UpsertMutation;
@@ -36,6 +38,11 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(PgSqlPartitionParser::class)]
+#[UsesClass(PgSqlMergeParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeStatement::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeClause::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeActionKind::class)]
 final class PgSqlMutationResolverTest extends TestCase
 {
     public function testPartitionDdlInheritsParentSchemaAndChildDmlUsesParentStorage(): void
@@ -2959,5 +2966,33 @@ final class PgSqlMutationResolverTest extends TestCase
             'UPDATE',
             QueryKind::WRITE_SIMULATED
         );
+    }
+
+    public function testResolveMergeReturnsAtomicTableSynchronization(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $registry->register('users', new TableDefinition(
+            ['id', 'name'],
+            ['id' => 'INTEGER', 'name' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+        ));
+        $resolver = new PgSqlMutationResolver(
+            $shadowStore,
+            $registry,
+            new PgSqlSchemaParser(),
+            new PgSqlParser(),
+        );
+
+        $mutation = $resolver->resolve(
+            'MERGE INTO users u USING source s ON u.id = s.id WHEN MATCHED THEN DELETE',
+            'MERGE',
+            QueryKind::WRITE_SIMULATED,
+        );
+
+        self::assertInstanceOf(SynchronizeMutation::class, $mutation);
+        self::assertSame('users', $mutation->tableName());
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -43,6 +43,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeClause::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeActionKind::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
 final class PgSqlMutationResolverTest extends TestCase
 {
     public function testPartitionDdlInheritsParentSchemaAndChildDmlUsesParentStorage(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -2971,6 +2971,7 @@ final class PgSqlMutationResolverTest extends TestCase
     public function testResolveMergeReturnsAtomicTableSynchronization(): void
     {
         $shadowStore = new ShadowStore();
+        $shadowStore->ensure('users');
         $registry = new TableDefinitionRegistry();
         $registry->register('users', new TableDefinition(
             ['id', 'name'],
@@ -2994,5 +2995,44 @@ final class PgSqlMutationResolverTest extends TestCase
 
         self::assertInstanceOf(SynchronizeMutation::class, $mutation);
         self::assertSame('users', $mutation->tableName());
+    }
+
+    public function testResolveMergeAcceptsInitializedTableWithoutReflectedSchema(): void
+    {
+        $shadowStore = new ShadowStore();
+        $shadowStore->ensure('users');
+        $resolver = new PgSqlMutationResolver(
+            $shadowStore,
+            new TableDefinitionRegistry(),
+            new PgSqlSchemaParser(),
+            new PgSqlParser(),
+        );
+
+        $mutation = $resolver->resolve(
+            'MERGE INTO users u USING source s ON u.id = s.id WHEN MATCHED THEN DELETE',
+            'MERGE',
+            QueryKind::WRITE_SIMULATED,
+        );
+
+        self::assertInstanceOf(SynchronizeMutation::class, $mutation);
+        self::assertSame('users', $mutation->tableName());
+    }
+
+    public function testResolveMergeRejectsUnknownUninitializedTable(): void
+    {
+        $resolver = new PgSqlMutationResolver(
+            new ShadowStore(),
+            new TableDefinitionRegistry(),
+            new PgSqlSchemaParser(),
+            new PgSqlParser(),
+        );
+
+        $this->expectException(UnknownSchemaException::class);
+
+        $resolver->resolve(
+            'MERGE INTO users u USING source s ON u.id = s.id WHEN MATCHED THEN DELETE',
+            'MERGE',
+            QueryKind::WRITE_SIMULATED,
+        );
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -77,6 +77,19 @@ final class PgSqlParserTest extends TestCase
         self::assertSame('DELETE', $parser->classifyStatement('DELETE FROM users WHERE id = 1'));
     }
 
+    public function testClassifiesMergeWithAndWithoutCtePrefix(): void
+    {
+        $parser = new PgSqlParser();
+
+        self::assertSame('MERGE', $parser->classifyStatement(
+            'MERGE INTO users USING source ON users.id = source.id WHEN MATCHED THEN DELETE',
+        ));
+        self::assertSame('MERGE', $parser->classifyStatement(
+            'WITH source AS (SELECT 1 AS id) '
+            . 'MERGE INTO users USING source ON users.id = source.id WHEN MATCHED THEN DELETE',
+        ));
+    }
+
     public function testClassifyTruncate(): void
     {
         $parser = new PgSqlParser();

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -88,6 +88,12 @@ final class PgSqlParserTest extends TestCase
             'WITH source AS (SELECT 1 AS id) '
             . 'MERGE INTO users USING source ON users.id = source.id WHEN MATCHED THEN DELETE',
         ));
+        self::assertSame('MERGE', $parser->classifyStatement(
+            'merge into users using source on users.id = source.id when matched then delete',
+        ));
+        self::assertSame('SELECT', $parser->classifyStatement('SELECT 1 AS merge_marker'));
+        self::assertNull($parser->classifyStatement('INVALID MERGE'));
+        self::assertNull($parser->classifyStatement('WITH source AS (SELECT 1) INVALID'));
     }
 
     public function testClassifyTruncate(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlQueryGuardTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlQueryGuardTest.php
@@ -76,6 +76,15 @@ final class PgSqlQueryGuardTest extends QueryClassifierContractTest
         self::assertSame(QueryKind::WRITE_SIMULATED, $guard->classify('DELETE FROM users WHERE id = 1'));
     }
 
+    public function testMergeClassifiesAsWriteSimulated(): void
+    {
+        $guard = new PgSqlQueryGuard(new PgSqlParser());
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $guard->classify(
+            'MERGE INTO users USING source ON users.id = source.id WHEN MATCHED THEN DELETE',
+        ));
+    }
+
     public function testTruncateClassifiesAsWriteSimulated(): void
     {
         $guard = new PgSqlQueryGuard(new PgSqlParser());

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -22,9 +22,11 @@ use ZtdQuery\Platform\Postgres\PgSqlTransformer;
 use ZtdQuery\Platform\Postgres\PgSqlViewDefinitionParser;
 use ZtdQuery\Platform\Postgres\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\InsertTransformer;
+use ZtdQuery\Platform\Postgres\Transformer\MergeTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 use ZtdQuery\Rewrite\QueryKind;
+use ZtdQuery\Rewrite\AffectedRowsMode;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\TableDefinition;
@@ -36,6 +38,7 @@ use ZtdQuery\Shadow\Mutation\CreateTableMutation;
 use ZtdQuery\Shadow\Mutation\DeleteMutation;
 use ZtdQuery\Shadow\Mutation\DropTableMutation;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\SynchronizeMutation;
 use ZtdQuery\Shadow\Mutation\TruncateMutation;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\ShadowStore;
@@ -63,6 +66,12 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(InsertTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertSelectRenderer::class)]
+#[UsesClass(MergeTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeStatement::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeClause::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeActionKind::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
@@ -76,6 +85,34 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlPartitionPredicateRenderer::class)]
 final class PgSqlRewriterTest extends RewriterContractTest
 {
+    public function testMergeBuildsAtomicSynchronizationPlan(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [['id' => 1, 'name' => 'old', 'email' => null]]);
+        $store->set('source', [['id' => 1, 'name' => 'updated'], ['id' => 2, 'name' => 'inserted']]);
+        $registry = new TableDefinitionRegistry();
+        $users = $this->createSchemaParser()->parse($this->usersCreateTableSql());
+        $source = $this->createSchemaParser()->parse(
+            'CREATE TABLE source (id INTEGER PRIMARY KEY, name TEXT NOT NULL)',
+        );
+        self::assertNotNull($users);
+        self::assertNotNull($source);
+        $registry->register('users', $users);
+        $registry->register('source', $source);
+
+        $plan = $this->createRewriter($store, $registry)->rewrite(
+            'MERGE INTO users AS target USING source ON target.id = source.id '
+            . 'WHEN MATCHED THEN UPDATE SET name = source.name '
+            . 'WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)',
+        );
+
+        self::assertSame(QueryKind::WRITE_SIMULATED, $plan->kind());
+        self::assertSame(AffectedRowsMode::Changed, $plan->affectedRowsMode());
+        self::assertInstanceOf(SynchronizeMutation::class, $plan->mutation());
+        self::assertStringContainsString('WHERE NOT (EXISTS', $plan->sql());
+        self::assertStringContainsString('UNION ALL', $plan->sql());
+    }
+
     public function testDoBlockPassesThroughWithoutInspectingBodyTables(): void
     {
         $sql = "DO \$body\$ BEGIN INSERT INTO physical_only VALUES (1); END \$body\$ LANGUAGE plpgsql";

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\PgSqlTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\InsertTransformer;
+use ZtdQuery\Platform\Postgres\Transformer\MergeTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 use ZtdQuery\Schema\ColumnType;
@@ -29,6 +30,12 @@ use ZtdQuery\Schema\ColumnTypeFamily;
 #[UsesClass(InsertTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertRowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertSelectRenderer::class)]
+#[UsesClass(MergeTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeStatement::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeClause::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlMergeActionKind::class)]
 #[UsesClass(UpdateTransformer::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
@@ -85,6 +92,37 @@ final class PgSqlTransformerTest extends TestCase
         $transformer = new PgSqlTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer);
         $result = $transformer->transform('DELETE FROM users WHERE id = 1', ['users' => ['alias' => '"users"', 'rows' => [['id' => 1, 'name' => 'Alice']], 'columns' => ['id', 'name'], 'columnTypes' => ['id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'), 'name' => new ColumnType(ColumnTypeFamily::STRING, 'TEXT')]]]);
         self::assertNotEmpty($result);
+    }
+
+    public function testTransformMergeDelegatesToMergeTransformer(): void
+    {
+        $parser = new PgSqlParser();
+        $selectTransformer = new SelectTransformer();
+        $transformer = new PgSqlTransformer(
+            $parser,
+            $selectTransformer,
+            new InsertTransformer($parser, $selectTransformer),
+            new UpdateTransformer($parser, $selectTransformer),
+            new DeleteTransformer($parser, $selectTransformer),
+        );
+        $result = $transformer->transform(
+            'MERGE INTO users u USING source s ON u.id = s.id WHEN MATCHED THEN DELETE',
+            [
+                'users' => [
+                    'rows' => [['id' => 1]],
+                    'columns' => ['id'],
+                    'columnTypes' => ['id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER')],
+                ],
+                'source' => [
+                    'rows' => [['id' => 1]],
+                    'columns' => ['id'],
+                    'columnTypes' => ['id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER')],
+                ],
+            ],
+        );
+
+        self::assertStringContainsString('WHERE NOT (EXISTS', $result);
+        $transformer->commitRewriteState();
     }
 
     public function testTransformUnsupportedStatementThrows(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertSelectRendererTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertSelectRendererTest.php
@@ -32,4 +32,18 @@ final class InsertSelectRendererTest extends TestCase
             $sql,
         );
     }
+
+    public function testRendersGeneratedIdentityExpression(): void
+    {
+        $renderer = new InsertSelectRenderer();
+
+        self::assertSame('1 + ROW_NUMBER() OVER () - 1', $renderer->renderGeneratedIdentity(1));
+    }
+
+    public function testRejectsNonPositiveGeneratedIdentityStart(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new InsertSelectRenderer())->renderGeneratedIdentity(0);
+    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/MergeTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/MergeTransformerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Transformer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
+use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
+use ZtdQuery\Platform\Postgres\PgSqlMergeActionKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeClause;
+use ZtdQuery\Platform\Postgres\PgSqlMergeMatchKind;
+use ZtdQuery\Platform\Postgres\PgSqlMergeParser;
+use ZtdQuery\Platform\Postgres\PgSqlMergeStatement;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleParser;
+use ZtdQuery\Platform\Postgres\PgSqlTableSampleRewriter;
+use ZtdQuery\Platform\Postgres\PgSqlValueRenderer;
+use ZtdQuery\Platform\Postgres\Transformer\MergeTransformer;
+use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+
+#[CoversClass(MergeTransformer::class)]
+#[UsesClass(PgSqlCastRenderer::class)]
+#[UsesClass(PgSqlIdentifierQuoter::class)]
+#[UsesClass(PgSqlMergeActionKind::class)]
+#[UsesClass(PgSqlMergeClause::class)]
+#[UsesClass(PgSqlMergeMatchKind::class)]
+#[UsesClass(PgSqlMergeParser::class)]
+#[UsesClass(PgSqlMergeStatement::class)]
+#[UsesClass(PgSqlTableSampleParser::class)]
+#[UsesClass(PgSqlTableSampleRewriter::class)]
+#[UsesClass(PgSqlValueRenderer::class)]
+#[UsesClass(SelectTransformer::class)]
+final class MergeTransformerTest extends TestCase
+{
+    public function testTransformsMixedUpdateAndInsertIntoCompleteTargetState(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+        $result = $transformer->transform(
+            'MERGE INTO target AS t USING source AS s ON t.id = s.id '
+            . 'WHEN MATCHED THEN UPDATE SET name = s.name '
+            . 'WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s.id, $1)',
+            [
+                'target' => [
+                    'rows' => [['id' => 1, 'name' => 'old']],
+                    'columns' => ['id', 'name'],
+                    'columnTypes' => [
+                        'id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
+                        'name' => new ColumnType(ColumnTypeFamily::STRING, 'TEXT'),
+                    ],
+                ],
+                'source' => [
+                    'rows' => [['id' => 1, 'name' => 'updated'], ['id' => 2, 'name' => 'inserted']],
+                    'columns' => ['id', 'name'],
+                    'columnTypes' => [
+                        'id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
+                        'name' => new ColumnType(ColumnTypeFamily::STRING, 'TEXT'),
+                    ],
+                ],
+            ],
+        );
+
+        self::assertStringContainsString('"target" AS MATERIALIZED', $result);
+        self::assertStringContainsString('"source" AS MATERIALIZED', $result);
+        self::assertStringContainsString('WHERE NOT (EXISTS', $result);
+        self::assertStringContainsString('JOIN source AS s ON (t.id = s.id)', $result);
+        self::assertStringContainsString('$1 AS "name"', $result);
+        self::assertStringContainsString('WHERE NOT EXISTS', $result);
+        self::assertSame(2, substr_count($result, 'UNION ALL'));
+        self::assertSame(
+            '8deccc308f3216f4695d5d03e93ee1a0deb7cbfe4ca451102125f6b2b691356c',
+            hash('sha256', $result),
+        );
+    }
+
+    public function testPreservesFirstEligibleClauseOrderingAndCtePrefix(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+        $result = $transformer->transform(
+            'WITH incoming AS (SELECT 1 AS id, TRUE AS skip) '
+            . 'MERGE INTO target t USING incoming s ON t.id = s.id '
+            . 'WHEN MATCHED AND s.skip THEN DO NOTHING '
+            . 'WHEN MATCHED THEN DELETE',
+            [
+                'target' => [
+                    'rows' => [['id' => 1]],
+                    'columns' => ['id'],
+                    'columnTypes' => ['id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER')],
+                ],
+            ],
+        );
+
+        self::assertStringContainsString('WITH "target" AS MATERIALIZED', $result);
+        self::assertStringContainsString('incoming AS (SELECT 1 AS id, TRUE AS skip)', $result);
+        self::assertStringContainsString('COALESCE((s.skip), FALSE)', $result);
+        self::assertStringContainsString('AND NOT (COALESCE((s.skip), FALSE))', $result);
+        self::assertSame(
+            '7c6934f735d990a45c2488968dfc74fb82557e87ef5bdaab9cba5e07f9de691e',
+            hash('sha256', $result),
+        );
+    }
+
+    public function testProjectsDefaultsAndGeneratedColumns(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+        $result = $transformer->transform(
+            'MERGE INTO totals t USING (VALUES (1, 3)) AS s(id, amount) ON t.id = s.id '
+            . 'WHEN MATCHED THEN UPDATE SET amount = DEFAULT '
+            . 'WHEN NOT MATCHED THEN INSERT (id, amount) VALUES (s.id, DEFAULT)',
+            [
+                'totals' => [
+                    'rows' => [],
+                    'columns' => ['id', 'amount', 'doubled'],
+                    'columnTypes' => [
+                        'id' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
+                        'amount' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
+                        'doubled' => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
+                    ],
+                    'columnDefaults' => ['amount' => '7'],
+                    'generatedExpressions' => ['doubled' => '"amount" * 2'],
+                ],
+            ],
+        );
+
+        self::assertStringContainsString('7 AS "amount"', $result);
+        self::assertStringContainsString('"amount" * 2 AS "doubled"', $result);
+        self::assertSame(
+            'd743861318ec598cf546902c70cb11b2c0be5b6c42e6fcc341afd99ee9d9fa34',
+            hash('sha256', $result),
+        );
+    }
+
+    public function testRejectsUnknownUpdateColumn(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+
+        $this->expectException(UnsupportedSqlException::class);
+
+        $transformer->transform(
+            'MERGE INTO target t USING source s ON t.id = s.id '
+            . 'WHEN MATCHED THEN UPDATE SET missing = s.value',
+            [
+                'target' => ['rows' => [], 'columns' => ['id'], 'columnTypes' => []],
+                'source' => ['rows' => [], 'columns' => ['id', 'value'], 'columnTypes' => []],
+            ],
+        );
+    }
+
+    public function testRejectsChildPartitionTargetBeforeStateCanBeTruncated(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+
+        $this->expectException(UnsupportedSqlException::class);
+
+        $transformer->transform(
+            'MERGE INTO child c USING source s ON c.id = s.id WHEN MATCHED THEN DELETE',
+            [
+                'child' => [
+                    'rows' => [['id' => 1]],
+                    'columns' => ['id'],
+                    'columnTypes' => [],
+                    'storageTable' => 'parent',
+                ],
+            ],
+        );
+    }
+
+    public function testCommitRewriteStateIsSafeWithoutIdentityAllocation(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+
+        $transformer->commitRewriteState();
+
+        self::assertInstanceOf(MergeTransformer::class, $transformer);
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/MergeTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/MergeTransformerTest.php
@@ -22,6 +22,7 @@ use ZtdQuery\Platform\Postgres\Transformer\MergeTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Schema\IdentityGenerationStrategy;
 
 #[CoversClass(MergeTransformer::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
@@ -150,6 +151,111 @@ final class MergeTransformerTest extends TestCase
         );
     }
 
+    public function testRejectsUnknownTargetAndViewTarget(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+        $sql = 'MERGE INTO target t USING source s ON t.id = s.id WHEN MATCHED THEN DELETE';
+
+        try {
+            $transformer->transform($sql, []);
+            self::fail('Unknown target must be rejected');
+        } catch (UnsupportedSqlException $exception) {
+            self::assertStringContainsString('Cannot resolve MERGE target schema', $exception->getMessage());
+        }
+
+        $this->expectException(UnsupportedSqlException::class);
+        $this->expectExceptionMessage('Cannot resolve MERGE target schema');
+        $transformer->transform($sql, ['target' => ['viewSql' => 'SELECT 1']]);
+    }
+
+    public function testRejectsNonListColumnMetadata(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+
+        $this->expectException(UnsupportedSqlException::class);
+        $this->expectExceptionMessage('MERGE target columns must preserve declaration order');
+
+        $transformer->transform(
+            'MERGE INTO target USING source ON TRUE WHEN MATCHED THEN DELETE',
+            ['target' => ['rows' => [], 'columns' => [2 => 'id'], 'columnTypes' => []]],
+        );
+    }
+
+    public function testProjectsDefaultValuesAndIdentity(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+        $result = $transformer->transform(
+            'MERGE INTO users target USING source ON FALSE '
+            . 'WHEN NOT MATCHED THEN INSERT DEFAULT VALUES',
+            [
+                'users' => [
+                    'rows' => [],
+                    'columns' => ['id', 'name'],
+                    'columnTypes' => [],
+                    'columnDefaults' => ['name' => "'anonymous'"],
+                    'identityStrategies' => ['id' => IdentityGenerationStrategy::Sequence],
+                ],
+            ],
+        );
+
+        self::assertStringContainsString('1 + ROW_NUMBER() OVER () - 1 AS "id"', $result);
+        self::assertStringContainsString("'anonymous' AS \"name\"", $result);
+    }
+
+    public function testRejectsUnknownInsertColumn(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+
+        $this->expectException(UnsupportedSqlException::class);
+        $this->expectExceptionMessage('MERGE INSERT references an unknown target column');
+
+        $transformer->transform(
+            'MERGE INTO users target USING source ON FALSE '
+            . 'WHEN NOT MATCHED THEN INSERT (missing) VALUES (source.value)',
+            ['users' => ['rows' => [], 'columns' => ['id'], 'columnTypes' => []]],
+        );
+    }
+
+    public function testExplicitIdentityValueIsNotGenerated(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+        $result = $transformer->transform(
+            'MERGE INTO users target USING source ON FALSE '
+            . 'WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)',
+            [
+                'users' => [
+                    'rows' => [],
+                    'columns' => ['id', 'name'],
+                    'columnTypes' => [],
+                    'identityStrategies' => ['id' => IdentityGenerationStrategy::Sequence],
+                ],
+            ],
+        );
+
+        self::assertStringContainsString('source.id AS "id"', $result);
+        self::assertStringNotContainsString('ROW_NUMBER()', $result);
+    }
+
+    public function testDefaultIdentityValueIsGenerated(): void
+    {
+        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
+        $result = $transformer->transform(
+            'MERGE INTO users target USING source ON FALSE '
+            . 'WHEN NOT MATCHED THEN INSERT (id, name) VALUES (DEFAULT, source.name)',
+            [
+                'users' => [
+                    'rows' => [],
+                    'columns' => ['id', 'name'],
+                    'columnTypes' => [],
+                    'identityStrategies' => ['id' => IdentityGenerationStrategy::Sequence],
+                ],
+            ],
+        );
+
+        self::assertStringContainsString('1 + ROW_NUMBER() OVER () - 1 AS "id"', $result);
+        self::assertStringContainsString('source.name AS "name"', $result);
+    }
+
     public function testRejectsChildPartitionTargetBeforeStateCanBeTruncated(): void
     {
         $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
@@ -169,12 +275,4 @@ final class MergeTransformerTest extends TestCase
         );
     }
 
-    public function testCommitRewriteStateIsSafeWithoutIdentityAllocation(): void
-    {
-        $transformer = new MergeTransformer(new PgSqlMergeParser(), new SelectTransformer());
-
-        $transformer->commitRewriteState();
-
-        self::assertInstanceOf(MergeTransformer::class, $transformer);
-    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/MergeTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/MergeTransformerTest.php
@@ -40,6 +40,7 @@ use ZtdQuery\Schema\IdentityGenerationStrategy;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertSelectRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertRowRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 final class MergeTransformerTest extends TestCase
 {
     public function testTransformsMixedUpdateAndInsertIntoCompleteTargetState(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/MergeTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/MergeTransformerTest.php
@@ -36,6 +36,10 @@ use ZtdQuery\Schema\IdentityGenerationStrategy;
 #[UsesClass(PgSqlTableSampleRewriter::class)]
 #[UsesClass(PgSqlValueRenderer::class)]
 #[UsesClass(SelectTransformer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertSelectRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\Transformer\InsertRowRenderer::class)]
 final class MergeTransformerTest extends TestCase
 {
     public function testTransformsMixedUpdateAndInsertIntoCompleteTargetState(): void

--- a/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
@@ -456,7 +456,7 @@ final class SqliteSchemaParser implements SchemaParser
     /**
      * Parse a comma-separated column name list.
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     private function parseColumnNameList(string $list): array
     {


### PR DESCRIPTION
## Summary
- parse PostgreSQL 15 MERGE into typed match and action clauses without a regex grammar shortcut
- evaluate mixed UPDATE, INSERT, DELETE, and DO NOTHING actions in PostgreSQL and atomically synchronize the complete shadow target state
- preserve clause ordering, CTE and VALUES sources, defaults, generated columns, constraints, cascades, affected-row counts, and prepared parameters
- add SQLFaker generation, three fuzz targets, mutation-resistant unit tests, and real PostgreSQL integration coverage

Closes #162