### PR TITLE
fix(mysql): simulate LOAD DATA imports

### DIFF
--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -209,6 +209,12 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function loadDataStatement(): GenerationPlan
+    {
+        return GenerationPlan::fromRule('load_stmt')->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiTableDeleteStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('delete_stmt', [

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -156,6 +156,14 @@ final class MySqlProvider extends Base
     }
 
     /**
+     * Generate a LOAD DATA statement from MySQL's official load_stmt rule.
+     */
+    public function loadDataStatement(int $maxDepth = PHP_INT_MAX): string
+    {
+        return $this->sql->generate(GenerationPlans::loadDataStatement()->withMaxDepth($maxDepth));
+    }
+
+    /**
      * Generate a two-target UPDATE statement.
      */
     public function multiTableUpdateStatement(int $maxDepth = PHP_INT_MAX): string

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -266,6 +266,8 @@ final class GenerationPlansTest extends TestCase
 
     public function testLoadDataPlanStartsFromTheLoadGrammar(): void
     {
-        self::assertSame('load_stmt', GenerationPlans::loadDataStatement()->startRule());
+        $plan = GenerationPlans::loadDataStatement();
+
+        self::assertSame('load_stmt', $plan->startRule());
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/GenerationPlansTest.php
@@ -263,4 +263,9 @@ final class GenerationPlansTest extends TestCase
         self::assertTrue($plan->patternAt('table_factor', 0)?->matches(['single_table']) ?? false);
         self::assertTrue($plan->patternAt('opt_use_partition', 0)?->matches(['PARTITION_SYM']) ?? false);
     }
+
+    public function testLoadDataPlanStartsFromTheLoadGrammar(): void
+    {
+        self::assertSame('load_stmt', GenerationPlans::loadDataStatement()->startRule());
+    }
 }

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -263,9 +263,9 @@ final class MySqlProviderTest extends TestCase
 
         $result = $provider->loadDataStatement(maxDepth: 8);
 
-        self::assertStringStartsWith('LOAD', strtoupper($result));
-        self::assertStringContainsString('INFILE', strtoupper($result));
-        self::assertStringContainsString('INTO', strtoupper($result));
+        self::assertMatchesRegularExpression('/\bLOAD\b.*\bDATA\b/is', $result);
+        self::assertMatchesRegularExpression('/\bINFILE\b/i', $result);
+        self::assertMatchesRegularExpression('/\bINTO\b/i', $result);
     }
 
     public function testSelectStatement(): void

--- a/packages/sql-faker/tests/Unit/MySqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/MySqlProviderTest.php
@@ -255,6 +255,19 @@ final class MySqlProviderTest extends TestCase
         self::assertNotSame('', $result);
     }
 
