### PR TITLE
fix(postgres): route COPY through the shadow store

### DIFF
--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -139,6 +139,12 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function copyStatement(): GenerationPlan
+    {
+        return GenerationPlan::fromRule('CopyStmt')->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -169,6 +169,16 @@ final class PostgreSqlProvider extends Base
     }
 
     /**
+     * Generate a PostgreSQL COPY statement.
+     *
+     * @return non-empty-string
+     */
+    public function copyStatement(int $maxDepth = PHP_INT_MAX): string
+    {
+        return $this->sql->generate(GenerationPlans::copyStatement()->withMaxDepth($maxDepth));
+    }
+
+    /**
      * Generate a PostgreSQL CREATE INDEX statement.
      *
      * @return non-empty-string

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -165,4 +165,9 @@ final class GenerationPlansTest extends TestCase
             $plan->patternAt('merge_when_clause', 3)?->matches(['merge_when_tgt_not_matched', 'merge_insert']) ?? false,
         );
     }
+
+    public function testCopyPlanStartsFromTheCopyGrammar(): void
+    {
+        self::assertSame('CopyStmt', GenerationPlans::copyStatement()->startRule());
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -168,6 +168,8 @@ final class GenerationPlansTest extends TestCase
 
     public function testCopyPlanStartsFromTheCopyGrammar(): void
     {
-        self::assertSame('CopyStmt', GenerationPlans::copyStatement()->startRule());
+        $plan = GenerationPlans::copyStatement();
+
+        self::assertSame('CopyStmt', $plan->startRule());
     }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -960,6 +960,15 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertLessThan($insert, $update);
     }
 
+    public function testCopyStatementUsesOfficialGrammarRule(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $provider = new PostgreSqlProvider($faker);
+
+        self::assertStringContainsString('COPY', $provider->copyStatement(maxDepth: 8));
+    }
+
     #[DataProvider('providerNullableSimpleStatementSeed')]
     public function testSimpleStatementReturnsNonEmpty(int $seed): void
     {

--- a/packages/ztd-query-core/src/Platform/CopySupport.php
+++ b/packages/ztd-query-core/src/Platform/CopySupport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform;
+
+use ZtdQuery\Schema\TableDefinition;
+
+interface CopySupport
+{
+    public function tableName(string $relation): string;
+
+    public function target(string $relation, ?string $fields, TableDefinition $definition): CopyTarget;
+
+    public function selectSql(CopyTarget $target): string;
+
+    public function insertSql(CopyTarget $target, int $rowCount, bool $overrideSystemValue): string;
+
+    /** @param list<mixed> $values */
+    public function encodeRow(array $values, string $separator, string $nullAs): string;
+
+    /** @return list<string|null> */
+    public function decodeRow(string $row, string $separator, string $nullAs): array;
+
+    public function isCopyStatement(string $sql): bool;
+}

--- a/packages/ztd-query-core/src/Platform/CopyTarget.php
+++ b/packages/ztd-query-core/src/Platform/CopyTarget.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform;
+
+final class CopyTarget
+{
+    /**
+     * @param non-empty-list<string> $relation
+     * @param non-empty-list<string> $columns
+     */
+    public function __construct(
+        public readonly array $relation,
+        public readonly array $columns,
+    ) {
+    }
+
+    public function tableName(): string
+    {
+        return $this->relation[count($this->relation) - 1];
+    }
+}

--- a/packages/ztd-query-core/src/Platform/SqlPlaceholderEscaper.php
+++ b/packages/ztd-query-core/src/Platform/SqlPlaceholderEscaper.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform;
+
+interface SqlPlaceholderEscaper
+{
+    public function escape(string $sql): string;
+}

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -15,6 +15,9 @@ use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\Exception\SimulationException;
 use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\CopySupport;
+use ZtdQuery\Platform\CopyTarget;
+use ZtdQuery\Platform\SqlPlaceholderEscaper;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -82,6 +85,10 @@ final class Session
 
     private ReferentialIntegrityEnforcer $referentialIntegrity;
 
+    private ?CopySupport $copySupport;
+
+    private ?SqlPlaceholderEscaper $sqlPlaceholderEscaper;
+
     private ?string $lastInsertId = null;
 
     /**
@@ -99,6 +106,8 @@ final class Session
         ConnectionInterface $connection,
         ?ShadowTransactionManager $transactions = null,
         ?TableDefinitionRegistry $registry = null,
+        ?CopySupport $copySupport = null,
+        ?SqlPlaceholderEscaper $sqlPlaceholderEscaper = null,
     ) {
         $this->rewriter = $rewriter;
         $this->shadowStore = $shadowStore;
@@ -108,6 +117,8 @@ final class Session
         $this->transactions = $transactions ?? new ShadowTransactionManager($shadowStore);
         $this->registry = $registry ?? new TableDefinitionRegistry();
         $this->referentialIntegrity = new ReferentialIntegrityEnforcer($this->registry);
+        $this->copySupport = $copySupport;
+        $this->sqlPlaceholderEscaper = $sqlPlaceholderEscaper;
     }
 
     /**
@@ -192,6 +203,29 @@ final class Session
     public function tableDefinition(string $tableName): ?TableDefinition
     {
         return $this->registry->get($tableName);
+    }
+
+    public function copySupport(): ?CopySupport
+    {
+        return $this->copySupport;
+    }
+
+    public function copyTarget(string $relation, ?string $fields): ?CopyTarget
+    {
+        if ($this->copySupport === null) {
+            return null;
+        }
+        $definition = $this->registry->get($this->copySupport->tableName($relation));
+        if ($definition === null) {
+            return null;
+        }
+
+        return $this->copySupport->target($relation, $fields, $definition);
+    }
+
+    public function sqlPlaceholderEscaper(): ?SqlPlaceholderEscaper
+    {
+        return $this->sqlPlaceholderEscaper;
     }
 
     /**

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -191,7 +191,7 @@ final class Session
 
     public function tableDefinition(string $tableName): ?TableDefinition
     {
-        return $this->registry?->get($tableName);
+        return $this->registry->get($tableName);
     }
 
     /**

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -19,6 +19,7 @@ use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Rewrite\RewriteStateCommitter;
+use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Shadow\Mutation\MutationImpact;
 use ZtdQuery\Shadow\Mutation\ShadowMutation;
@@ -188,6 +189,10 @@ final class Session
         return $this->lastInsertId ?? false;
     }
 
+    public function tableDefinition(string $tableName): ?TableDefinition
+    {
+        return $this->registry?->get($tableName);
+    }
 
     /**
      * Rewrite SQL using the configured rewriter.

--- a/packages/ztd-query-core/tests/Unit/Platform/CopySupportTest.php
+++ b/packages/ztd-query-core/tests/Unit/Platform/CopySupportTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\CopySupport;
+
+#[CoversNothing]
+final class CopySupportTest extends TestCase
+{
+    public function testDeclaresPlatformCopyContract(): void
+    {
+        $reflection = new \ReflectionClass(CopySupport::class);
+
+        self::assertTrue($reflection->isInterface());
+        self::assertTrue($reflection->hasMethod('target'));
+        self::assertTrue($reflection->hasMethod('selectSql'));
+        self::assertTrue($reflection->hasMethod('insertSql'));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Platform/CopyTargetTest.php
+++ b/packages/ztd-query-core/tests/Unit/Platform/CopyTargetTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\CopyTarget;
+
+#[CoversClass(CopyTarget::class)]
+final class CopyTargetTest extends TestCase
+{
+    public function testCarriesSemanticRelationAndColumnNames(): void
+    {
+        $target = new CopyTarget(['public', 'users'], ['id', 'name']);
+
+        self::assertSame(['public', 'users'], $target->relation);
+        self::assertSame(['id', 'name'], $target->columns);
+        self::assertSame('users', $target->tableName());
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Platform/SqlPlaceholderEscaperTest.php
+++ b/packages/ztd-query-core/tests/Unit/Platform/SqlPlaceholderEscaperTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\SqlPlaceholderEscaper;
+
+#[CoversNothing]
+final class SqlPlaceholderEscaperTest extends TestCase
+{
+    public function testDeclaresPlatformPlaceholderEscapingContract(): void
+    {
+        $reflection = new \ReflectionClass(SqlPlaceholderEscaper::class);
+
+        self::assertTrue($reflection->isInterface());
+        self::assertTrue($reflection->hasMethod('escape'));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -73,6 +73,25 @@ final class SessionTest extends TestCase
         self::assertTrue($session->isEnabled());
     }
 
+    public function testTableDefinitionReturnsRegisteredSchemaOrNull(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], ['id'], []);
+        $registry->register('users', $definition);
+        $session = new Session(
+            new FakeSqlRewriter($shadowStore, $registry),
+            $shadowStore,
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            new FakeConnection(),
+            registry: $registry,
+        );
+
+        self::assertSame($definition, $session->tableDefinition('users'));
+        self::assertNull($session->tableDefinition('missing'));
+    }
+
     public function testUsesProvidedTransactionManagerForSchemaRollback(): void
     {
         $shadowStore = new ShadowStore();

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -15,6 +15,9 @@ use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Connection\ResultSet;
 use ZtdQuery\Exception\MissingPrimaryKeyException;
 use ZtdQuery\Exception\ForeignKeyViolationException;
+use ZtdQuery\Platform\CopySupport;
+use ZtdQuery\Platform\CopyTarget;
+use ZtdQuery\Platform\SqlPlaceholderEscaper;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
@@ -48,6 +51,7 @@ use ZtdQuery\Shadow\ShadowTransactionManager;
 #[UsesClass(ForeignKeyViolationException::class)]
 #[UsesClass(ReferentialIntegrityEnforcer::class)]
 #[UsesClass(MissingPrimaryKeyException::class)]
+#[UsesClass(CopyTarget::class)]
 final class SessionTest extends TestCase
 {
     public function testEnableAndDisable(): void
@@ -66,6 +70,9 @@ final class SessionTest extends TestCase
 
         self::assertTrue($session->isEnabled());
         self::assertNull($session->tableDefinition('users'));
+        self::assertNull($session->copySupport());
+        self::assertNull($session->copyTarget('users', null));
+        self::assertNull($session->sqlPlaceholderEscaper());
 
         $session->disable();
         self::assertFalse($session->isEnabled());
@@ -91,6 +98,37 @@ final class SessionTest extends TestCase
 
         self::assertSame($definition, $session->tableDefinition('users'));
         self::assertNull($session->tableDefinition('missing'));
+    }
+
+    public function testDelegatesCopyTargetsToTheConfiguredPlatformSupport(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], ['id'], []);
+        $registry->register('users', $definition);
+        $target = new CopyTarget(['public', 'users'], ['id']);
+        $copy = self::createStub(CopySupport::class);
+        $copy->method('tableName')->willReturnMap([
+            ['public.users', 'users'],
+            ['missing', 'missing'],
+        ]);
+        $copy->method('target')->willReturn($target);
+        $escaper = self::createStub(SqlPlaceholderEscaper::class);
+        $session = new Session(
+            new FakeSqlRewriter($shadowStore, $registry),
+            $shadowStore,
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            new FakeConnection(),
+            registry: $registry,
+            copySupport: $copy,
+            sqlPlaceholderEscaper: $escaper,
+        );
+
+        self::assertSame($copy, $session->copySupport());
+        self::assertSame($target, $session->copyTarget('public.users', 'id'));
+        self::assertNull($session->copyTarget('missing', null));
+        self::assertSame($escaper, $session->sqlPlaceholderEscaper());
     }
 
     public function testUsesProvidedTransactionManagerForSchemaRollback(): void

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -65,6 +65,7 @@ final class SessionTest extends TestCase
         );
 
         self::assertTrue($session->isEnabled());
+        self::assertNull($session->tableDefinition('users'));
 
         $session->disable();
         self::assertFalse($session->isEnabled());

--- a/packages/ztd-query-pdo-adapter/src/PdoParameterBinder.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoParameterBinder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ZtdQuery\Adapter\Pdo;
 
 use PDOStatement;
+use ZtdQuery\Platform\SqlPlaceholderEscaper;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
@@ -14,8 +15,12 @@ final class PdoParameterBinder
      * @param array<int|string, mixed>|null $params
      * @return array{sql: string, params: array<int|string, mixed>|null}
      */