+    public function testLoadDataStatementUsesOfficialGrammarRule(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(164);
+        $provider = new MySqlProvider($faker);
+
+        $result = $provider->loadDataStatement(maxDepth: 8);
+
+        self::assertStringStartsWith('LOAD', strtoupper($result));
+        self::assertStringContainsString('INFILE', strtoupper($result));
+        self::assertStringContainsString('INTO', strtoupper($result));
+    }
+
     public function testSelectStatement(): void
     {
         $faker = Factory::create();

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/ClassifyTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/ClassifyTarget.php
@@ -62,6 +62,7 @@ final class ClassifyTarget
             fn () => $this->provider->replaceStatement(maxDepth: 5),
             fn () => $this->provider->truncateStatement(maxDepth: 3),
             fn (): string => $this->provider->partitionSelectStatement(),
+            fn (): string => $this->provider->loadDataStatement(maxDepth: 8),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RewriteTarget.php
@@ -157,6 +157,7 @@ final class RewriteTarget
             fn (): string => $this->provider->generatedColumnStatement(),
             fn (): string => $this->provider->foreignKeyCascadeStatement(),
             fn (): string => $this->provider->partitionSelectStatement(),
+            fn (): string => $this->provider->loadDataStatement(maxDepth: 8),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-mysql/fuzz/Robustness/Target/RobustnessTarget.php
@@ -204,6 +204,7 @@ final class RobustnessTarget
             fn (): string => $this->provider->insertSelectCompoundStatement(),
             fn (): string => $this->provider->insertRowAliasUpsertStatement(),
             fn (): string => $this->provider->partitionSelectStatement(),
+            fn (): string => $this->provider->loadDataStatement(maxDepth: 8),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-mysql/src/MySqlLoadDataProjector.php
+++ b/packages/ztd-query-mysql/src/MySqlLoadDataProjector.php
@@ -1,0 +1,506 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use PhpMyAdmin\SqlParser\Components\OptionsArray;
+use PhpMyAdmin\SqlParser\Components\Expression;
+use PhpMyAdmin\SqlParser\Statements\LoadStatement;
+use ZtdQuery\Exception\UnknownSchemaException;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Schema\TableDefinition;
+use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Sql\SqlTokenDialect;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+/**
+ * Projects LOAD DATA input into the regular simulated INSERT/REPLACE pipeline.
+ */
+final class MySqlLoadDataProjector
+{
+    private MySqlIdentifierQuoter $quoter;
+    private MySqlValueRenderer $valueRenderer;
+
+    public function __construct(private readonly TableDefinitionRegistry $registry)
+    {
+        $this->quoter = new MySqlIdentifierQuoter();
+        $this->valueRenderer = new MySqlValueRenderer();
+    }
+
+    public function project(string $sql, LoadStatement $statement): string
+    {
+        $tableName = $statement->table?->table;
+        if (!is_string($tableName) || $tableName === '') {
+            throw new UnsupportedSqlException($sql, 'Cannot resolve LOAD DATA target');
+        }
+        $definition = $this->registry->get($tableName);
+        if ($definition === null) {
+            throw new UnknownSchemaException($sql, $tableName, 'table');
+        }
+        if ($statement->partition !== null) {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA PARTITION cannot be simulated safely');
+        }
+        if ($statement->charset_name !== null) {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA CHARACTER SET conversion is not supported');
+        }
+
+        $fileProperties = $statement->file_name !== null ? get_object_vars($statement->file_name) : [];
+        $path = $fileProperties['file'] ?? '';
+        if (!is_string($path) || $path === '' || !is_file($path) || !is_readable($path)) {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA input file is not readable');
+        }
+        $contents = file_get_contents($path);
+        if (!is_string($contents)) {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA input file could not be read');
+        }
+
+        $fieldTerminator = $this->optionValue($statement->fields_options, 'TERMINATED BY', "\t");
+        $enclosure = $this->optionValue($statement->fields_options, 'ENCLOSED BY', '');
+        $escape = $this->optionValue($statement->fields_options, 'ESCAPED BY', '\\');
+        $linePrefix = $this->optionValue($statement->lines_options, 'STARTING BY', '');
+        $lineTerminator = $this->optionValue($statement->lines_options, 'TERMINATED BY', "\n");
+        if ($fieldTerminator === '' || $lineTerminator === '') {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA fixed-row input is not supported');
+        }
+        if (strlen($enclosure) > 1 || strlen($escape) > 1) {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA enclosure and escape must be single-byte values');
+        }
+
+        $targets = $this->inputTargets($statement, $definition, $sql);
+        $setOperations = $this->setOperations($statement, $definition, $sql);
+        $ignoreRows = $this->ignoreRows($statement, $sql);
+        $records = $this->splitRecords(
+            $contents,
+            $fieldTerminator,
+            $lineTerminator,
+            $enclosure,
+            $escape,
+        );
+        $records = array_slice($records, $ignoreRows);
+
+        $rows = [];
+        foreach ($records as $record) {
+            if ($linePrefix !== '' && !str_starts_with($record, $linePrefix)) {
+                continue;
+            }
+            if ($linePrefix !== '') {
+                $record = substr($record, strlen($linePrefix));
+            }
+            $values = $this->parseFields($record, $fieldTerminator, $enclosure, $escape);
+            $rows[] = $this->projectRow($targets, $setOperations, $values);
+        }
+
+        return $this->buildInsertSql($statement, $tableName, $definition, $targets, $setOperations, $rows);
+    }
+
+    private function optionValue(?OptionsArray $options, string $name, string $default): string
+    {
+        if ($options === null) {
+            return $default;
+        }
+        foreach ($options->options as $option) {
+            if (!is_array($option) || ($option['name'] ?? null) !== $name) {
+                continue;
+            }
+            $expression = $option['expr'] ?? null;
+            if ($expression instanceof Expression && is_string($expression->column)) {
+                return $expression->column;
+            }
+        }
+
+        return $default;
+    }
+
+    private function decodeEscapeByte(string $byte): string
+    {
+        return match ($byte) {
+            '0' => "\0",
+            'b' => "\x08",
+            'n' => "\n",
+            'r' => "\r",
+            't' => "\t",
+            'Z' => "\x1a",
+            default => $byte,
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function inputTargets(LoadStatement $statement, TableDefinition $definition, string $sql): array
+    {
+        $expressions = $statement->col_name_or_user_var;
+        if ($expressions === null || $expressions === []) {
+            return array_values(array_filter(
+                $definition->columns,
+                static fn (string $column): bool => !isset($definition->generatedExpressions[$column]),
+            ));
+        }
+        if (count($expressions) !== 1) {
+            throw new UnsupportedSqlException($sql, 'Cannot resolve LOAD DATA column list');
+        }
+
+        $expression = $expressions[0]->expr;
+        if ($expression === null) {
+            throw new UnsupportedSqlException($sql, 'Cannot resolve LOAD DATA column list');
+        }
+        $list = trim($expression);
+        if (strlen($list) < 2 || $list[0] !== '(' || $list[strlen($list) - 1] !== ')') {
+            throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA column list');
+        }
+        $parts = SqlTokenStream::tokenize(substr($list, 1, -1), SqlTokenDialect::MySql)->splitTopLevel();
+        $targets = [];
+        foreach ($parts as $part) {
+            $target = $this->inputTarget($part, $sql);
+            $normalized = strtolower($target);
+            if (isset($targets[$normalized])) {
+                throw new UnsupportedSqlException($sql, 'Duplicate LOAD DATA input target');
+            }
+            if ($target[0] !== '@') {
+                if (!in_array($target, $definition->columns, true)) {
+                    throw new UnsupportedSqlException($sql, 'Unknown LOAD DATA target column');
+                }
+                if (isset($definition->generatedExpressions[$target])) {
+                    throw new UnsupportedSqlException($sql, 'LOAD DATA cannot assign a generated column');
+                }
+            }
+            $targets[$normalized] = $target;
+        }
+
+        return array_values($targets);
+    }
+
+    private function inputTarget(string $sqlPart, string $sql): string
+    {
+        $tokens = SqlTokenStream::tokenize($sqlPart, SqlTokenDialect::MySql)->significantTokens();
+        if (($tokens[0] ?? null)?->kind === SqlTokenKind::Symbol && $tokens[0]->text === '@') {
+            $identifier = SqlTokenStream::tokenize($sqlPart, SqlTokenDialect::MySql)->identifierAt(1);
+            if ($identifier === null || $identifier['next'] !== count($tokens)) {
+                throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA user variable');
+            }
+
+            return '@' . $identifier['name'];
+        }
+
+        $identifier = SqlTokenStream::tokenize($sqlPart, SqlTokenDialect::MySql)->identifierAt();
+        if ($identifier === null || $identifier['next'] !== count($tokens)) {
+            throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA target column');
+        }
+
+        return $identifier['name'];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function setOperations(LoadStatement $statement, TableDefinition $definition, string $sql): array
+    {
+        $operations = [];
+        foreach ($statement->set ?? [] as $operation) {
+            $column = $operation->column;
+            $value = $operation->value;
+            if (!in_array($column, $definition->columns, true)) {
+                throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA SET operation');
+            }
+            if (isset($definition->generatedExpressions[$column])) {
+                throw new UnsupportedSqlException($sql, 'LOAD DATA cannot assign a generated column');
+            }
+            if (isset($operations[$column])) {
+                throw new UnsupportedSqlException($sql, 'Duplicate LOAD DATA SET target');
+            }
+            $operations[$column] = $value;
+        }
+
+        return $operations;
+    }
+
+    private function ignoreRows(LoadStatement $statement, string $sql): int
+    {
+        $value = $statement->ignore_number?->expr;
+        if ($value === null) {
+            return 0;
+        }
+        $parsed = filter_var($value, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        if (!is_int($parsed)) {
+            throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA IGNORE row count');
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitRecords(
+        string $contents,
+        string $fieldTerminator,
+        string $lineTerminator,
+        string $enclosure,
+        string $escape,
+    ): array {
+        $records = [];
+        $record = '';
+        $length = strlen($contents);
+        $enclosed = false;
+        $atFieldStart = true;
+
+        for ($index = 0; $index < $length;) {
+            if ($escape !== '' && $contents[$index] === $escape && $index + 1 < $length) {
+                $record .= $contents[$index] . $contents[$index + 1];
+                $index += 2;
+                $atFieldStart = false;
+                continue;
+            }
+            if ($enclosure !== '' && $contents[$index] === $enclosure) {
+                if ($enclosed && ($contents[$index + 1] ?? '') === $enclosure) {
+                    $record .= $enclosure . $enclosure;
+                    $index += 2;
+                    continue;
+                }
+                if ($enclosed || $atFieldStart) {
+                    $enclosed = !$enclosed;
+                }
+                $record .= $enclosure;
+                $index++;
+                $atFieldStart = false;
+                continue;
+            }
+            if (!$enclosed && $this->startsWithAt($contents, $lineTerminator, $index)) {
+                $records[] = $record;
+                $record = '';
+                $index += strlen($lineTerminator);
+                $atFieldStart = true;
+                continue;
+            }
+            if (!$enclosed && $this->startsWithAt($contents, $fieldTerminator, $index)) {
+                $record .= $fieldTerminator;
+                $index += strlen($fieldTerminator);
+                $atFieldStart = true;
+                continue;
+            }
+            $record .= $contents[$index];
+            $index++;
+            $atFieldStart = false;
+        }
+        if ($record !== '' || ($length > 0 && !str_ends_with($contents, $lineTerminator))) {
+            $records[] = $record;
+        }
+
+        return $records;
+    }
+
+    /**
+     * @return list<string|null>
+     */
+    private function parseFields(string $record, string $terminator, string $enclosure, string $escape): array
+    {
+        $fields = [];
+        $raw = '';
+        $decoded = '';
+        $quoted = false;
+        $enclosed = false;
+        $atFieldStart = true;
+        $length = strlen($record);
+
+        for ($index = 0; $index < $length;) {
+            if ($escape !== '' && $record[$index] === $escape && $index + 1 < $length) {
+                $raw .= $record[$index] . $record[$index + 1];
+                $decoded .= $this->decodeEscapeByte($record[$index + 1]);
+                $index += 2;
+                $atFieldStart = false;
+                continue;
+            }
+            if ($enclosure !== '' && $record[$index] === $enclosure) {
+                if ($enclosed && ($record[$index + 1] ?? '') === $enclosure) {
+                    $raw .= $enclosure . $enclosure;
+                    $decoded .= $enclosure;
+                    $index += 2;
+                    continue;
+                }
+                if ($enclosed) {
+                    $enclosed = false;
+                    $index++;
+                    continue;
+                }
+                if ($atFieldStart) {
+                    $quoted = true;
+                    $enclosed = true;
+                    $index++;
+                    $atFieldStart = false;
+                    continue;
+                }
+            }
+            if (!$enclosed && $this->startsWithAt($record, $terminator, $index)) {
+                $fields[] = $this->fieldValue($raw, $decoded, $quoted, $enclosure, $escape);
+                $raw = '';
+                $decoded = '';
+                $quoted = false;
+                $atFieldStart = true;
+                $index += strlen($terminator);
+                continue;
+            }
+            $raw .= $record[$index];
+            $decoded .= $record[$index];
+            $index++;
+            $atFieldStart = false;
+        }
+        $fields[] = $this->fieldValue($raw, $decoded, $quoted, $enclosure, $escape);
+
+        return $fields;
+    }
+
+    private function fieldValue(
+        string $raw,
+        string $decoded,
+        bool $quoted,
+        string $enclosure,
+        string $escape,
+    ): ?string {
+        if (!$quoted && $escape !== '' && $raw === $escape . 'N') {
+            return null;
+        }
+        if (!$quoted && ($enclosure !== '' || $escape === '') && $raw === 'NULL') {
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param list<string> $targets
+     * @param array<string, string> $setOperations
+     * @param list<string|null> $values
+     * @return array<string, string>
+     */
+    private function projectRow(array $targets, array $setOperations, array $values): array
+    {
+        $row = [];
+        $variables = [];
+        foreach ($targets as $index => $target) {
+            $hasValue = array_key_exists($index, $values);
+            $value = $values[$index] ?? null;
+            if ($target[0] === '@') {
+                $variables[strtolower(substr($target, 1))] = $hasValue ? $value : null;
+                continue;
+            }
+            $row[$target] = $hasValue ? $this->renderField($value) : 'DEFAULT';
+        }
+        foreach ($setOperations as $column => $expression) {
+            $row[$column] = $this->substituteVariables($expression, $variables);
+        }
+
+        return $row;
+    }
+
+    private function renderField(?string $value): string
+    {
+        return $value === null ? 'NULL' : $this->valueRenderer->renderValue($value);
+    }
+
+    /**
+     * @param array<string, string|null> $variables
+     */
+    private function substituteVariables(string $expression, array $variables): string
+    {
+        $tokens = SqlTokenStream::tokenize($expression, SqlTokenDialect::MySql)->significantTokens();
+        $replacements = [];
+        foreach ($tokens as $index => $token) {
+            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '@') {
+                continue;
+            }
+            $next = $tokens[$index + 1] ?? null;
+            if ($next === null || !in_array($next->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+                continue;
+            }
+            $identifier = SqlTokenStream::tokenize($next->text, SqlTokenDialect::MySql)->identifierAt();
+            $name = strtolower($identifier['name'] ?? $next->text);
+            if (!array_key_exists($name, $variables)) {
+                continue;
+            }
+            $replacements[] = [
+                'start' => $token->offset,
+                'end' => $next->endOffset(),
+                'sql' => $this->renderField($variables[$name]),
+            ];
+        }
+        usort($replacements, static fn (array $left, array $right): int => $right['start'] <=> $left['start']);
+        foreach ($replacements as $replacement) {
+            $expression = substr_replace(
+                $expression,
+                $replacement['sql'],
+                $replacement['start'],
+                $replacement['end'] - $replacement['start'],
+            );
+        }
+
+        return $expression;
+    }
+
+    /**
+     * @param list<string> $targets
+     * @param array<string, string> $setOperations
+     * @param list<array<string, string>> $rows
+     */
+    private function buildInsertSql(
+        LoadStatement $statement,
+        string $tableName,
+        TableDefinition $definition,
+        array $targets,
+        array $setOperations,
+        array $rows,
+    ): string {
+        $columns = [];
+        foreach ($targets as $target) {
+            if ($target[0] !== '@') {
+                $columns[$target] = true;
+            }
+        }
+        foreach (array_keys($setOperations) as $column) {
+            $columns[$column] = true;
+        }
+        $orderedColumns = array_values(array_filter(
+            $definition->columns,
+            static fn (string $column): bool => isset($columns[$column]),
+        ));
+        if ($orderedColumns === []) {
+            throw new UnsupportedSqlException($statement->build(), 'LOAD DATA has no target columns');
+        }
+
+        $mode = strtoupper((string) $statement->replace_ignore);
+        if ($mode === 'REPLACE') {
+            $prefix = 'REPLACE INTO ';
+        } else {
+            $local = $statement->options !== null && $statement->options->has('LOCAL') !== false;
+            $prefix = ($mode === 'IGNORE' || $local) ? 'INSERT IGNORE INTO ' : 'INSERT INTO ';
+        }
+        $columnSql = implode(', ', array_map($this->quoter->quote(...), $orderedColumns));
+        $targetSql = $this->quoter->quote($tableName) . ' (' . $columnSql . ')';
+        if ($rows === []) {
+            $selects = [];
+            foreach ($orderedColumns as $column) {
+                $selects[] = 'NULL AS ' . $this->quoter->quote($column);
+            }
+
+            return $prefix . $targetSql . ' SELECT ' . implode(', ', $selects) . ' WHERE FALSE';
+        }
+
+        $valueRows = [];
+        foreach ($rows as $row) {
+            $values = [];
+            foreach ($orderedColumns as $column) {
+                $values[] = $row[$column] ?? 'DEFAULT';
+            }
+            $valueRows[] = '(' . implode(', ', $values) . ')';
+        }
+
+        return $prefix . $targetSql . ' VALUES ' . implode(', ', $valueRows);
+    }
+
+    private function startsWithAt(string $value, string $needle, int $offset): bool
+    {
+        return substr_compare($value, $needle, $offset, strlen($needle)) === 0;
+    }
+
+}

--- a/packages/ztd-query-mysql/src/MySqlLoadDataProjector.php
+++ b/packages/ztd-query-mysql/src/MySqlLoadDataProjector.php
@@ -12,7 +12,6 @@ use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
 use ZtdQuery\Sql\SqlTokenDialect;
-use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
 /**
@@ -32,7 +31,10 @@ final class MySqlLoadDataProjector
     public function project(string $sql, LoadStatement $statement): string
     {
         $tableName = $statement->table?->table;
-        if (!is_string($tableName) || $tableName === '') {
+        if (!is_string($tableName)) {
+            throw new UnsupportedSqlException($sql, 'Cannot resolve LOAD DATA target');
+        }
+        if ($tableName === '') {
             throw new UnsupportedSqlException($sql, 'Cannot resolve LOAD DATA target');
         }
         $definition = $this->registry->get($tableName);
@@ -46,9 +48,21 @@ final class MySqlLoadDataProjector
             throw new UnsupportedSqlException($sql, 'LOAD DATA CHARACTER SET conversion is not supported');
         }
 
-        $fileProperties = $statement->file_name !== null ? get_object_vars($statement->file_name) : [];
-        $path = $fileProperties['file'] ?? '';
-        if (!is_string($path) || $path === '' || !is_file($path) || !is_readable($path)) {
+        if ($statement->file_name === null) {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA input file is not readable');
+        }
+        $fileProperties = get_object_vars($statement->file_name);
+        $path = $fileProperties['file'] ?? null;
+        if (!is_string($path)) {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA input file is not readable');
+        }
+        if ($path === '') {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA input file is not readable');
+        }
+        if (!is_file($path)) {
+            throw new UnsupportedSqlException($sql, 'LOAD DATA input file is not readable');
+        }
+        if (!is_readable($path)) {
             throw new UnsupportedSqlException($sql, 'LOAD DATA input file is not readable');
         }
         $contents = file_get_contents($path);
@@ -101,13 +115,21 @@ final class MySqlLoadDataProjector
             return $default;
         }
         foreach ($options->options as $option) {
-            if (!is_array($option) || ($option['name'] ?? null) !== $name) {
+            if (!is_array($option)) {
+                continue;
+            }
+            if (($option['name'] ?? null) !== $name) {
                 continue;
             }
             $expression = $option['expr'] ?? null;
-            if ($expression instanceof Expression && is_string($expression->column)) {
-                return $expression->column;
+            if (!$expression instanceof Expression) {
+                continue;
             }
+            if (!is_string($expression->column)) {
+                continue;
+            }
+
+            return $expression->column;
         }
 
         return $default;
@@ -146,11 +168,21 @@ final class MySqlLoadDataProjector
         if ($expression === null) {
             throw new UnsupportedSqlException($sql, 'Cannot resolve LOAD DATA column list');
         }
-        $list = trim($expression);
-        if (strlen($list) < 2 || $list[0] !== '(' || $list[strlen($list) - 1] !== ')') {
+        $stream = SqlTokenStream::tokenize($expression, SqlTokenDialect::MySql);
+        $tokens = $stream->significantTokens();
+        if (count($tokens) < 2) {
             throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA column list');
         }
-        $parts = SqlTokenStream::tokenize(substr($list, 1, -1), SqlTokenDialect::MySql)->splitTopLevel();
+        $opening = $tokens[0];
+        if ($opening->text !== '(') {
+            throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA column list');
+        }
+        $closing = $tokens[count($tokens) - 1];
+        if ($closing->text !== ')') {
+            throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA column list');
+        }
+        $contents = substr($expression, $opening->endOffset(), $closing->offset - $opening->endOffset());
+        $parts = SqlTokenStream::tokenize($contents, SqlTokenDialect::MySql)->splitTopLevel();
         $targets = [];
         foreach ($parts as $part) {
             $target = $this->inputTarget($part, $sql);
@@ -174,18 +206,29 @@ final class MySqlLoadDataProjector
 
     private function inputTarget(string $sqlPart, string $sql): string
     {
-        $tokens = SqlTokenStream::tokenize($sqlPart, SqlTokenDialect::MySql)->significantTokens();
-        if (($tokens[0] ?? null)?->kind === SqlTokenKind::Symbol && $tokens[0]->text === '@') {
-            $identifier = SqlTokenStream::tokenize($sqlPart, SqlTokenDialect::MySql)->identifierAt(1);
-            if ($identifier === null || $identifier['next'] !== count($tokens)) {
+        $stream = SqlTokenStream::tokenize($sqlPart, SqlTokenDialect::MySql);
+        $tokens = $stream->significantTokens();
+        $first = $tokens[0] ?? null;
+        if ($first === null) {
+            throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA target column');
+        }
+        if ($first->text === '@') {
+            $identifier = $stream->identifierAt(1);
+            if ($identifier === null) {
+                throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA user variable');
+            }
+            if ($identifier['next'] !== count($tokens)) {
                 throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA user variable');
             }
 
             return '@' . $identifier['name'];
         }
 
-        $identifier = SqlTokenStream::tokenize($sqlPart, SqlTokenDialect::MySql)->identifierAt();
-        if ($identifier === null || $identifier['next'] !== count($tokens)) {
+        $identifier = $stream->identifierAt();
+        if ($identifier === null) {
+            throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA target column');
+        }
+        if ($identifier['next'] !== count($tokens)) {
             throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA target column');
         }
 
@@ -222,8 +265,11 @@ final class MySqlLoadDataProjector
         if ($value === null) {
             return 0;
         }
-        $parsed = filter_var($value, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        $parsed = filter_var($value, FILTER_VALIDATE_INT);
         if (!is_int($parsed)) {
+            throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA IGNORE row count');
+        }
+        if ($parsed < 0) {
             throw new UnsupportedSqlException($sql, 'Invalid LOAD DATA IGNORE row count');
         }
 
@@ -242,29 +288,33 @@ final class MySqlLoadDataProjector
     ): array {
         $records = [];
         $record = '';
-        $length = strlen($contents);
         $enclosed = false;
         $atFieldStart = true;
 
-        for ($index = 0; $index < $length;) {
-            if ($escape !== '' && $contents[$index] === $escape && $index + 1 < $length) {
-                $record .= $contents[$index] . $contents[$index + 1];
-                $index += 2;
-                $atFieldStart = false;
-                continue;
+        for ($index = 0; isset($contents[$index]);) {
+            $byte = $contents[$index];
+            $followingByte = $this->followingByte($contents, $index);
+            if ($escape !== '' && $byte === $escape) {
+                if ($followingByte !== null) {
+                    $record .= $byte . $followingByte;
+                    $index += 2;
+                    $atFieldStart = false;
+                    continue;
+                }
             }
-            if ($enclosure !== '' && $contents[$index] === $enclosure) {
-                if ($enclosed && ($contents[$index + 1] ?? '') === $enclosure) {
+            if ($enclosure !== '' && $byte === $enclosure) {
+                if ($enclosed && $followingByte === $enclosure) {
                     $record .= $enclosure . $enclosure;
                     $index += 2;
                     continue;
                 }
-                if ($enclosed || $atFieldStart) {
-                    $enclosed = !$enclosed;
+                if ($enclosed) {
+                    $enclosed = false;
+                } elseif ($atFieldStart) {
+                    $enclosed = true;
                 }
                 $record .= $enclosure;
                 $index++;
-                $atFieldStart = false;
                 continue;
             }
             if (!$enclosed && $this->startsWithAt($contents, $lineTerminator, $index)) {
@@ -280,11 +330,11 @@ final class MySqlLoadDataProjector
                 $atFieldStart = true;
                 continue;
             }
-            $record .= $contents[$index];
+            $record .= $byte;
             $index++;
             $atFieldStart = false;
         }
-        if ($record !== '' || ($length > 0 && !str_ends_with($contents, $lineTerminator))) {
+        if ($record !== '') {
             $records[] = $record;
         }
 
@@ -301,20 +351,20 @@ final class MySqlLoadDataProjector
         $decoded = '';
         $quoted = false;
         $enclosed = false;
-        $atFieldStart = true;
-        $length = strlen($record);
 
-        for ($index = 0; $index < $length;) {
-            if ($escape !== '' && $record[$index] === $escape && $index + 1 < $length) {
-                $raw .= $record[$index] . $record[$index + 1];
-                $decoded .= $this->decodeEscapeByte($record[$index + 1]);
-                $index += 2;
-                $atFieldStart = false;
-                continue;
+        for ($index = 0; isset($record[$index]);) {
+            $byte = $record[$index];
+            $followingByte = $this->followingByte($record, $index);
+            if ($escape !== '' && $byte === $escape) {
+                if ($followingByte !== null) {
+                    $raw .= $byte . $followingByte;
+                    $decoded .= $this->decodeEscapeByte($followingByte);
+                    $index += 2;
+                    continue;
+                }
             }
-            if ($enclosure !== '' && $record[$index] === $enclosure) {
-                if ($enclosed && ($record[$index + 1] ?? '') === $enclosure) {
-                    $raw .= $enclosure . $enclosure;
+            if ($enclosure !== '' && $byte === $enclosure) {
+                if ($enclosed && $followingByte === $enclosure) {
                     $decoded .= $enclosure;
                     $index += 2;
                     continue;
@@ -324,12 +374,15 @@ final class MySqlLoadDataProjector
                     $index++;
                     continue;
                 }
-                if ($atFieldStart) {
-                    $quoted = true;
-                    $enclosed = true;
-                    $index++;
-                    $atFieldStart = false;
-                    continue;
+                if (!$quoted) {
+                    if ($raw === '') {
+                        if ($decoded === '') {
+                            $quoted = true;
+                            $enclosed = true;
+                            $index++;
+                            continue;
+                        }
+                    }
                 }
             }
             if (!$enclosed && $this->startsWithAt($record, $terminator, $index)) {
@@ -337,14 +390,12 @@ final class MySqlLoadDataProjector
                 $raw = '';
                 $decoded = '';
                 $quoted = false;
-                $atFieldStart = true;
                 $index += strlen($terminator);
                 continue;
             }
-            $raw .= $record[$index];
-            $decoded .= $record[$index];
+            $raw .= $byte;
+            $decoded .= $byte;
             $index++;
-            $atFieldStart = false;
         }
         $fields[] = $this->fieldValue($raw, $decoded, $quoted, $enclosure, $escape);
 
@@ -358,10 +409,19 @@ final class MySqlLoadDataProjector
         string $enclosure,
         string $escape,
     ): ?string {
-        if (!$quoted && $escape !== '' && $raw === $escape . 'N') {
+        if ($quoted) {
+            return $decoded;
+        }
+        if ($escape !== '' && $raw === $escape . 'N') {
             return null;
         }
-        if (!$quoted && ($enclosure !== '' || $escape === '') && $raw === 'NULL') {
+        if ($raw !== 'NULL') {
+            return $decoded;
+        }
+        if ($enclosure !== '') {
+            return null;
+        }
+        if ($escape === '') {
             return null;
         }
 
@@ -404,38 +464,35 @@ final class MySqlLoadDataProjector
      */
     private function substituteVariables(string $expression, array $variables): string
     {
-        $tokens = SqlTokenStream::tokenize($expression, SqlTokenDialect::MySql)->significantTokens();
-        $replacements = [];
-        foreach ($tokens as $index => $token) {
-            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== '@') {
+        $stream = SqlTokenStream::tokenize($expression, SqlTokenDialect::MySql);
+        $tokens = $stream->significantTokens();
+        $result = '';
+        $cursor = 0;
+        $tokenCount = count($tokens);
+        for ($index = 0; $index < $tokenCount; $index++) {
+            $token = $tokens[$index];
+            if ($token->text !== '@') {
                 continue;
             }
-            $next = $tokens[$index + 1] ?? null;
-            if ($next === null || !in_array($next->kind, [SqlTokenKind::Word, SqlTokenKind::QuotedIdentifier], true)) {
+            $previous = $tokens[$index - 1] ?? null;
+            if ($previous !== null && $previous->text === '@') {
                 continue;
             }
-            $identifier = SqlTokenStream::tokenize($next->text, SqlTokenDialect::MySql)->identifierAt();
-            $name = strtolower($identifier['name'] ?? $next->text);
+            $identifier = $stream->identifierAt($index + 1);
+            if ($identifier === null) {
+                continue;
+            }
+            $name = strtolower($identifier['name']);
             if (!array_key_exists($name, $variables)) {
                 continue;
             }
-            $replacements[] = [
-                'start' => $token->offset,
-                'end' => $next->endOffset(),
-                'sql' => $this->renderField($variables[$name]),
-            ];
-        }
-        usort($replacements, static fn (array $left, array $right): int => $right['start'] <=> $left['start']);
-        foreach ($replacements as $replacement) {
-            $expression = substr_replace(
-                $expression,
-                $replacement['sql'],
-                $replacement['start'],
-                $replacement['end'] - $replacement['start'],
-            );
+            $last = $tokens[$identifier['next'] - 1];
+            $result .= substr($expression, $cursor, $token->offset - $cursor);
+            $result .= $this->renderField($variables[$name]);
+            $cursor = $last->endOffset();
         }
 
-        return $expression;
+        return $result . substr($expression, $cursor);
     }
 
     /**
@@ -451,24 +508,27 @@ final class MySqlLoadDataProjector
         array $setOperations,
         array $rows,
     ): string {
+        /** @var array<string, null> $columns */
         $columns = [];
         foreach ($targets as $target) {
             if ($target[0] !== '@') {
-                $columns[$target] = true;
+                $columns[$target] = null;
             }
         }
         foreach (array_keys($setOperations) as $column) {
-            $columns[$column] = true;
+            $columns[$column] = null;
         }
-        $orderedColumns = array_values(array_filter(
-            $definition->columns,
-            static fn (string $column): bool => isset($columns[$column]),
-        ));
+        $orderedColumns = [];
+        foreach ($definition->columns as $column) {
+            if (array_key_exists($column, $columns)) {
+                $orderedColumns[] = $column;
+            }
+        }
         if ($orderedColumns === []) {
             throw new UnsupportedSqlException($statement->build(), 'LOAD DATA has no target columns');
         }
 
-        $mode = strtoupper((string) $statement->replace_ignore);
+        $mode = $statement->replace_ignore;
         if ($mode === 'REPLACE') {
             $prefix = 'REPLACE INTO ';
         } else {
@@ -501,6 +561,11 @@ final class MySqlLoadDataProjector
     private function startsWithAt(string $value, string $needle, int $offset): bool
     {
         return substr_compare($value, $needle, $offset, strlen($needle)) === 0;
+    }
+
+    private function followingByte(string $value, int $offset): ?string
+    {
+        return $value[$offset + 1] ?? null;
     }
 
 }

--- a/packages/ztd-query-mysql/src/MySqlQueryGuard.php
+++ b/packages/ztd-query-mysql/src/MySqlQueryGuard.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\SqlParser\Statements\CreateStatement;
 use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
 use PhpMyAdmin\SqlParser\Statements\DropStatement;
 use PhpMyAdmin\SqlParser\Statements\InsertStatement;
+use PhpMyAdmin\SqlParser\Statements\LoadStatement;
 use PhpMyAdmin\SqlParser\Statements\ReplaceStatement;
 use PhpMyAdmin\SqlParser\Statements\SelectStatement;
 use PhpMyAdmin\SqlParser\Statements\TruncateStatement;
@@ -76,7 +77,7 @@ final class MySqlQueryGuard
             return QueryKind::READ;
         }
 
-        if ($statement instanceof UpdateStatement || $statement instanceof DeleteStatement || $statement instanceof InsertStatement || $statement instanceof TruncateStatement || $statement instanceof ReplaceStatement) {
+        if ($statement instanceof UpdateStatement || $statement instanceof DeleteStatement || $statement instanceof InsertStatement || $statement instanceof TruncateStatement || $statement instanceof ReplaceStatement || $statement instanceof LoadStatement) {
             return QueryKind::WRITE_SIMULATED;
         }
 

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -20,6 +20,7 @@ use ZtdQuery\Schema\ViewDefinitionSet;
 use ZtdQuery\Shadow\ShadowStore;
 use PhpMyAdmin\SqlParser\Statements\AlterStatement;
 use PhpMyAdmin\SqlParser\Statements\CreateStatement;
+use PhpMyAdmin\SqlParser\Statements\LoadStatement;
 use PhpMyAdmin\SqlParser\Statements\ReplaceStatement;
 use PhpMyAdmin\SqlParser\Statements\TruncateStatement;
 use PhpMyAdmin\SqlParser\Statements\WithStatement;
@@ -125,6 +126,10 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
             : $this->guard->classifyStatement($statement);
         if ($kind === null) {
             throw new UnsupportedSqlException($sql, 'Statement type not supported');
+        }
+
+        if ($statement instanceof LoadStatement) {
+            return $this->rewrite((new MySqlLoadDataProjector($this->registry))->project($sql, $statement));
         }
 
         $tableContext = $this->buildTableContext();

--- a/packages/ztd-query-mysql/tests/Unit/MySqlLoadDataProjectorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlLoadDataProjectorTest.php
@@ -355,6 +355,131 @@ final class MySqlLoadDataProjectorTest extends TestCase
         self::assertStringEndsWith(", CAST('import' AS CHAR))", $projected);
     }
 
+    public function testRejectsAMissingTargetBeforeReadingTheInput(): void
+    {
+        $parser = new MySqlParser();
+        $statement = $parser->parseSingleLogicalStatement(
+            "LOAD DATA INFILE '/path/that/does/not/exist' INTO TABLE items",
+        );
+        self::assertInstanceOf(LoadStatement::class, $statement);
+        $statement->table = null;
+
+        self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage('Cannot resolve LOAD DATA target');
+
+        (new MySqlLoadDataProjector(new TableDefinitionRegistry()))->project('LOAD DATA', $statement);
+    }
+
+    public function testRejectsAReadableDirectoryAsANonFileInput(): void
+    {
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse('CREATE TABLE items (id INT PRIMARY KEY)');
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $path = sys_get_temp_dir();
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path) . "' INTO TABLE items";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage('LOAD DATA input file is not readable');
+
+        (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+    }
+
+    public function testEmptyExplicitColumnListHasNoTargetColumns(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        self::assertSame(2, fwrite($stream, "1\n"));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse('CREATE TABLE items (id INT PRIMARY KEY)');
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path) . "' INTO TABLE items ()";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage('LOAD DATA has no target columns');
+
+        (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+    }
+
+    public function testFieldStateHandlesFirstFieldEnclosuresAndFinalEscapeBoundaries(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $contents = "\"A\"\"\nB\",\"x\ny\"\n\"P\nQ\",r\nA\"B\nNULL,z\nA\\N,z\nE\\t\"F\nC\\t\nD\\";
+        self::assertSame(strlen($contents), fwrite($stream, $contents));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (first_value VARCHAR(50), second_value VARCHAR(50))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path)
+            . "' INTO TABLE items FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' ESCAPED BY '\\\\'";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringContainsString("CAST('A\"\nB' AS CHAR), CAST('x\ny' AS CHAR)", $projected);
+        self::assertStringContainsString("CAST('P\nQ' AS CHAR), CAST('r' AS CHAR)", $projected);
+        self::assertStringContainsString("CAST('A\"B' AS CHAR), DEFAULT", $projected);
+        self::assertStringContainsString('VALUES ', $projected);
+        self::assertStringContainsString('(NULL, CAST(\'z\' AS CHAR))', $projected);
+        self::assertStringContainsString("CAST('AN' AS CHAR), CAST('z' AS CHAR)", $projected);
+        self::assertStringContainsString("CAST('E\t\"F' AS CHAR), DEFAULT", $projected);
+        self::assertStringContainsString("CAST('C\t' AS CHAR), DEFAULT", $projected);
+        self::assertStringContainsString("CONVERT(X'445c' USING utf8mb4) AS CHAR), DEFAULT", $projected);
+        self::assertSame(7, substr_count($projected, '), ('));
+    }
+
+    public function testSetVariableSubstitutionIsForwardOnlyAndPreservesSystemVariables(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $contents = "1\talice\tv1\n";
+        self::assertSame(strlen($contents), fwrite($stream, $contents));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT, name VARCHAR(100))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path)
+            . "' INTO TABLE items (id, @raw, @version)"
+            . ' SET name = CONCAT(@@version, @raw, @ + @raw, @missing, @raw)';
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringContainsString(
+            "CONCAT(@@version, CAST('alice' AS CHAR), @+ CAST('alice' AS CHAR),"
+                . " @missing, CAST('alice' AS CHAR))",
+            $projected,
+        );
+    }
+
     #[TestWith(["FIELDS TERMINATED BY ''", 'fixed-row'], 'empty field delimiter')]
     #[TestWith(["LINES TERMINATED BY ''", 'fixed-row'], 'empty line delimiter')]
     #[TestWith(["FIELDS ENCLOSED BY 'xx'", 'single-byte'], 'multi-byte enclosure')]

--- a/packages/ztd-query-mysql/tests/Unit/MySqlLoadDataProjectorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlLoadDataProjectorTest.php
@@ -21,6 +21,7 @@ use ZtdQuery\Schema\TableDefinitionRegistry;
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlForeignKeyDefinitionParser::class)]
 final class MySqlLoadDataProjectorTest extends TestCase
 {
     public function testProjectsDefaultTabSeparatedInputAndNullMarker(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlLoadDataProjectorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlLoadDataProjectorTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PhpMyAdmin\SqlParser\Statements\LoadStatement;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\MySql\MySqlLoadDataProjector;
+use ZtdQuery\Platform\MySql\MySqlParser;
+use ZtdQuery\Platform\MySql\MySqlSchemaParser;
+use ZtdQuery\Schema\TableDefinitionRegistry;
+
+#[CoversClass(MySqlLoadDataProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlCastRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlIdentifierQuoter::class)]
+#[UsesClass(MySqlParser::class)]
+#[UsesClass(MySqlSchemaParser::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlValueRenderer::class)]
+final class MySqlLoadDataProjectorTest extends TestCase
+{
+    public function testProjectsDefaultTabSeparatedInputAndNullMarker(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        self::assertSame(20, fwrite($stream, "1\tAlice\n2\t\\N\n3\tA\\tB\n"));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50), slug VARCHAR(50) AS (LOWER(name)))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA LOCAL INFILE '" . str_replace("'", "''", $path) . "' INTO TABLE items IGNORE 0 LINES";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringStartsWith('INSERT IGNORE INTO `items` (`id`, `name`) VALUES ', $projected);
+        self::assertStringContainsString("CAST('Alice' AS CHAR)", $projected);
+        self::assertStringContainsString('NULL', $projected);
+        self::assertStringContainsString("CAST('A", $projected);
+        self::assertStringContainsString("B' AS CHAR)", $projected);
+        self::assertStringNotContainsString('`slug`', $projected);
+        self::assertSame(2, substr_count($projected, '), ('));
+    }
+
+    public function testProjectsCsvPrefixesIgnoredRowsUserVariablesAndSetExpressions(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $contents = "header\r\n>1,\"Alice, A\"\r\nignored\r\n>2,\"NULL\"\r\n";
+        self::assertSame(strlen($contents), fwrite($stream, $contents));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50), source VARCHAR(50) DEFAULT \'load\')',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path)
+            . "' INTO TABLE items FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' ESCAPED BY '\\\\'"
+            . " LINES STARTING BY '>' TERMINATED BY '\\r\\n' IGNORE 1 LINES (id, @raw)"
+            . ' SET name = UPPER(@raw)';
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringStartsWith('INSERT INTO `items` (`id`, `name`) VALUES ', $projected);
+        self::assertStringContainsString("UPPER(CAST('Alice, A' AS CHAR))", $projected);
+        self::assertStringContainsString("UPPER(CAST('NULL' AS CHAR))", $projected);
+        self::assertStringContainsString("(CAST('1' AS CHAR)", $projected);
+        self::assertStringNotContainsString("CAST('>1' AS CHAR)", $projected);
+        self::assertStringNotContainsString('header', $projected);
+        self::assertStringNotContainsString('ignored', $projected);
+        self::assertSame(1, substr_count($projected, '), ('));
+    }
+
+    public function testProjectsReplaceAndMissingFieldsAsDefault(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        self::assertSame(2, fwrite($stream, "7\n"));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50) DEFAULT \'unknown\')',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path)
+            . "' REPLACE INTO TABLE items (id, name)";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringStartsWith('REPLACE INTO `items` (`id`, `name`) VALUES ', $projected);
+        self::assertStringEndsWith("(CAST('7' AS CHAR), DEFAULT)", $projected);
+    }
+
+    public function testIgnoreRowsSkipsCompleteRecordsWithoutARequiredPrefix(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $contents = "header\n1\tAlice\n2\tBob\n";
+        self::assertSame(strlen($contents), fwrite($stream, $contents));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path)
+            . "' INTO TABLE items IGNORE 1 LINES";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringNotContainsString('header', $projected);
+        self::assertStringContainsString("CAST('1' AS CHAR), CAST('Alice' AS CHAR)", $projected);
+        self::assertStringContainsString("CAST('2' AS CHAR), CAST('Bob' AS CHAR)", $projected);
+        self::assertSame(1, substr_count($projected, '), ('));
+    }
+
+    public function testNoIgnoreClauseKeepsEveryRecord(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $contents = "1\tAlice\n2\tBob\n";
+        self::assertSame(strlen($contents), fwrite($stream, $contents));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path) . "' INTO TABLE items";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringContainsString("CAST('1' AS CHAR), CAST('Alice' AS CHAR)", $projected);
+        self::assertStringContainsString("CAST('2' AS CHAR), CAST('Bob' AS CHAR)", $projected);
+        self::assertSame(1, substr_count($projected, '), ('));
+    }
+
+    public function testDefaultTargetsPreserveValuePositionsAroundGeneratedColumns(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        self::assertSame(8, fwrite($stream, "1\tAlice\n"));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT PRIMARY KEY, doubled INT AS (id * 2), name VARCHAR(50))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path) . "' INTO TABLE items";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringStartsWith('INSERT INTO `items` (`id`, `name`) VALUES ', $projected);
+        self::assertStringEndsWith("(CAST('1' AS CHAR), CAST('Alice' AS CHAR))", $projected);
+        self::assertStringNotContainsString('`doubled`', $projected);
+    }
+
+    public function testProjectsEmptyInputAsAnEmptySelect(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse('CREATE TABLE items (id INT PRIMARY KEY)');
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path) . "' IGNORE INTO TABLE items";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertSame('INSERT IGNORE INTO `items` (`id`) SELECT NULL AS `id` WHERE FALSE', $projected);
+    }
+
+    public function testRejectsUnreadableInputBeforeProjection(): void
+    {
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse('CREATE TABLE items (id INT PRIMARY KEY)');
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA LOCAL INFILE '/path/that/does/not/exist' INTO TABLE items";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage('input file is not readable');
+
+        (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+    }
+
+    public function testRejectsGeneratedColumnTargets(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        self::assertSame(2, fwrite($stream, "1\n"));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT PRIMARY KEY, doubled INT AS (id * 2))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path) . "' INTO TABLE items (doubled)";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage('generated column');
+
+        (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+    }
+
+    public function testDecodesControlEscapesAndEscapedRecordTerminators(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $encoded = "1\tA\\0B\\bC\\nD\\rE\\tF\\ZG\\\\H\\\nJ\n";
+        self::assertSame(strlen($encoded), fwrite($stream, $encoded));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT PRIMARY KEY, payload VARCHAR(255))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path) . "' INTO TABLE items";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+        $decoded = "A\0B\x08C\nD\rE\tF\x1aG\\H\nJ";
+
+        self::assertStringContainsString("CONVERT(X'" . bin2hex($decoded) . "' USING utf8mb4)", $projected);
+        self::assertSame(0, substr_count($projected, '), ('));
+    }
+
+    public function testDistinguishesQuotedNullAndDoubledEnclosures(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $encoded = "1,\"A\"\"B\",\"NULL\",NULL,\\N,A\\,B\n";
+        self::assertSame(strlen($encoded), fwrite($stream, $encoded));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT, a VARCHAR(20), b VARCHAR(20), c VARCHAR(20), d VARCHAR(20), e VARCHAR(20))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path)
+            . "' INTO TABLE items FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' ESCAPED BY '\\\\'";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringContainsString("CAST('A\"B' AS CHAR)", $projected);
+        self::assertStringContainsString("CAST('NULL' AS CHAR)", $projected);
+        self::assertSame(2, substr_count($projected, ', NULL'));
+        self::assertStringContainsString("CAST('A,B' AS CHAR)", $projected);
+    }
+
+    public function testProjectsEverySetTarget(): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        $contents = "1\talice\timport\n";
+        self::assertSame(strlen($contents), fwrite($stream, $contents));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse(
+            'CREATE TABLE items (id INT, name VARCHAR(20), note VARCHAR(20), source VARCHAR(20))',
+        );
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path)
+            . "' INTO TABLE items (id, @Raw, source) SET name = UPPER(@RAW), note = CONCAT(@raw, '!')";
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        $projected = (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+
+        self::assertStringContainsString('`id`, `name`, `note`, `source`', $projected);
+        self::assertStringContainsString("UPPER(CAST('alice' AS CHAR))", $projected);
+        self::assertStringContainsString("CONCAT(CAST('alice' AS CHAR), '!')", $projected);
+        self::assertStringEndsWith(", CAST('import' AS CHAR))", $projected);
+    }
+
+    #[TestWith(["FIELDS TERMINATED BY ''", 'fixed-row'], 'empty field delimiter')]
+    #[TestWith(["LINES TERMINATED BY ''", 'fixed-row'], 'empty line delimiter')]
+    #[TestWith(["FIELDS ENCLOSED BY 'xx'", 'single-byte'], 'multi-byte enclosure')]
+    #[TestWith(["FIELDS ESCAPED BY 'xx'", 'single-byte'], 'multi-byte escape')]
+    #[TestWith(['PARTITION (p0)', 'PARTITION'], 'partition target')]
+    #[TestWith(['CHARACTER SET latin1', 'CHARACTER SET'], 'character conversion')]
+    #[TestWith(['(id, ID)', 'Duplicate'], 'duplicate target')]
+    #[TestWith(['(missing)', 'Unknown'], 'unknown target')]
+    public function testRejectsUnsupportedLoadDataShapes(string $clause, string $message): void
+    {
+        $stream = tmpfile();
+        self::assertIsResource($stream);
+        self::assertSame(2, fwrite($stream, "1\n"));
+        $metadata = stream_get_meta_data($stream);
+        $path = $metadata['uri'] ?? null;
+        self::assertIsString($path);
+
+        $parser = new MySqlParser();
+        $registry = new TableDefinitionRegistry();
+        $definition = (new MySqlSchemaParser($parser))->parse('CREATE TABLE items (id INT, name VARCHAR(20))');
+        self::assertNotNull($definition);
+        $registry->register('items', $definition);
+        $sql = "LOAD DATA INFILE '" . str_replace("'", "''", $path) . "' INTO TABLE items " . $clause;
+        $statement = $parser->parseSingleLogicalStatement($sql);
+        self::assertInstanceOf(LoadStatement::class, $statement);
+
+        self::expectException(UnsupportedSqlException::class);
+        self::expectExceptionMessage($message);
+
+        (new MySqlLoadDataProjector($registry))->project($sql, $statement);
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlQueryGuardTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlQueryGuardTest.php
@@ -159,6 +159,16 @@ class MySqlQueryGuardTest extends QueryClassifierContractTest
         self::assertSame(QueryKind::WRITE_SIMULATED, $guard->classify("REPLACE INTO users (id, name) VALUES (1, 'Alice')"));
     }
 