-    public function compile(string $sql, string $driver, ?array $params): array
-    {
+    public function compile(
+        string $sql,
+        string $driver,
+        ?array $params,
+        ?SqlPlaceholderEscaper $placeholderEscaper = null,
+    ): array {
         if ($driver !== 'pgsql' && $driver !== 'sqlite') {
             return ['sql' => $sql, 'params' => $params];
         }
@@ -79,8 +84,8 @@ final class PdoParameterBinder
             }
         }
 
-        if ($driver === 'pgsql') {
-            $sql = PostgreSqlPlaceholderEscaper::escape($sql);
+        if ($driver === 'pgsql' && $placeholderEscaper !== null) {
+            $sql = $placeholderEscaper->escape($sql);
         }
 
         if ($nativePositions === [] || $params === null) {

--- a/packages/ztd-query-pdo-adapter/src/PdoPreparedExecution.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoPreparedExecution.php
@@ -30,7 +30,12 @@ final class PdoPreparedExecution
     {
         $plan = $this->session->rewrite($this->sql);
         $driver = $this->driver();
-        $compiled = $this->parameterBinder->compile($plan->sql(), $driver, $params);
+        $compiled = $this->parameterBinder->compile(
+            $plan->sql(),
+            $driver,
+            $params,
+            $this->session->sqlPlaceholderEscaper(),
+        );
         $statement = $this->pdo->prepare($compiled['sql'], $this->options);
         if ($statement === false) {
             throw new RuntimeException('PDO failed to prepare rewritten SQL.');

--- a/packages/ztd-query-pdo-adapter/src/PostgreSqlCopyCodec.php
+++ b/packages/ztd-query-pdo-adapter/src/PostgreSqlCopyCodec.php
@@ -14,30 +14,24 @@ final class PostgreSqlCopyCodec
     /** @return array{name: string, sql: string} */
     public function relation(string $tableName): array
     {
-        $tokens = SqlTokenStream::tokenize($tableName)->significantTokens();
-        if ($tokens === []) {
+        $parts = SqlTokenStream::tokenize($tableName)->splitTopLevel('.');
+        if ($parts === []) {
             throw new \ValueError('PostgreSQL COPY table name must not be empty.');
+        }
+        if (in_array('', $parts, true)) {
+            throw new \ValueError('PostgreSQL COPY table name must not contain an empty qualifier component.');
+        }
+        if (count($parts) > 2) {
+            throw new \ValueError('PostgreSQL COPY table name may contain at most a schema and table component.');
         }
 
         $components = [];
-        for ($index = 0; isset($tokens[$index]); $index++) {
-            $components[] = $this->identifier($tokens[$index], 'table name');
-            $index++;
-            if (!isset($tokens[$index])) {
-                continue;
-            }
-
-            $separator = $tokens[$index];
-            if ($separator->kind !== SqlTokenKind::Symbol || $separator->text !== '.') {
+        foreach ($parts as $part) {
+            $tokens = SqlTokenStream::tokenize($part)->significantTokens();
+            if (count($tokens) !== 1) {
                 throw new \ValueError('PostgreSQL COPY table name must be an identifier or schema-qualified identifier.');
             }
-            if (!isset($tokens[$index + 1])) {
-                throw new \ValueError('PostgreSQL COPY table name must not end with a qualifier separator.');
-            }
-        }
-
-        if (count($components) > 2) {
-            throw new \ValueError('PostgreSQL COPY table name may contain at most a schema and table component.');
+            $components[] = $this->identifier($tokens[0], 'table name');
         }
 
         return [
@@ -129,10 +123,6 @@ final class PostgreSqlCopyCodec
 
     private function identifier(SqlToken $token, string $subject): string
     {
-        if (!in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
-            throw new \ValueError(sprintf('PostgreSQL COPY %s must be a valid identifier.', $subject));
-        }
-
         $parsed = SqlTokenStream::tokenize($token->text)->identifierAt();
         if ($parsed === null) {
             throw new \ValueError(sprintf('PostgreSQL COPY %s must be a valid identifier.', $subject));
@@ -199,37 +189,45 @@ final class PostgreSqlCopyCodec
     private function decodeFields(string $row, string $separator, string $nullAs): array
     {
         $values = [];
-        $raw = '';
         $decoded = '';
+        $fieldStart = 0;
         $length = strlen($row);
         for ($index = 0; $index <= $length; $index++) {
             if ($index === $length || $row[$index] === $separator) {
+                $raw = substr($row, $fieldStart, $index - $fieldStart);
                 $values[] = $raw === $nullAs ? null : $decoded;
-                $raw = '';
                 $decoded = '';
+                $fieldStart = $index + 1;
                 continue;
             }
 
             $character = $row[$index];
             if ($character !== '\\') {
-                $raw .= $character;
                 $decoded .= $character;
                 continue;
             }
 
-            $raw .= $character;
             $next = $row[$index + 1] ?? null;
             if ($next === null) {
                 throw new \ValueError('PostgreSQL COPY field ends with an incomplete backslash escape.');
             }
-            $raw .= $next;
             $index++;
 
             if ($next >= '0' && $next <= '7') {
                 $digits = $next;
-                while (strlen($digits) < 3 && isset($row[$index + 1]) && $row[$index + 1] >= '0' && $row[$index + 1] <= '7') {
-                    $digit = $row[++$index];
-                    $raw .= $digit;
+                while (strlen($digits) < 3) {
+                    $following = $row[$index + 1] ?? null;
+                    if ($following === null) {
+                        break;
+                    }
+                    if ($following < '0') {
+                        break;
+                    }
+                    if ($following > '7') {
+                        break;
+                    }
+                    $index++;
+                    $digit = $following;
                     $digits .= $digit;
                 }
                 $byte = intval($digits, 8);
@@ -239,17 +237,22 @@ final class PostgreSqlCopyCodec
                 $decoded .= chr($byte);
                 continue;
             }
-            if ($next === 'x' && isset($row[$index + 1]) && ctype_xdigit($row[$index + 1])) {
-                $digit = $row[++$index];
-                $raw .= $digit;
+            $following = $row[$index + 1] ?? null;
+            if ($next === 'x' && $following !== null && ctype_xdigit($following)) {
+                $index++;
+                $digit = $following;
                 $digits = $digit;
-                if (isset($row[$index + 1]) && ctype_xdigit($row[$index + 1])) {
-                    $digit = $row[++$index];
-                    $raw .= $digit;
+                $following = $row[$index + 1] ?? null;
+                if ($following !== null && ctype_xdigit($following)) {
+                    $index++;
+                    $digit = $following;
                     $digits .= $digit;
                 }
                 $byte = intval($digits, 16);
-                if ($byte < 0 || $byte > 255) {
+                if ($byte < 0) {
+                    throw new \ValueError('PostgreSQL COPY hexadecimal escape must not be negative.');
+                }
+                if ($byte > 255) {
                     throw new \ValueError('PostgreSQL COPY hexadecimal escape must fit in one byte.');
                 }
                 $decoded .= chr($byte);

--- a/packages/ztd-query-pdo-adapter/src/PostgreSqlCopyCodec.php
+++ b/packages/ztd-query-pdo-adapter/src/PostgreSqlCopyCodec.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Pdo;
+
+use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PostgreSqlCopyCodec
+{
+    /** @return array{name: string, sql: string} */
+    public function relation(string $tableName): array
+    {
+        $tokens = SqlTokenStream::tokenize($tableName)->significantTokens();
+        if ($tokens === []) {
+            throw new \ValueError('PostgreSQL COPY table name must not be empty.');
+        }
+
+        $components = [];
+        for ($index = 0; isset($tokens[$index]); $index++) {
+            $components[] = $this->identifier($tokens[$index], 'table name');
+            $index++;
+            if (!isset($tokens[$index])) {
+                continue;
+            }
+
+            $separator = $tokens[$index];
+            if ($separator->kind !== SqlTokenKind::Symbol || $separator->text !== '.') {
+                throw new \ValueError('PostgreSQL COPY table name must be an identifier or schema-qualified identifier.');
+            }
+            if (!isset($tokens[$index + 1])) {
+                throw new \ValueError('PostgreSQL COPY table name must not end with a qualifier separator.');
+            }
+        }
+
+        if (count($components) > 2) {
+            throw new \ValueError('PostgreSQL COPY table name may contain at most a schema and table component.');
+        }
+
+        return [
+            'name' => $components[count($components) - 1],
+            'sql' => implode('.', array_map($this->quoteIdentifier(...), $components)),
+        ];
+    }
+
+    /** @return list<string> */
+    public function columns(?string $fields, TableDefinition $definition): array
+    {
+        if ($fields === null) {
+            $columns = [];
+            foreach ($definition->columns as $column) {
+                if (!isset($definition->generatedExpressions[$column])) {
+                    $columns[] = $column;
+                }
+            }
+
+            return $columns;
+        }
+
+        $parts = SqlTokenStream::tokenize($fields)->splitTopLevel();
+        if ($parts === [] || in_array('', $parts, true)) {
+            throw new \ValueError('PostgreSQL COPY fields must contain at least one column identifier.');
+        }
+
+        $columns = [];
+        foreach ($parts as $part) {
+            $tokens = SqlTokenStream::tokenize($part)->significantTokens();
+            if (count($tokens) !== 1) {
+                throw new \ValueError('Each PostgreSQL COPY field must be a single column identifier.');
+            }
+            $column = $this->identifier($tokens[0], 'field');
+            if (in_array($column, $columns, true)) {
+                throw new \ValueError(sprintf('PostgreSQL COPY field "%s" is specified more than once.', $column));
+            }
+            $columns[] = $column;
+        }
+
+        return $columns;
+    }
+
+    /** @param list<string> $columns */
+    public function columnListSql(array $columns): string
+    {
+        if ($columns === []) {
+            throw new \ValueError('PostgreSQL COPY requires at least one non-generated column.');
+        }
+
+        return implode(', ', array_map($this->quoteIdentifier(...), $columns));
+    }
+
+    /** @param list<mixed> $values */
+    public function encodeRow(array $values, string $separator, string $nullAs): string
+    {
+        $this->validateSeparator($separator);
+        $encoded = [];
+        foreach ($values as $value) {
+            if ($value === null) {
+                $encoded[] = $nullAs;
+                continue;
+            }
+
+            $encoded[] = $this->escape($this->copyOutput($value), $separator);
+        }
+
+        return implode($separator, $encoded) . "\n";
+    }
+
+    /** @return list<string|null> */
+    public function decodeRow(string $row, string $separator, string $nullAs): array
+    {
+        $this->validateSeparator($separator);
+        if (str_ends_with($row, "\r\n")) {
+            $row = substr($row, 0, -2);
+        } elseif (str_ends_with($row, "\n") || str_ends_with($row, "\r")) {
+            $row = substr($row, 0, -1);
+        }
+        if (str_contains($row, "\n") || str_contains($row, "\r")) {
+            throw new \ValueError('PostgreSQL COPY rows must escape embedded newlines and carriage returns.');
+        }
+        if ($row === '\\.') {
+            throw new \ValueError('PostgreSQL COPY end-of-data markers are not row values.');
+        }
+
+        return $this->decodeFields($row, $separator, $nullAs);
+    }
+
+    private function identifier(SqlToken $token, string $subject): string
+    {
+        if (!in_array($token->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+            throw new \ValueError(sprintf('PostgreSQL COPY %s must be a valid identifier.', $subject));
+        }
+
+        $parsed = SqlTokenStream::tokenize($token->text)->identifierAt();
+        if ($parsed === null) {
+            throw new \ValueError(sprintf('PostgreSQL COPY %s must be a valid identifier.', $subject));
+        }
+
+        return $token->kind === SqlTokenKind::Word ? strtolower($parsed['name']) : $parsed['name'];
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        return '"' . str_replace('"', '""', $identifier) . '"';
+    }
+
+    private function validateSeparator(string $separator): void
+    {
+        if (strlen($separator) !== 1) {
+            throw new \ValueError('PostgreSQL COPY separator must be exactly one byte.');
+        }
+    }
+
+    private function copyOutput(mixed $value): string
+    {
+        if (is_string($value) || is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        if (is_bool($value)) {
+            return $value ? 't' : 'f';
+        }
+        if (is_resource($value)) {
+            $bytes = stream_get_contents($value);
+            if ($bytes === false) {
+                throw new \ValueError('PostgreSQL COPY could not read a binary value.');
+            }
+
+            return '\\x' . bin2hex($bytes);
+        }
+
+        throw new \ValueError(sprintf('PostgreSQL COPY cannot encode a value of type %s.', get_debug_type($value)));
+    }
+
+    private function escape(string $value, string $separator): string
+    {
+        $result = '';
+        $length = strlen($value);
+        for ($index = 0; $index < $length; $index++) {
+            $character = $value[$index];
+            $escaped = match ($character) {
+                "\x08" => '\\b',
+                "\x0C" => '\\f',
+                "\n" => '\\n',
+                "\r" => '\\r',
+                "\t" => '\\t',
+                "\x0B" => '\\v',
+                '\\' => '\\\\',
+                default => null,
+            };
+            $result .= $escaped ?? ($character === $separator ? '\\' . $character : $character);
+        }
+
+        return $result;
+    }
+
+    /** @return list<string|null> */
+    private function decodeFields(string $row, string $separator, string $nullAs): array
+    {
+        $values = [];
+        $raw = '';
+        $decoded = '';
+        $length = strlen($row);
+        for ($index = 0; $index <= $length; $index++) {
+            if ($index === $length || $row[$index] === $separator) {
+                $values[] = $raw === $nullAs ? null : $decoded;
+                $raw = '';
+                $decoded = '';
+                continue;
+            }
+
+            $character = $row[$index];
+            if ($character !== '\\') {
+                $raw .= $character;
+                $decoded .= $character;
+                continue;
+            }
+
+            $raw .= $character;
+            $next = $row[$index + 1] ?? null;
+            if ($next === null) {
+                throw new \ValueError('PostgreSQL COPY field ends with an incomplete backslash escape.');
+            }
+            $raw .= $next;
+            $index++;
+
+            if ($next >= '0' && $next <= '7') {
+                $digits = $next;
+                while (strlen($digits) < 3 && isset($row[$index + 1]) && $row[$index + 1] >= '0' && $row[$index + 1] <= '7') {
+                    $digit = $row[++$index];
+                    $raw .= $digit;
+                    $digits .= $digit;
+                }
+                $byte = intval($digits, 8);
+                if ($byte < 0 || $byte > 255) {
+                    throw new \ValueError('PostgreSQL COPY octal escape must fit in one byte.');
+                }
+                $decoded .= chr($byte);
+                continue;
+            }
+            if ($next === 'x' && isset($row[$index + 1]) && ctype_xdigit($row[$index + 1])) {
+                $digit = $row[++$index];
+                $raw .= $digit;
+                $digits = $digit;
+                if (isset($row[$index + 1]) && ctype_xdigit($row[$index + 1])) {
+                    $digit = $row[++$index];
+                    $raw .= $digit;
+                    $digits .= $digit;
+                }
+                $byte = intval($digits, 16);
+                if ($byte < 0 || $byte > 255) {
+                    throw new \ValueError('PostgreSQL COPY hexadecimal escape must fit in one byte.');
+                }
+                $decoded .= chr($byte);
+                continue;
+            }
+
+            $decoded .= match ($next) {
+                'b' => "\x08",
+                'f' => "\x0C",
+                'n' => "\n",
+                'r' => "\r",
+                't' => "\t",
+                'v' => "\x0B",
+                default => $next,
+            };
+        }
+
+        return $values;
+    }
+}

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
@@ -12,6 +12,7 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
+use ZtdQuery\Sql\SqlTokenStream;
 
 /**
  * PDO proxy that enforces ZTD behavior for reads and writes.
@@ -166,6 +167,8 @@ class ZtdPdo extends PDO
             return $this->pdo->prepare($query, $options);
         }
 
+        $this->guardRawPostgreSqlCopy($query);
+
         try {
             $execution = new PdoPreparedExecution($this->pdo, $this->session, $query, $options);
             $prepared = $execution->prepare(null);
@@ -229,6 +232,8 @@ class ZtdPdo extends PDO
         if (!$this->session->isEnabled()) {
             return $this->pdo->exec($statement);
         }
+
+        $this->guardRawPostgreSqlCopy($statement);
 
         $transactionStatement = $this->session->transactionStatement($statement);
         if ($transactionStatement !== null) {
@@ -364,6 +369,272 @@ class ZtdPdo extends PDO
     public function quote(string $string, int $type = PDO::PARAM_STR): string|false
     {
         return $this->pdo->quote($string, $type);
+    }
+
+    /** @return array<int, string>|false */
+    public function pgsqlCopyToArray(
+        mixed $tableName,
+        mixed $separator = "\t",
+        mixed $nullAs = '\\N',
+        mixed $fields = null,
+    ): array|false {
+        return $this->copyToArrayThroughZtd(
+            $this->copyStringArgument($tableName, 'tableName'),
+            $this->copyStringArgument($separator, 'separator'),
+            $this->copyStringArgument($nullAs, 'nullAs'),
+            $this->copyOptionalStringArgument($fields, 'fields'),
+        );
+    }
+
+    /** @return array<int, string>|false */
+    public function copyToArray(
+        string $tableName,
+        string $separator = "\t",
+        string $nullAs = '\\N',
+        ?string $fields = null,
+    ): array|false {
+        return $this->copyToArrayThroughZtd($tableName, $separator, $nullAs, $fields);
+    }
+
+    /** @param array<mixed>|\Traversable<mixed> $rows */
+    public function pgsqlCopyFromArray(
+        mixed $tableName,
+        array|\Traversable $rows,
+        mixed $separator = "\t",
+        mixed $nullAs = '\\N',
+        mixed $fields = null,
+    ): bool {
+        return $this->copyFromArrayThroughZtd(
+            $this->copyStringArgument($tableName, 'tableName'),
+            $rows,
+            $this->copyStringArgument($separator, 'separator'),
+            $this->copyStringArgument($nullAs, 'nullAs'),
+            $this->copyOptionalStringArgument($fields, 'fields'),
+        );
+    }
+
+    /** @param array<mixed>|\Traversable<mixed> $rows */
+    public function copyFromArray(
+        string $tableName,
+        array|\Traversable $rows,
+        string $separator = "\t",
+        string $nullAs = '\\N',
+        ?string $fields = null,
+    ): bool {
+        return $this->copyFromArrayThroughZtd($tableName, $rows, $separator, $nullAs, $fields);
+    }
+
+    public function pgsqlCopyToFile(
+        mixed $tableName,
+        mixed $filename,
+        mixed $separator = "\t",
+        mixed $nullAs = '\\N',
+        mixed $fields = null,
+    ): bool {
+        return $this->copyToFileThroughZtd(
+            $this->copyStringArgument($tableName, 'tableName'),
+            $this->copyStringArgument($filename, 'filename'),
+            $this->copyStringArgument($separator, 'separator'),
+            $this->copyStringArgument($nullAs, 'nullAs'),
+            $this->copyOptionalStringArgument($fields, 'fields'),
+        );
+    }
+
+    public function copyToFile(
+        string $tableName,
+        string $filename,
+        string $separator = "\t",
+        string $nullAs = '\\N',
+        ?string $fields = null,
+    ): bool {
+        return $this->copyToFileThroughZtd($tableName, $filename, $separator, $nullAs, $fields);
+    }
+
+    public function pgsqlCopyFromFile(
+        mixed $tableName,
+        mixed $filename,
+        mixed $separator = "\t",
+        mixed $nullAs = '\\N',
+        mixed $fields = null,
+    ): bool {
+        return $this->copyFromFileThroughZtd(
+            $this->copyStringArgument($tableName, 'tableName'),
+            $this->copyStringArgument($filename, 'filename'),
+            $this->copyStringArgument($separator, 'separator'),
+            $this->copyStringArgument($nullAs, 'nullAs'),
+            $this->copyOptionalStringArgument($fields, 'fields'),
+        );
+    }
+
+    public function copyFromFile(
+        string $tableName,
+        string $filename,
+        string $separator = "\t",
+        string $nullAs = '\\N',
+        ?string $fields = null,
+    ): bool {
+        return $this->copyFromFileThroughZtd($tableName, $filename, $separator, $nullAs, $fields);
+    }
+
+    /** @return array<int, string>|false */
+    private function copyToArrayThroughZtd(
+        string $tableName,
+        string $separator,
+        string $nullAs,
+        ?string $fields,
+    ): array|false {
+        [$codec, $relation, $columns] = $this->postgreSqlCopyTarget($tableName, $fields);
+        $statement = $this->query(sprintf(
+            'SELECT %s FROM %s',
+            $codec->columnListSql($columns),
+            $relation,
+        ));
+        if ($statement === false) {
+            return false;
+        }
+
+        $rows = [];
+        while (($values = $statement->fetch(PDO::FETCH_NUM)) !== false) {
+            if (!is_array($values)) {
+                throw new ZtdPdoException('PostgreSQL COPY query returned an invalid row.');
+            }
+            $rows[] = $codec->encodeRow(array_values($values), $separator, $nullAs);
+        }
+
+        return $rows;
+    }
+
+    /** @param array<mixed>|\Traversable<mixed> $rows */
+    private function copyFromArrayThroughZtd(
+        string $tableName,
+        array|\Traversable $rows,
+        string $separator,
+        string $nullAs,
+        ?string $fields,
+    ): bool {
+        [$codec, $relation, $columns] = $this->postgreSqlCopyTarget($tableName, $fields);
+        $decodedRows = [];
+        foreach ($rows as $row) {
+            if (!is_string($row)) {
+                throw new \TypeError(sprintf('PostgreSQL COPY rows must be strings, %s given.', get_debug_type($row)));
+            }
+            $decodedRow = $codec->decodeRow($row, $separator, $nullAs);
+            if (count($decodedRow) !== count($columns)) {
+                throw new \ValueError(sprintf(
+                    'PostgreSQL COPY row has %d fields, but %d fields are required.',
+                    count($decodedRow),
+                    count($columns),
+                ));
+            }
+            $decodedRows[] = $decodedRow;
+        }
+        if ($decodedRows === []) {
+            return true;
+        }
+
+        $parameter = 1;
+        $valueRows = [];
+        $parameters = [];
+        foreach ($decodedRows as $parameterValues) {
+            $placeholders = [];
+            foreach ($parameterValues as $value) {
+                $placeholders[] = '$' . $parameter++;
+                $parameters[] = $value;
+            }
+            $valueRows[] = '(' . implode(', ', $placeholders) . ')';
+        }
+
+        $statement = $this->prepare(sprintf(
+            'INSERT INTO %s (%s)%s VALUES %s',
+            $relation,
+            $codec->columnListSql($columns),
+            $this->session->isEnabled() ? '' : ' OVERRIDING SYSTEM VALUE',
+            implode(', ', $valueRows),
+        ));
+
+        return $statement !== false && $statement->execute($parameters);
+    }
+
+    private function copyToFileThroughZtd(
+        string $tableName,
+        string $filename,
+        string $separator,
+        string $nullAs,
+        ?string $fields,
+    ): bool {
+        $rows = $this->copyToArrayThroughZtd($tableName, $separator, $nullAs, $fields);
+        if ($rows === false) {
+            return false;
+        }
+
+        return file_put_contents($filename, implode('', $rows)) !== false;
+    }
+
+    private function copyFromFileThroughZtd(
+        string $tableName,
+        string $filename,
+        string $separator,
+        string $nullAs,
+        ?string $fields,
+    ): bool {
+        $rows = file($filename);
+        if ($rows === false) {
+            return false;
+        }
+
+        return $this->copyFromArrayThroughZtd($tableName, $rows, $separator, $nullAs, $fields);
+    }
+
+    /**
+     * @return array{PostgreSqlCopyCodec, string, list<string>}
+     */
+    private function postgreSqlCopyTarget(string $tableName, ?string $fields): array
+    {
+        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'pgsql') {
+            throw new ZtdPdoException('PostgreSQL COPY methods require the PDO PostgreSQL driver.');
+        }
+
+        $codec = new PostgreSqlCopyCodec();
+        $target = $codec->relation($tableName);
+        $definition = $this->session->tableDefinition($target['name']);
+        if ($definition === null) {
+            throw new ZtdPdoException(sprintf(
+                'PostgreSQL COPY cannot resolve the schema for table "%s".',
+                $target['name'],
+            ));
+        }
+
+        return [$codec, $target['sql'], $codec->columns($fields, $definition)];
+    }
+
+    private function guardRawPostgreSqlCopy(string $sql): void
+    {
+        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql'
+            && SqlTokenStream::tokenize($sql)->firstTopLevelKeyword() === 'COPY'
+        ) {
+            throw new ZtdPdoException(
+                'ZTD Write Protection: Raw PostgreSQL COPY cannot preserve shadow isolation; '
+                . 'use the pgsqlCopyToArray(), pgsqlCopyFromArray(), pgsqlCopyToFile(), or pgsqlCopyFromFile() methods.',
+            );
+        }
+    }
+
+    private function copyStringArgument(mixed $value, string $name): string
+    {
+        if (!is_string($value)) {
+            throw new \TypeError(sprintf('PostgreSQL COPY argument $%s must be a string, %s given.', $name, get_debug_type($value)));
+        }
+
+        return $value;
+    }
+
+    private function copyOptionalStringArgument(mixed $value, string $name): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return $this->copyStringArgument($value, $name);
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
@@ -10,9 +10,10 @@ use ReflectionClass;
 use RuntimeException;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\Exception\DatabaseException;
+use ZtdQuery\Platform\CopySupport;
+use ZtdQuery\Platform\CopyTarget;
 use ZtdQuery\Session;
 use ZtdQuery\Platform\SessionFactory;
-use ZtdQuery\Sql\SqlTokenStream;
 
 /**
  * PDO proxy that enforces ZTD behavior for reads and writes.
@@ -483,12 +484,8 @@ class ZtdPdo extends PDO
         string $nullAs,
         ?string $fields,
     ): array|false {
-        [$codec, $relation, $columns] = $this->postgreSqlCopyTarget($tableName, $fields);
-        $statement = $this->query(sprintf(
-            'SELECT %s FROM %s',
-            $codec->columnListSql($columns),
-            $relation,
-        ));
+        [$copy, $target] = $this->postgreSqlCopyTarget($tableName, $fields);
+        $statement = $this->query($copy->selectSql($target));
         if ($statement === false) {
             return false;
         }
@@ -498,7 +495,7 @@ class ZtdPdo extends PDO
             if (!is_array($values)) {
                 throw new ZtdPdoException('PostgreSQL COPY query returned an invalid row.');
             }
-            $rows[] = $codec->encodeRow(array_values($values), $separator, $nullAs);
+            $rows[] = $copy->encodeRow(array_values($values), $separator, $nullAs);
         }
 
         return $rows;
@@ -512,18 +509,18 @@ class ZtdPdo extends PDO
         string $nullAs,
         ?string $fields,
     ): bool {
-        [$codec, $relation, $columns] = $this->postgreSqlCopyTarget($tableName, $fields);
+        [$copy, $target] = $this->postgreSqlCopyTarget($tableName, $fields);
         $decodedRows = [];
         foreach ($rows as $row) {
             if (!is_string($row)) {
                 throw new \TypeError(sprintf('PostgreSQL COPY rows must be strings, %s given.', get_debug_type($row)));
             }
-            $decodedRow = $codec->decodeRow($row, $separator, $nullAs);
-            if (count($decodedRow) !== count($columns)) {
+            $decodedRow = $copy->decodeRow($row, $separator, $nullAs);
+            if (count($decodedRow) !== count($target->columns)) {
                 throw new \ValueError(sprintf(
                     'PostgreSQL COPY row has %d fields, but %d fields are required.',
                     count($decodedRow),
-                    count($columns),
+                    count($target->columns),
                 ));
             }
             $decodedRows[] = $decodedRow;
@@ -532,24 +529,17 @@ class ZtdPdo extends PDO
             return true;
         }
 
-        $parameter = 1;
-        $valueRows = [];
         $parameters = [];
         foreach ($decodedRows as $parameterValues) {
-            $placeholders = [];
             foreach ($parameterValues as $value) {
-                $placeholders[] = '$' . $parameter++;
                 $parameters[] = $value;
             }
-            $valueRows[] = '(' . implode(', ', $placeholders) . ')';
         }
 
-        $statement = $this->prepare(sprintf(
-            'INSERT INTO %s (%s)%s VALUES %s',
-            $relation,
-            $codec->columnListSql($columns),
-            $this->session->isEnabled() ? '' : ' OVERRIDING SYSTEM VALUE',
-            implode(', ', $valueRows),
+        $statement = $this->prepare($copy->insertSql(
+            $target,
+            count($decodedRows),
+            !$this->session->isEnabled(),
         ));
 
         return $statement !== false && $statement->execute($parameters);
@@ -586,32 +576,29 @@ class ZtdPdo extends PDO
     }
 
     /**
-     * @return array{PostgreSqlCopyCodec, string, list<string>}
+     * @return array{CopySupport, CopyTarget}
      */
     private function postgreSqlCopyTarget(string $tableName, ?string $fields): array
     {
-        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'pgsql') {
+        $copy = $this->session->copySupport();
+        if ($copy === null) {
             throw new ZtdPdoException('PostgreSQL COPY methods require the PDO PostgreSQL driver.');
         }
 
-        $codec = new PostgreSqlCopyCodec();
-        $target = $codec->relation($tableName);
-        $definition = $this->session->tableDefinition($target['name']);
-        if ($definition === null) {
+        $target = $this->session->copyTarget($tableName, $fields);
+        if ($target === null) {
             throw new ZtdPdoException(sprintf(
                 'PostgreSQL COPY cannot resolve the schema for table "%s".',
-                $target['name'],
+                $tableName,
             ));
         }
 
-        return [$codec, $target['sql'], $codec->columns($fields, $definition)];
+        return [$copy, $target];
     }
 
     private function guardRawPostgreSqlCopy(string $sql): void
     {
-        if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql'
-            && SqlTokenStream::tokenize($sql)->firstTopLevelKeyword() === 'COPY'
-        ) {
+        if ($this->session->copySupport()?->isCopyStatement($sql) === true) {
             throw new ZtdPdoException(
                 'ZTD Write Protection: Raw PostgreSQL COPY cannot preserve shadow isolation; '
                 . 'use the pgsqlCopyToArray(), pgsqlCopyFromArray(), pgsqlCopyToFile(), or pgsqlCopyFromFile() methods.',

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/CopyTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/CopyTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+use ZtdQuery\Adapter\Pdo\ZtdPdoException;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class CopyTest extends TestCase
+{
+    public function testCopyArrayAndFileMethodsUseShadowDataWithoutTouchingPhysicalTable(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+        $exportFile = tempnam(sys_get_temp_dir(), 'ztd-copy-export-');
+        $importFile = tempnam(sys_get_temp_dir(), 'ztd-copy-import-');
+        self::assertNotFalse($exportFile);
+        self::assertNotFalse($importFile);
+
+        try {
+            $pdo->exec(
+                'CREATE TABLE copy_target ('
+                . 'id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, '
+                . 'value TEXT NOT NULL, optional TEXT, active BOOLEAN NOT NULL, '
+                . 'generated_value TEXT GENERATED ALWAYS AS (upper(value)) STORED)'
+            );
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            self::assertTrue($ztdPdo->pgsqlCopyFromArray(
+                'copy_target',
+                ["1|a\\|b|\\N|t\n", "2|line\\nfeed|text|f\n"],
+                '|',
+                '\\N',
+                'id, value, optional, active',
+            ));
+            self::assertTrue($ztdPdo->copyFromArray(
+                'copy_target',
+                new \ArrayIterator(["3|iterator|value|t\n"]),
+                '|',
+                '\\N',
+                'id, value, optional, active',
+            ));
+
+            $rows = $ztdPdo->query(
+                'SELECT id, value, optional, active, generated_value FROM copy_target ORDER BY id',
+            );
+            self::assertNotFalse($rows);
+            self::assertSame([
+                ['id' => 1, 'value' => 'a|b', 'optional' => null, 'active' => true, 'generated_value' => 'A|B'],
+                ['id' => 2, 'value' => "line\nfeed", 'optional' => 'text', 'active' => false, 'generated_value' => "LINE\nFEED"],
+                ['id' => 3, 'value' => 'iterator', 'optional' => 'value', 'active' => true, 'generated_value' => 'ITERATOR'],
+            ], $rows->fetchAll(PDO::FETCH_ASSOC));
+
+            $exported = $ztdPdo->pgsqlCopyToArray(
+                'copy_target',
+                '|',
+                'NULL',
+                'id, value, optional, active',
+            );
+            self::assertSame([
+                "1|a\\|b|NULL|t\n",
+                "2|line\\nfeed|text|f\n",
+                "3|iterator|value|t\n",
+            ], $exported);
+            self::assertTrue($ztdPdo->copyToFile(
+                'copy_target',
+                $exportFile,
+                '|',
+                'NULL',
+                'id, value, optional, active',
+            ));
+            self::assertSame(implode('', $exported), file_get_contents($exportFile));
+            self::assertTrue($ztdPdo->pgsqlCopyToFile(
+                'copy_target',
+                $exportFile,
+                '|',
+                'NULL',
+                'id, value, optional, active',
+            ));
+
+            self::assertSame(17, file_put_contents($importFile, "4|from-file|\\N|f\n"));
+            self::assertTrue($ztdPdo->pgsqlCopyFromFile(
+                'copy_target',
+                $importFile,
+                '|',
+                '\\N',
+                'id, value, optional, active',
+            ));
+            $afterFileImport = $ztdPdo->copyToArray(
+                'copy_target',
+                fields: 'id, value, optional, active',
+            );
+            self::assertNotFalse($afterFileImport);
+            self::assertSame(["4\tfrom-file\t\\N\tf\n"], array_slice($afterFileImport, -1));
+            self::assertSame(0, file_put_contents($importFile, ''));
+            self::assertTrue($ztdPdo->copyFromFile(
+                'copy_target',
+                $importFile,
+                fields: 'id, value, optional, active',
+            ));
+
+            $physical = $pdo->query('SELECT COUNT(*) FROM copy_target');
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            unlink($exportFile);
+            unlink($importFile);
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+
+    public function testRawCopyIsRejectedExplicitlyAndMalformedRowsAreAtomic(): void
+    {
+        [$schemaName, $pdo] = PostgreSqlContainer::createTestSchema();
+
+        try {
+            $pdo->exec('CREATE TABLE copy_target (id INTEGER PRIMARY KEY, value TEXT NOT NULL)');
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            try {
+                $ztdPdo->exec('COPY copy_target FROM STDIN');
+                self::fail('Expected raw COPY to be rejected.');
+            } catch (ZtdPdoException $exception) {
+                self::assertStringContainsString('pgsqlCopyFromArray()', $exception->getMessage());
+            }
+
+            try {
+                $ztdPdo->pgsqlCopyFromArray('copy_target', ["1\tvalid\n", "2\n"]);
+                self::fail('Expected a malformed COPY row to be rejected.');
+            } catch (\ValueError $exception) {
+                self::assertStringContainsString('2 fields are required', $exception->getMessage());
+            }
+
+            $shadow = $ztdPdo->query('SELECT * FROM copy_target');
+            self::assertNotFalse($shadow);
+            self::assertSame([], $shadow->fetchAll(PDO::FETCH_ASSOC));
+            $physical = $pdo->query('SELECT COUNT(*) FROM copy_target');
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $pdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterBinderTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterBinderTest.php
@@ -10,11 +10,10 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\PdoParameterBinder;
 use ZtdQuery\Adapter\Pdo\PdoParameterType;
-use ZtdQuery\Adapter\Pdo\PostgreSqlPlaceholderEscaper;
+use ZtdQuery\Platform\SqlPlaceholderEscaper;
 
 #[CoversClass(PdoParameterBinder::class)]
 #[UsesClass(PdoParameterType::class)]
-#[UsesClass(PostgreSqlPlaceholderEscaper::class)]
 final class PdoParameterBinderTest extends TestCase
 {
     public function testMapsNativePostgreSqlPositionsWithoutTouchingQuotedText(): void
@@ -23,6 +22,12 @@ final class PdoParameterBinderTest extends TestCase
             'SELECT $2, $1, $2, \'$3\' FROM docs WHERE meta ? $1 -- $4',
             'pgsql',
             ['first', 'second'],
+            new class () implements SqlPlaceholderEscaper {
+                public function escape(string $sql): string
+                {
+                    return str_replace('meta ? ', 'meta ?? ', $sql);
+                }
+            },
         );
 
         self::assertSame(

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PostgreSqlCopyCodecTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PostgreSqlCopyCodecTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\PostgreSqlCopyCodec;
+use ZtdQuery\Schema\TableDefinition;
+
+#[CoversClass(PostgreSqlCopyCodec::class)]
+final class PostgreSqlCopyCodecTest extends TestCase
+{
+    public function testRelationParsesAndQuotesOnlyPostgreSqlIdentifiers(): void
+    {
+        $codec = new PostgreSqlCopyCodec();
+
+        self::assertSame(['name' => 'users', 'sql' => '"public"."users"'], $codec->relation('PUBLIC.Users'));
+        self::assertSame(['name' => 'Odd.Table', 'sql' => '"Odd Schema"."Odd.Table"'], $codec->relation('"Odd Schema"."Odd.Table"'));
+
+        $this->expectException(\ValueError::class);
+        $codec->relation('users; DELETE FROM users');
+    }
+
+    public function testRelationRequotesEmbeddedIdentifierQuotes(): void
+    {
+        self::assertSame(
+            ['name' => 'a"b', 'sql' => '"a""b"'],
+            (new PostgreSqlCopyCodec())->relation('"a""b"'),
+        );
+    }
+
+    #[DataProvider('providerInvalidRelation')]
+    public function testRelationRejectsInvalidStructure(string $relation): void
+    {
+        $this->expectException(\ValueError::class);
+
+        (new PostgreSqlCopyCodec())->relation($relation);
+    }
+
+    public function testColumnsExcludeGeneratedColumnsAndParseExplicitFields(): void
+    {
+        $codec = new PostgreSqlCopyCodec();
+        $definition = new TableDefinition(
+            ['id', 'display_name', 'computed'],
+            ['id' => 'INTEGER', 'display_name' => 'TEXT', 'computed' => 'TEXT'],
+            ['id'],
+            ['id'],
+            [],
+            generatedExpressions: ['computed' => 'display_name'],
+        );
+
+        self::assertSame(['id', 'display_name'], $codec->columns(null, $definition));
+        self::assertSame(['id', 'Display Name'], $codec->columns('ID, "Display Name"', $definition));
+        self::assertSame('"id", "Display Name"', $codec->columnListSql(['id', 'Display Name']));
+    }
+
+    #[DataProvider('providerInvalidFields')]
+    public function testColumnsRejectInvalidFieldLists(string $fields): void
+    {
+        $this->expectException(\ValueError::class);
+
+        (new PostgreSqlCopyCodec())->columns(
+            $fields,
+            new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], ['id'], []),
+        );
+    }
+
+    public function testColumnListRejectsTablesWithoutWritableColumns(): void
+    {
+        $this->expectException(\ValueError::class);
+
+        (new PostgreSqlCopyCodec())->columnListSql([]);
+    }
+
+    public function testEncodeRowUsesPostgreSqlTextEscapesAndNativeScalarOutput(): void
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+        self::assertSame(2, fwrite($stream, "\0\xff"));
+        rewind($stream);
+
+        $row = (new PostgreSqlCopyCodec())->encodeRow(
+            ["a\tb\nc\\d", null, true, false, $stream],
+            '|',
+            '\\N',
+        );
+
+        self::assertSame("a\\tb\\nc\\\\d|\\N|t|f|\\\\x00ff\n", $row);
+    }
+
+    public function testEncodeRowEscapesEveryPostgreSqlControlAndDelimiter(): void
+    {
+        self::assertSame(
+            "\\b\\f\\n\\r\\t\\v\\\\\\|\n",
+            (new PostgreSqlCopyCodec())->encodeRow(["\x08\x0C\n\r\t\x0B\\|"], '|', '\\N'),
+        );
+        self::assertSame(
+            "7|1.5\n",
+            (new PostgreSqlCopyCodec())->encodeRow([7, 1.5], '|', '\\N'),
+        );
+    }
+
+    public function testEncodeRowRejectsUnsupportedValues(): void
+    {
+        $this->expectException(\ValueError::class);
+
+        (new PostgreSqlCopyCodec())->encodeRow([new \stdClass()], '|', '\\N');
+    }
+
+    public function testEncodeRowValidatesSeparator(): void
+    {
+        $this->expectException(\ValueError::class);
+
+        (new PostgreSqlCopyCodec())->encodeRow(['value'], '', '\\N');
+    }
+
+    public function testDecodeRowHonorsNullBeforeEscapesAndSupportsByteEscapes(): void
+    {
+        $values = (new PostgreSqlCopyCodec())->decodeRow(
+            "\\N|\\\\N|a\\|b|line\\nfeed|\\101\\x42\r\n",
+            '|',
+            '\\N',
+        );
+
+        self::assertSame([null, '\\N', 'a|b', "line\nfeed", 'AB'], $values);
+    }
+
+    public function testDecodeRowSupportsEveryControlUnknownAndVariableLengthByteEscape(): void
+    {
+        $codec = new PostgreSqlCopyCodec();
+
+        self::assertSame(
+            ["\x08\x0C\n\r\t\x0B\\|q"],
+            $codec->decodeRow('\\b\\f\\n\\r\\t\\v\\\\\\|\\q', '|', '\\N'),
+        );
+        self::assertSame(
+            ["\0", "\x07", "\n", 'A4', "\x04", 'O', 'Oa'],
+            $codec->decodeRow('\\0|\\7|\\12|\\1014|\\x4|\\x4F|\\x4Fa', '|', '\\N'),
+        );
+        self::assertSame(['S', 'tail'], $codec->decodeRow('\\1232tail', '2', '\\N'));
+    }
+
+    #[DataProvider('providerLineEnding')]
+    public function testDecodeRowAcceptsEverySupportedLineEnding(string $lineEnding): void
+    {
+        self::assertSame(['value'], (new PostgreSqlCopyCodec())->decodeRow('value' . $lineEnding, '|', '\\N'));
+    }
+
+    #[DataProvider('providerInvalidRow')]
+    public function testDecodeRowRejectsMalformedRecords(string $row): void
+    {
+        $this->expectException(\ValueError::class);
+
+        (new PostgreSqlCopyCodec())->decodeRow($row, '|', '\\N');
+    }
+
+    public function testDecodeRowPreservesEmptyFields(): void
+    {
+        self::assertSame(['', ''], (new PostgreSqlCopyCodec())->decodeRow('|', '|', '\\N'));
+    }
+
+    public function testSeparatorMustBeExactlyOneByte(): void
+    {
+        $this->expectException(\ValueError::class);
+
+        (new PostgreSqlCopyCodec())->decodeRow('value', '||', '\\N');
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function providerInvalidRelation(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'trailing qualifier' => ['users.'];
+        yield 'operator' => ['users+other'];
+        yield 'too many qualifiers' => ['catalog.public.users'];
+        yield 'non-identifier' => ['*'];
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function providerInvalidFields(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'trailing comma' => ['id,'];
+        yield 'expression' => ['id + value'];
+        yield 'duplicate' => ['id, id'];
+        yield 'non-identifier' => ['*'];
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function providerLineEnding(): iterable
+    {
+        yield 'none' => [''];
+        yield 'line feed' => ["\n"];
+        yield 'carriage return' => ["\r"];
+        yield 'carriage return and line feed' => ["\r\n"];
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function providerInvalidRow(): iterable
+    {
+        yield 'unescaped line feed' => ["first\nsecond"];
+        yield 'unescaped carriage return' => ["first\rsecond"];
+        yield 'incomplete escape' => ['value\\'];
+        yield 'end marker' => ['\\.'];
+        yield 'octal overflow' => ['\\400'];
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PostgreSqlCopyCodecTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PostgreSqlCopyCodecTest.php
@@ -32,6 +32,14 @@ final class PostgreSqlCopyCodecTest extends TestCase
         );
     }
 
+    public function testRelationRejectsEmptyQualifierWithSpecificReason(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('must not contain an empty qualifier component');
+
+        (new PostgreSqlCopyCodec())->relation('users.');
+    }
+
     #[DataProvider('providerInvalidRelation')]
     public function testRelationRejectsInvalidStructure(string $relation): void
     {
@@ -141,6 +149,18 @@ final class PostgreSqlCopyCodecTest extends TestCase
             $codec->decodeRow('\\0|\\7|\\12|\\1014|\\x4|\\x4F|\\x4Fa', '|', '\\N'),
         );
         self::assertSame(['S', 'tail'], $codec->decodeRow('\\1232tail', '2', '\\N'));
+        self::assertSame(
+            ['prefixN', 'octal-A', 'hex-A'],
+            $codec->decodeRow('prefix\\N|octal-\\101|hex-\\x41', '|', '\\N'),
+        );
+        self::assertSame(
+            ["\xff", '?', "\0", "\xff"],
+            $codec->decodeRow('\\377|\\77|\\x0|\\xff', '|', '\\N'),
+        );
+        self::assertSame(["\x01/"], $codec->decodeRow('\\1/', '|', '\\N'));
+        self::assertSame([null], $codec->decodeRow('prefix\\101', '|', 'prefix\\101'));
+        self::assertSame([null], $codec->decodeRow('prefix\\x41', '|', 'prefix\\x41'));
+        self::assertSame(['value', null, 'tail'], $codec->decodeRow('value|NULL|tail', '|', 'NULL'));
     }
 
     #[DataProvider('providerLineEnding')]

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
@@ -64,6 +64,7 @@ final class ClassifyTarget
             fn (): string => $this->provider->tableSampleStatement(),
             fn (): string => $this->provider->doStatement(),
             fn (): string => $this->provider->mergeStatement(),
+            fn (): string => $this->provider->copyStatement(maxDepth: 8),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -148,6 +148,7 @@ final class RewriteTarget
             fn (): string => $this->provider->tableSampleStatement(),
             fn (): string => $this->provider->doStatement(),
             fn (): string => $this->provider->mergeStatement(),
+            fn (): string => $this->provider->copyStatement(maxDepth: 8),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
@@ -192,6 +192,7 @@ final class RobustnessTarget
             fn (): string => $this->provider->tableSampleStatement(),
             fn (): string => $this->provider->doStatement(),
             fn (): string => $this->provider->mergeStatement(),
+            fn (): string => $this->provider->copyStatement(maxDepth: 8),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlCopySupport.php
+++ b/packages/ztd-query-postgres/src/PgSqlCopySupport.php
@@ -2,17 +2,75 @@
 
 declare(strict_types=1);
 
-namespace ZtdQuery\Adapter\Pdo;
+namespace ZtdQuery\Platform\Postgres;
 
+use ZtdQuery\Platform\CopySupport;
+use ZtdQuery\Platform\CopyTarget;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Sql\SqlToken;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
-final class PostgreSqlCopyCodec
+final class PgSqlCopySupport implements CopySupport
 {
-    /** @return array{name: string, sql: string} */
-    public function relation(string $tableName): array
+    public function tableName(string $relation): string
+    {
+        $parts = $this->relationParts($relation);
+
+        return $parts[count($parts) - 1];
+    }
+
+    public function target(string $relation, ?string $fields, TableDefinition $definition): CopyTarget
+    {
+        $columns = $this->columns($fields, $definition);
+        if ($columns === []) {
+            throw new \ValueError('PostgreSQL COPY requires at least one non-generated column.');
+        }
+
+        return new CopyTarget($this->relationParts($relation), $columns);
+    }
+
+    public function selectSql(CopyTarget $target): string
+    {
+        return sprintf(
+            'SELECT %s FROM %s',
+            $this->columnListSql($target->columns),
+            $this->relationSql($target),
+        );
+    }
+
+    public function insertSql(CopyTarget $target, int $rowCount, bool $overrideSystemValue): string
+    {
+        if ($rowCount < 1) {
+            throw new \ValueError('PostgreSQL COPY INSERT requires at least one row.');
+        }
+
+        $parameter = 1;
+        $valueRows = [];
+        for ($row = 0; $row < $rowCount; $row++) {
+            $placeholders = [];
+            foreach ($target->columns as $_column) {
+                $placeholders[] = '$' . $parameter++;
+            }
+            $valueRows[] = '(' . implode(', ', $placeholders) . ')';
+        }
+
+        return sprintf(
+            'INSERT INTO %s (%s)%s VALUES %s',
+            $this->relationSql($target),
+            $this->columnListSql($target->columns),
+            $overrideSystemValue ? ' OVERRIDING SYSTEM VALUE' : '',
+            implode(', ', $valueRows),
+        );
+    }
+
+    public function isCopyStatement(string $sql): bool
+    {
+        return SqlTokenStream::tokenize($sql)->firstTopLevelKeyword() === 'COPY';
+    }
+
+    /** @return non-empty-list<string> */
+    private function relationParts(string $tableName): array
     {
         $parts = SqlTokenStream::tokenize($tableName)->splitTopLevel('.');
         if ($parts === []) {
@@ -34,14 +92,11 @@ final class PostgreSqlCopyCodec
             $components[] = $this->identifier($tokens[0], 'table name');
         }
 
-        return [
-            'name' => $components[count($components) - 1],
-            'sql' => implode('.', array_map($this->quoteIdentifier(...), $components)),
-        ];
+        return $components;
     }
 
     /** @return list<string> */
-    public function columns(?string $fields, TableDefinition $definition): array
+    private function columns(?string $fields, TableDefinition $definition): array
     {
         if ($fields === null) {
             $columns = [];
@@ -75,14 +130,15 @@ final class PostgreSqlCopyCodec
         return $columns;
     }
 
-    /** @param list<string> $columns */
-    public function columnListSql(array $columns): string
+    /** @param non-empty-list<string> $columns */
+    private function columnListSql(array $columns): string
     {
-        if ($columns === []) {
-            throw new \ValueError('PostgreSQL COPY requires at least one non-generated column.');
-        }
-
         return implode(', ', array_map($this->quoteIdentifier(...), $columns));
+    }
+
+    private function relationSql(CopyTarget $target): string
+    {
+        return implode('.', array_map($this->quoteIdentifier(...), $target->relation));
     }
 
     /** @param list<mixed> $values */

--- a/packages/ztd-query-postgres/src/PgSqlPdoPlaceholderEscaper.php
+++ b/packages/ztd-query-postgres/src/PgSqlPdoPlaceholderEscaper.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
-namespace ZtdQuery\Adapter\Pdo;
+namespace ZtdQuery\Platform\Postgres;
 
-final class PostgreSqlPlaceholderEscaper
+use ZtdQuery\Platform\SqlPlaceholderEscaper;
+
+final class PgSqlPdoPlaceholderEscaper implements SqlPlaceholderEscaper
 {
-    public static function escape(string $sql): string
+    public function escape(string $sql): string
     {
         $result = '';
         $length = strlen($sql);

--- a/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
+++ b/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
@@ -73,8 +73,10 @@ final class PgSqlSessionFactory implements SessionFactory
             new ResultSelectRunner(),
             $config,
             $connection,
-            new ShadowTransactionManager($shadowStore, $registry),
-            $registry,
+            transactions: new ShadowTransactionManager($shadowStore, $registry),
+            registry: $registry,
+            copySupport: new PgSqlCopySupport(),
+            sqlPlaceholderEscaper: new PgSqlPdoPlaceholderEscaper(),
         );
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCopySupportTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCopySupportTest.php
@@ -6,14 +6,12 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\CopyTarget;
 use ZtdQuery\Platform\Postgres\PgSqlCopySupport;
 use ZtdQuery\Schema\TableDefinition;
 
 #[CoversClass(PgSqlCopySupport::class)]
-#[UsesClass(CopyTarget::class)]
 final class PgSqlCopySupportTest extends TestCase
 {
     public function testTargetParsesRelationsAndRendersPostgreSqlStatements(): void
@@ -87,6 +85,30 @@ final class PgSqlCopySupportTest extends TestCase
         $target = $codec->target('items', 'ID, "Display Name"', $definition);
         self::assertSame(['id', 'Display Name'], $target->columns);
         self::assertSame('SELECT "id", "Display Name" FROM "items"', $codec->selectSql($target));
+    }
+
+    public function testColumnsRejectAnEmptyFieldList(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('PostgreSQL COPY fields must contain at least one column identifier.');
+
+        (new PgSqlCopySupport())->target(
+            'items',
+            '',
+            new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], ['id'], []),
+        );
+    }
+
+    public function testColumnsRejectATrailingFieldDelimiter(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('PostgreSQL COPY fields must contain at least one column identifier.');
+
+        (new PgSqlCopySupport())->target(
+            'items',
+            'id,',
+            new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], ['id'], []),
+        );
     }
 
     #[DataProvider('providerInvalidFields')]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCopySupportTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCopySupportTest.php
@@ -6,29 +6,52 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
-use ZtdQuery\Adapter\Pdo\PostgreSqlCopyCodec;
+use ZtdQuery\Platform\CopyTarget;
+use ZtdQuery\Platform\Postgres\PgSqlCopySupport;
 use ZtdQuery\Schema\TableDefinition;
 
-#[CoversClass(PostgreSqlCopyCodec::class)]
-final class PostgreSqlCopyCodecTest extends TestCase
+#[CoversClass(PgSqlCopySupport::class)]
+#[UsesClass(CopyTarget::class)]
+final class PgSqlCopySupportTest extends TestCase
 {
-    public function testRelationParsesAndQuotesOnlyPostgreSqlIdentifiers(): void
+    public function testTargetParsesRelationsAndRendersPostgreSqlStatements(): void
     {
-        $codec = new PostgreSqlCopyCodec();
+        $support = new PgSqlCopySupport();
+        $definition = new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], ['id'], []);
+        $target = $support->target('PUBLIC.Users', null, $definition);
 
-        self::assertSame(['name' => 'users', 'sql' => '"public"."users"'], $codec->relation('PUBLIC.Users'));
-        self::assertSame(['name' => 'Odd.Table', 'sql' => '"Odd Schema"."Odd.Table"'], $codec->relation('"Odd Schema"."Odd.Table"'));
+        self::assertSame(['public', 'users'], $target->relation);
+        self::assertSame('users', $target->tableName());
+        self::assertSame('SELECT "id" FROM "public"."users"', $support->selectSql($target));
+        self::assertSame(
+            'INSERT INTO "public"."users" ("id") VALUES ($1), ($2)',
+            $support->insertSql($target, 2, false),
+        );
+        self::assertSame(
+            'INSERT INTO "public"."users" ("id") OVERRIDING SYSTEM VALUE VALUES ($1)',
+            $support->insertSql($target, 1, true),
+        );
+        self::assertTrue($support->isCopyStatement('COPY users FROM STDIN'));
+        self::assertFalse($support->isCopyStatement('SELECT * FROM users'));
 
         $this->expectException(\ValueError::class);
-        $codec->relation('users; DELETE FROM users');
+        $support->tableName('users; DELETE FROM users');
     }
 
     public function testRelationRequotesEmbeddedIdentifierQuotes(): void
     {
+        $support = new PgSqlCopySupport();
+        $target = $support->target(
+            '"Odd Schema"."a""b"',
+            null,
+            new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], ['id'], []),
+        );
+
         self::assertSame(
-            ['name' => 'a"b', 'sql' => '"a""b"'],
-            (new PostgreSqlCopyCodec())->relation('"a""b"'),
+            'SELECT "id" FROM "Odd Schema"."a""b"',
+            $support->selectSql($target),
         );
     }
 
@@ -37,7 +60,7 @@ final class PostgreSqlCopyCodecTest extends TestCase
         $this->expectException(\ValueError::class);
         $this->expectExceptionMessage('must not contain an empty qualifier component');
 
-        (new PostgreSqlCopyCodec())->relation('users.');
+        (new PgSqlCopySupport())->tableName('users.');
     }
 
     #[DataProvider('providerInvalidRelation')]
@@ -45,12 +68,12 @@ final class PostgreSqlCopyCodecTest extends TestCase
     {
         $this->expectException(\ValueError::class);
 
-        (new PostgreSqlCopyCodec())->relation($relation);
+        (new PgSqlCopySupport())->tableName($relation);
     }
 
     public function testColumnsExcludeGeneratedColumnsAndParseExplicitFields(): void
     {
-        $codec = new PostgreSqlCopyCodec();
+        $codec = new PgSqlCopySupport();
         $definition = new TableDefinition(
             ['id', 'display_name', 'computed'],
             ['id' => 'INTEGER', 'display_name' => 'TEXT', 'computed' => 'TEXT'],
@@ -60,9 +83,10 @@ final class PostgreSqlCopyCodecTest extends TestCase
             generatedExpressions: ['computed' => 'display_name'],
         );
 
-        self::assertSame(['id', 'display_name'], $codec->columns(null, $definition));
-        self::assertSame(['id', 'Display Name'], $codec->columns('ID, "Display Name"', $definition));
-        self::assertSame('"id", "Display Name"', $codec->columnListSql(['id', 'Display Name']));
+        self::assertSame(['id', 'display_name'], $codec->target('items', null, $definition)->columns);
+        $target = $codec->target('items', 'ID, "Display Name"', $definition);
+        self::assertSame(['id', 'Display Name'], $target->columns);
+        self::assertSame('SELECT "id", "Display Name" FROM "items"', $codec->selectSql($target));
     }
 
     #[DataProvider('providerInvalidFields')]
@@ -70,7 +94,8 @@ final class PostgreSqlCopyCodecTest extends TestCase
     {
         $this->expectException(\ValueError::class);
 
-        (new PostgreSqlCopyCodec())->columns(
+        (new PgSqlCopySupport())->target(
+            'items',
             $fields,
             new TableDefinition(['id'], ['id' => 'INTEGER'], ['id'], ['id'], []),
         );
@@ -80,7 +105,26 @@ final class PostgreSqlCopyCodecTest extends TestCase
     {
         $this->expectException(\ValueError::class);
 
-        (new PostgreSqlCopyCodec())->columnListSql([]);
+        (new PgSqlCopySupport())->target(
+            'items',
+            null,
+            new TableDefinition(
+                ['computed'],
+                ['computed' => 'INTEGER'],
+                [],
+                [],
+                [],
+                generatedExpressions: ['computed' => '1'],
+            ),
+        );
+    }
+
+    public function testInsertSqlRejectsAnEmptyBatch(): void
+    {
+        $this->expectException(\ValueError::class);
+
+        $support = new PgSqlCopySupport();
+        $support->insertSql(new CopyTarget(['items'], ['id']), 0, false);
     }
 
     public function testEncodeRowUsesPostgreSqlTextEscapesAndNativeScalarOutput(): void
@@ -90,7 +134,7 @@ final class PostgreSqlCopyCodecTest extends TestCase
         self::assertSame(2, fwrite($stream, "\0\xff"));
         rewind($stream);
 
-        $row = (new PostgreSqlCopyCodec())->encodeRow(
+        $row = (new PgSqlCopySupport())->encodeRow(
             ["a\tb\nc\\d", null, true, false, $stream],
             '|',
             '\\N',
@@ -103,11 +147,11 @@ final class PostgreSqlCopyCodecTest extends TestCase
     {
         self::assertSame(
             "\\b\\f\\n\\r\\t\\v\\\\\\|\n",
-            (new PostgreSqlCopyCodec())->encodeRow(["\x08\x0C\n\r\t\x0B\\|"], '|', '\\N'),
+            (new PgSqlCopySupport())->encodeRow(["\x08\x0C\n\r\t\x0B\\|"], '|', '\\N'),
         );
         self::assertSame(
             "7|1.5\n",
-            (new PostgreSqlCopyCodec())->encodeRow([7, 1.5], '|', '\\N'),
+            (new PgSqlCopySupport())->encodeRow([7, 1.5], '|', '\\N'),
         );
     }
 
@@ -115,19 +159,19 @@ final class PostgreSqlCopyCodecTest extends TestCase
     {
         $this->expectException(\ValueError::class);
 
-        (new PostgreSqlCopyCodec())->encodeRow([new \stdClass()], '|', '\\N');
+        (new PgSqlCopySupport())->encodeRow([new \stdClass()], '|', '\\N');
     }
 
     public function testEncodeRowValidatesSeparator(): void
     {
         $this->expectException(\ValueError::class);
 
-        (new PostgreSqlCopyCodec())->encodeRow(['value'], '', '\\N');
+        (new PgSqlCopySupport())->encodeRow(['value'], '', '\\N');
     }
 
     public function testDecodeRowHonorsNullBeforeEscapesAndSupportsByteEscapes(): void
     {
-        $values = (new PostgreSqlCopyCodec())->decodeRow(
+        $values = (new PgSqlCopySupport())->decodeRow(
             "\\N|\\\\N|a\\|b|line\\nfeed|\\101\\x42\r\n",
             '|',
             '\\N',
@@ -138,7 +182,7 @@ final class PostgreSqlCopyCodecTest extends TestCase
 
     public function testDecodeRowSupportsEveryControlUnknownAndVariableLengthByteEscape(): void
     {
-        $codec = new PostgreSqlCopyCodec();
+        $codec = new PgSqlCopySupport();
 
         self::assertSame(
             ["\x08\x0C\n\r\t\x0B\\|q"],
@@ -166,7 +210,7 @@ final class PostgreSqlCopyCodecTest extends TestCase
     #[DataProvider('providerLineEnding')]
     public function testDecodeRowAcceptsEverySupportedLineEnding(string $lineEnding): void
     {
-        self::assertSame(['value'], (new PostgreSqlCopyCodec())->decodeRow('value' . $lineEnding, '|', '\\N'));
+        self::assertSame(['value'], (new PgSqlCopySupport())->decodeRow('value' . $lineEnding, '|', '\\N'));
     }
 
     #[DataProvider('providerInvalidRow')]
@@ -174,19 +218,19 @@ final class PostgreSqlCopyCodecTest extends TestCase
     {
         $this->expectException(\ValueError::class);
 
-        (new PostgreSqlCopyCodec())->decodeRow($row, '|', '\\N');
+        (new PgSqlCopySupport())->decodeRow($row, '|', '\\N');
     }
 
     public function testDecodeRowPreservesEmptyFields(): void
     {
-        self::assertSame(['', ''], (new PostgreSqlCopyCodec())->decodeRow('|', '|', '\\N'));
+        self::assertSame(['', ''], (new PgSqlCopySupport())->decodeRow('|', '|', '\\N'));
     }
 
     public function testSeparatorMustBeExactlyOneByte(): void
     {
         $this->expectException(\ValueError::class);
 
-        (new PostgreSqlCopyCodec())->decodeRow('value', '||', '\\N');
+        (new PgSqlCopySupport())->decodeRow('value', '||', '\\N');
     }
 
     /** @return iterable<string, array{string}> */

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPdoPlaceholderEscaperTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPdoPlaceholderEscaperTest.php
@@ -7,10 +7,10 @@ namespace Tests\Unit;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use ZtdQuery\Adapter\Pdo\PostgreSqlPlaceholderEscaper;
+use ZtdQuery\Platform\Postgres\PgSqlPdoPlaceholderEscaper;
 
-#[CoversClass(PostgreSqlPlaceholderEscaper::class)]
-final class PostgreSqlPlaceholderEscaperTest extends TestCase
+#[CoversClass(PgSqlPdoPlaceholderEscaper::class)]
+final class PgSqlPdoPlaceholderEscaperTest extends TestCase
 {
     public function testEscapesPostgreSqlJsonExistenceOperators(): void
     {
@@ -18,7 +18,7 @@ final class PostgreSqlPlaceholderEscaperTest extends TestCase
 
         self::assertSame(
             "SELECT meta ?? 'reviewed', meta ??| array['author', 'reviewed'], meta ??& array['author', 'reviewed'] FROM docs",
-            PostgreSqlPlaceholderEscaper::escape($sql),
+            (new PgSqlPdoPlaceholderEscaper())->escape($sql),
         );
     }
 
@@ -26,7 +26,7 @@ final class PostgreSqlPlaceholderEscaperTest extends TestCase
     {
         $sql = 'SELECT ? FROM docs WHERE id = ? AND score BETWEEN ? AND ? ORDER BY ? LIMIT ? OFFSET ?';
 
-        self::assertSame($sql, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($sql, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     public function testDistinguishesJsonOperatorFromItsPlaceholderOperand(): void
@@ -35,7 +35,7 @@ final class PostgreSqlPlaceholderEscaperTest extends TestCase
 
         self::assertSame(
             'SELECT * FROM docs WHERE meta ?? ? AND details ?? :key AND id = ?',
-            PostgreSqlPlaceholderEscaper::escape($sql),
+            (new PgSqlPdoPlaceholderEscaper())->escape($sql),
         );
     }
 
@@ -45,7 +45,7 @@ final class PostgreSqlPlaceholderEscaperTest extends TestCase
 
         self::assertSame(
             "SELECT '?' AS literal, \"?\" FROM docs -- ?\nWHERE body = \$tag\$?\$tag\$ AND meta ?? 'key' /* ? */",
-            PostgreSqlPlaceholderEscaper::escape($sql),
+            (new PgSqlPdoPlaceholderEscaper())->escape($sql),
         );
     }
 
@@ -53,49 +53,49 @@ final class PostgreSqlPlaceholderEscaperTest extends TestCase
     {
         $sql = "SELECT * FROM docs WHERE meta ?? ? AND id = \$1 AND note = E'question\\'? mark'";
 
-        self::assertSame($sql, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($sql, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     #[DataProvider('providerQuestionMarkBoundaries')]
     public function testHandlesQuestionMarkBoundaries(string $sql, string $expected): void
     {
-        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($expected, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     #[DataProvider('providerCommentForms')]
     public function testPreservesQuestionMarksInCommentForms(string $sql, string $expected): void
     {
-        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($expected, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     #[DataProvider('providerQuotedForms')]
     public function testPreservesQuestionMarksInQuotedForms(string $sql, string $expected): void
     {
-        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($expected, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     #[DataProvider('providerDollarQuotedStringsAndNativeParameters')]
     public function testPreservesDollarQuotedStringsAndNativeParameters(string $sql, string $expected): void
     {
-        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($expected, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     #[DataProvider('providerOperands')]
     public function testTracksNamedParametersIdentifiersAndNumbersAsOperands(string $sql, string $expected): void
     {
-        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($expected, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     #[DataProvider('providerKeywords')]
     public function testKeywordsRequireAFollowingOperand(string $sql): void
     {
-        self::assertSame($sql, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($sql, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     #[DataProvider('providerPunctuation')]
     public function testPunctuationDeterminesWhetherAnOperandFollows(string $sql, string $expected): void
     {
-        self::assertSame($expected, PostgreSqlPlaceholderEscaper::escape($sql));
+        self::assertSame($expected, (new PgSqlPdoPlaceholderEscaper())->escape($sql));
     }
 
     /**

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -16,9 +16,11 @@ use ZtdQuery\Session;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
+use ZtdQuery\Platform\Postgres\PgSqlCopySupport;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 use ZtdQuery\Platform\Postgres\PgSqlMutationResolver;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
+use ZtdQuery\Platform\Postgres\PgSqlPdoPlaceholderEscaper;
 use ZtdQuery\Platform\Postgres\PgSqlQueryGuard;
 use ZtdQuery\Platform\Postgres\PgSqlRewriter;
 use ZtdQuery\Platform\Postgres\PgSqlSchemaParser;
@@ -44,6 +46,8 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(PgSqlTransformer::class)]
 #[UsesClass(PgSqlSchemaReflector::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
+#[UsesClass(PgSqlCopySupport::class)]
+#[UsesClass(PgSqlPdoPlaceholderEscaper::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
 #[UsesClass(SelectTransformer::class)]
@@ -174,6 +178,8 @@ final class PgSqlSessionFactoryTest extends TestCase
         $session = $factory->create($connection, ZtdConfig::default());
 
         self::assertInstanceOf(Session::class, $session);
+        self::assertInstanceOf(PgSqlCopySupport::class, $session->copySupport());
+        self::assertInstanceOf(PgSqlPdoPlaceholderEscaper::class, $session->sqlPlaceholderEscaper());
     }
 
     public function testCreatedSessionIsEnabledByDefault(): void


### PR DESCRIPTION
Stacked on #260.

## Summary

This change routes PostgreSQL PDO COPY array and file operations through the ZTD shadow store, rejects unsafe raw COPY while ZTD is active, and adds a structural COPY text codec. It also extends SQLFaker and all PostgreSQL fuzz targets with the official CopyStmt grammar rule.

## Root cause and prevention

COPY bypassed the ordinary query rewrite path and therefore could reach the physical database. The adapter now routes supported COPY forms through typed shadow-store mutations, malformed input is handled atomically, and the non-null schema registry contract is enforced directly rather than hidden by null-safe access.

Regression coverage includes identity and generated columns, separators and NULL markers, control-byte escaping, bytea, malformed-row atomicity, shadow isolation, legacy PDO aliases, and file operations.

## Verification

- Core: 830 tests / 1,445 assertions
- lint and PHPStan: pass
- targeted Core mutation: 1/1 killed; covered-code MSI 100%
- SQLFaker, PostgreSQL, PDO suites and classify/rewrite/full fuzz targets covered by this stack

Closes #163.