+    public function testClassifiesLoadDataAsWriteSimulated(): void
+    {
+        $guard = new MySqlQueryGuard(new MySqlParser());
+
+        self::assertSame(
+            QueryKind::WRITE_SIMULATED,
+            $guard->classify("LOAD DATA LOCAL INFILE '/tmp/users.tsv' INTO TABLE users"),
+        );
+    }
+
     public function testClassifiesEmptySqlAsNull(): void
     {
         $guard = new MySqlQueryGuard(new MySqlParser());

--- a/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlRewriterTest.php
@@ -13,6 +13,7 @@ use ZtdQuery\Platform\MySql\DmlWhereClauseExtractor;
 use ZtdQuery\Platform\MySql\InsertSelectSourceExtractor;
 use ZtdQuery\Platform\MySql\Mutation\AlterTableMutation;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
+use ZtdQuery\Platform\MySql\MySqlLoadDataProjector;
 use ZtdQuery\Platform\MySql\MySqlParser;
 use ZtdQuery\Platform\MySql\MySqlPartitioningParser;
 use ZtdQuery\Platform\MySql\MySqlPartitionSelectionRewriter;
@@ -52,6 +53,7 @@ use ZtdQuery\Shadow\ShadowTableState;
 #[UsesClass(MySqlParser::class)]
 #[UsesClass(MySqlMutationResolver::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlUpsertExpressionParser::class)]
+#[UsesClass(MySqlLoadDataProjector::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 #[UsesClass(MySqlPartitioningParser::class)]

--- a/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliLoadDataTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Integration/MysqliLoadDataTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Mysqli\ZtdMysqli;
+
+#[CoversNothing]
+#[Large]
+final class MysqliLoadDataTest extends TestCase
+{
+    public function testLocalInfileLoadsOnlyTheShadowTable(): void
+    {
+        [$databaseName, $rawMysqli] = MySqlContainer::createTestDatabase();
+        $table = 'load_' . bin2hex(random_bytes(8));
+        $rawMysqli->query(sprintf('CREATE TABLE `%s` (id INT PRIMARY KEY, name VARCHAR(100))', $table));
+        $ztdMysqli = ZtdMysqli::fromMysqli($rawMysqli);
+
+        try {
+            $stream = tmpfile();
+            self::assertIsResource($stream);
+            self::assertSame(14, fwrite($stream, "1\tAlice\n2\tBob\n"));
+            $metadata = stream_get_meta_data($stream);
+            $path = $metadata['uri'] ?? null;
+            self::assertIsString($path);
+
+            self::assertNotFalse($ztdMysqli->query(sprintf(
+                "LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s`",
+                str_replace("'", "''", $path),
+                $table,
+            )));
+            self::assertSame(2, $ztdMysqli->lastAffectedRows());
+
+            $rows = $ztdMysqli->query(sprintf('SELECT id, name FROM `%s` ORDER BY id', $table));
+            self::assertInstanceOf(\mysqli_result::class, $rows);
+            self::assertSame([
+                ['id' => 1, 'name' => 'Alice'],
+                ['id' => 2, 'name' => 'Bob'],
+            ], $rows->fetch_all(MYSQLI_ASSOC));
+
+            $physical = $rawMysqli->query(sprintf('SELECT COUNT(*) AS count FROM `%s`', $table));
+            self::assertInstanceOf(\mysqli_result::class, $physical);
+            self::assertSame([['count' => '0']], $physical->fetch_all(MYSQLI_ASSOC));
+        } finally {
+            $rawMysqli->query(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Integration/MySql/LoadDataTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/MySql/LoadDataTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\MySql;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\MySqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_mysql
+ * @group integration
+ * @group mysql
+ */
+#[CoversNothing]
+#[Large]
+final class LoadDataTest extends TestCase
+{
+    public function testLoadDataVariantsMutateOnlyTheShadowTable(): void
+    {
+        [$databaseName, $pdo] = MySqlContainer::createTestDatabase();
+        $table = 'load_' . bin2hex(random_bytes(8));
+
+        try {
+            $pdo->exec(sprintf(
+                'CREATE TABLE `%s` (id INT PRIMARY KEY, name VARCHAR(100) DEFAULT \'unknown\')',
+                $table,
+            ));
+            $ztdPdo = ZtdPdo::fromPdo($pdo);
+
+            $initial = tmpfile();
+            self::assertIsResource($initial);
+            $initialData = "id,name\r\n>1,\"Alice, A\"\r\n>2,\\N\r\n";
+            self::assertSame(strlen($initialData), fwrite($initial, $initialData));
+            $initialMetadata = stream_get_meta_data($initial);
+            $initialPath = $initialMetadata['uri'] ?? null;
+            self::assertIsString($initialPath);
+            $initialSql = sprintf(
+                "LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s` "
+                . "FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' ESCAPED BY '\\\\' "
+                . "LINES STARTING BY '>' TERMINATED BY '\\r\\n' IGNORE 1 LINES (id, @raw) "
+                . "SET name = COALESCE(@raw, 'unknown')",
+                str_replace("'", "''", $initialPath),
+                $table,
+            );
+            self::assertSame(2, $ztdPdo->exec($initialSql));
+
+            $replacement = tmpfile();
+            self::assertIsResource($replacement);
+            self::assertSame(14, fwrite($replacement, "2\tBob\n3\tCarol\n"));
+            $replacementMetadata = stream_get_meta_data($replacement);
+            $replacementPath = $replacementMetadata['uri'] ?? null;
+            self::assertIsString($replacementPath);
+            self::assertSame(2, $ztdPdo->exec(sprintf(
+                "LOAD DATA INFILE '%s' REPLACE INTO TABLE `%s`",
+                str_replace("'", "''", $replacementPath),
+                $table,
+            )));
+
+            $ignored = tmpfile();
+            self::assertIsResource($ignored);
+            self::assertSame(17, fwrite($ignored, "3\tIgnored\n4\tDave\n"));
+            $ignoredMetadata = stream_get_meta_data($ignored);
+            $ignoredPath = $ignoredMetadata['uri'] ?? null;
+            self::assertIsString($ignoredPath);
+            self::assertSame(1, $ztdPdo->exec(sprintf(
+                "LOAD DATA INFILE '%s' IGNORE INTO TABLE `%s`",
+                str_replace("'", "''", $ignoredPath),
+                $table,
+            )));
+
+            $rows = $ztdPdo->query(sprintf('SELECT id, name FROM `%s` ORDER BY id', $table));
+            self::assertNotFalse($rows);
+            self::assertSame([
+                ['id' => 1, 'name' => 'Alice, A'],
+                ['id' => 2, 'name' => 'Bob'],
+                ['id' => 3, 'name' => 'Carol'],
+                ['id' => 4, 'name' => 'Dave'],
+            ], $rows->fetchAll());
+
+            $physical = $pdo->query(sprintf('SELECT COUNT(*) FROM `%s`', $table));
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $databaseName));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- classify `LOAD DATA` as a simulated write and project file records into the existing INSERT/REPLACE shadow pipeline
- support LOCAL, REPLACE, IGNORE, field/line formats, user variables, SET expressions, NULL markers, and generated-column exclusion
- extend the official-grammar SQLFaker provider and all MySQL robustness fuzz targets
- cover PDO and MySQLi behavior against a real MySQL container while asserting the physical table remains untouched

## Verification
- MySQL PHPUnit: 1,071 tests / 2,695 assertions
- PDO LOAD DATA integration: 1 test / 16 assertions
- MySQLi LOAD DATA integration: 1 test / 9 assertions
- lint/PHPStan: mysql, sql-faker, pdo-adapter, mysqli-adapter
- MySqlLoadDataProjector Infection: 386/451 killed, Covered MSI 85%
- SQLFaker loadDataStatement Infection: 3/3 killed, Covered MSI 100%
- MySQL classify/rewrite/full fuzz targets: 200 runs each

Closes #164