### PR TITLE
fix(postgres): honor partial-index conflict targets

### DIFF
--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -145,6 +145,19 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function partialIndexUpsertStatement(): GenerationPlan
+    {
+        return GenerationPlan::constrained('InsertStmt', [
+            'opt_with_clause' => [ProductionPattern::exactly()],
+            'qualified_name' => [ProductionPattern::exactly('ColId')],
+            'insert_rest' => [ProductionPattern::exactly('DEFAULT', 'VALUES')],
+            'opt_on_conflict' => [ProductionPattern::containing('DO', 'UPDATE')],
+            'opt_conf_expr' => [ProductionPattern::containing('index_params', 'where_clause')],
+            'where_clause' => [ProductionPattern::nonEmpty()],
+        ])->requiringNonEmpty();
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(): GenerationPlan
     {
         return GenerationPlan::constrained('TableConstraint', [

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -426,6 +426,12 @@ final class PostgreSqlProvider extends Base
     }
 
     /** @return non-empty-string */
+    public function partialIndexUpsertStatement(int $maxDepth = 40): string
+    {
+        return $this->sql->generatePartialIndexUpsertStatement($maxDepth);
+    }
+
+    /** @return non-empty-string */
     public function temporaryTableStatement(int $maxDepth = 40): string
     {
         return $this->sql->generate(

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -428,7 +428,9 @@ final class PostgreSqlProvider extends Base
     /** @return non-empty-string */
     public function partialIndexUpsertStatement(int $maxDepth = 40): string
     {
-        return $this->sql->generatePartialIndexUpsertStatement($maxDepth);
+        return $this->sql->generate(
+            GenerationPlans::partialIndexUpsertStatement()->withMaxDepth($maxDepth),
+        );
     }
 
     /** @return non-empty-string */

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -178,7 +178,13 @@ final class GenerationPlansTest extends TestCase
         $plan = GenerationPlans::partialIndexUpsertStatement();
 
         self::assertSame('InsertStmt', $plan->startRule());
-        self::assertNotNull($plan->patternAt('opt_conf_expr', 0));
-        self::assertNotNull($plan->patternAt('where_clause', 0));
+        self::assertTrue($plan->patternAt('opt_with_clause', 0)?->matches([]) ?? false);
+        self::assertTrue($plan->patternAt('qualified_name', 0)?->matches(['ColId']) ?? false);
+        self::assertTrue($plan->patternAt('insert_rest', 0)?->matches(['DEFAULT', 'VALUES']) ?? false);
+        self::assertTrue($plan->patternAt('opt_on_conflict', 0)?->matches(['DO', 'UPDATE']) ?? false);
+        self::assertTrue(
+            $plan->patternAt('opt_conf_expr', 0)?->matches(['index_params', 'where_clause']) ?? false,
+        );
+        self::assertTrue($plan->patternAt('where_clause', 0)?->matches(['a_expr']) ?? false);
     }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/GenerationPlansTest.php
@@ -172,4 +172,13 @@ final class GenerationPlansTest extends TestCase
 
         self::assertSame('CopyStmt', $plan->startRule());
     }
+
+    public function testPartialIndexUpsertPlanRequiresAConflictPredicate(): void
+    {
+        $plan = GenerationPlans::partialIndexUpsertStatement();
+
+        self::assertSame('InsertStmt', $plan->startRule());
+        self::assertNotNull($plan->patternAt('opt_conf_expr', 0));
+        self::assertNotNull($plan->patternAt('where_clause', 0));
+    }
 }

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -96,13 +96,26 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
-    public function testPartialIndexUpsertStatementIncludesArbiterPredicate(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testPartialIndexUpsertStatementIncludesArbiterPredicate(int $seed): void
     {
-        $sql = (new PostgreSqlProvider(Factory::create()))->partialIndexUpsertStatement();
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new PostgreSqlProvider($faker);
+        $sql = $provider->partialIndexUpsertStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'pg-17.2', true))
+            ->tokenize($sql);
 
-        self::assertStringStartsWith('INSERT INTO users ', $sql);
-        self::assertStringContainsString("ON CONFLICT (email) WHERE status = 'active'", $sql);
-        self::assertStringEndsWith('DO UPDATE SET name = EXCLUDED.name', $sql);
+        self::assertSame($sql, $provider->partialIndexUpsertStatement(40));
+        $conflict = array_search('CONFLICT', $tokens, true);
+        $where = array_search('WHERE', $tokens, true);
+        $update = array_search('UPDATE', $tokens, true);
+        self::assertIsInt($conflict);
+        self::assertIsInt($where);
+        self::assertIsInt($update);
+        self::assertGreaterThan($conflict, $where);
+        self::assertGreaterThan($where, $update);
     }
 
     #[DataProvider('providerTargetedGenerationSeed')]

--- a/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSqlProviderTest.php
@@ -96,6 +96,15 @@ final class PostgreSqlProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
+    public function testPartialIndexUpsertStatementIncludesArbiterPredicate(): void
+    {
+        $sql = (new PostgreSqlProvider(Factory::create()))->partialIndexUpsertStatement();
+
+        self::assertStringStartsWith('INSERT INTO users ', $sql);
+        self::assertStringContainsString("ON CONFLICT (email) WHERE status = 'active'", $sql);
+        self::assertStringEndsWith('DO UPDATE SET name = EXCLUDED.name', $sql);
+    }
+
     #[DataProvider('providerTargetedGenerationSeed')]
     public function testTemporaryTableStatement(int $seed): void
     {

--- a/packages/ztd-query-core/src/Schema/PartialUniqueIndex.php
+++ b/packages/ztd-query-core/src/Schema/PartialUniqueIndex.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Schema;
+
+/**
+ * A unique index whose candidate rows are restricted by a SQL predicate.
+ */
+final class PartialUniqueIndex
+{
+    /** @var non-empty-list<string> */
+    public readonly array $columns;
+
+    /** @param list<string> $columns */
+    public function __construct(
+        public readonly string $name,
+        array $columns,
+        public readonly string $predicate,
+    ) {
+        if (trim($name) === '' || $columns === [] || trim($predicate) === '') {
+            throw new \InvalidArgumentException('Partial unique indexes require a name, columns, and predicate.');
+        }
+        $this->columns = $columns;
+    }
+}

--- a/packages/ztd-query-core/src/Schema/TableDefinition.php
+++ b/packages/ztd-query-core/src/Schema/TableDefinition.php
@@ -32,6 +32,9 @@ final class TableDefinition
 
     public readonly ?TablePartitionRelation $partitionRelation;
 
+    /** @var array<string, PartialUniqueIndex> */
+    public readonly array $partialUniqueIndexes;
+
     /**
      * @param list<string> $columns Column names in declaration order.
      * @param array<string, string> $columnTypes Column name => MySQL type string.
@@ -46,6 +49,7 @@ final class TableDefinition
      * @param TablePartitioning|null $partitioning Named partition selection predicates.
      * @param TablePartitionKey|null $partitionKey Declarative partition key metadata.
      * @param TablePartitionRelation|null $partitionRelation Parent partition relationship.
+     * @param array<string, PartialUniqueIndex> $partialUniqueIndexes Partial unique indexes keyed by name.
      */
     public function __construct(
         public readonly array $columns,
@@ -61,6 +65,7 @@ final class TableDefinition
         ?TablePartitioning $partitioning = null,
         ?TablePartitionKey $partitionKey = null,
         ?TablePartitionRelation $partitionRelation = null,
+        array $partialUniqueIndexes = [],
     ) {
         $this->typedColumns = $typedColumns;
         $this->columnDefaults = $columnDefaults;
@@ -70,6 +75,7 @@ final class TableDefinition
         $this->partitioning = $partitioning;
         $this->partitionKey = $partitionKey;
         $this->partitionRelation = $partitionRelation;
+        $this->partialUniqueIndexes = $partialUniqueIndexes;
     }
 
     public function candidateKeys(): CandidateKeySet
@@ -93,6 +99,7 @@ final class TableDefinition
             $partitioning,
             $this->partitionKey,
             $this->partitionRelation,
+            $this->partialUniqueIndexes,
         );
     }
 
@@ -112,6 +119,7 @@ final class TableDefinition
             $this->partitioning,
             $partitionKey,
             $this->partitionRelation,
+            $this->partialUniqueIndexes,
         );
     }
 
@@ -131,6 +139,30 @@ final class TableDefinition
             $this->partitioning,
             $this->partitionKey,
             $partitionRelation,
+            $this->partialUniqueIndexes,
+        );
+    }
+
+    public function withPartialUniqueIndex(PartialUniqueIndex $index): self
+    {
+        $indexes = $this->partialUniqueIndexes;
+        $indexes[$index->name] = $index;
+
+        return new self(
+            $this->columns,
+            $this->columnTypes,
+            $this->primaryKeys,
+            $this->notNullColumns,
+            $this->uniqueConstraints,
+            $this->typedColumns,
+            $this->columnDefaults,
+            $this->identityStrategies,
+            $this->generatedExpressions,
+            $this->foreignKeys,
+            $this->partitioning,
+            $this->partitionKey,
+            $this->partitionRelation,
+            $indexes,
         );
     }
 }

--- a/packages/ztd-query-core/src/Shadow/Mutation/InsertMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/InsertMutation.php
@@ -52,6 +52,8 @@ final class InsertMutation implements DataMutation
 
     private CandidateKeySet $candidateKeys;
 
+    private ?UpsertExpression $conflictPredicate;
+
     /**
      * @param string $tableName Target table.
      * @param array<int, string> $primaryKeys Primary key columns.
@@ -60,6 +62,7 @@ final class InsertMutation implements DataMutation
      * @param string $sql Original SQL statement for exception messages.
      * @param bool $validateConstraints Whether to validate constraints.
      * @param CandidateKeySet|null $candidateKeys Candidate keys used for duplicate detection.
+     * @param UpsertExpression|null $conflictPredicate Condition that controls candidate-key eligibility.
      */
     public function __construct(
         string $tableName,
@@ -69,6 +72,7 @@ final class InsertMutation implements DataMutation
         string $sql = '',
         bool $validateConstraints = false,
         ?CandidateKeySet $candidateKeys = null,
+        ?UpsertExpression $conflictPredicate = null,
     ) {
         $this->tableName = $tableName;
         $this->ignore = $ignore;
@@ -76,6 +80,7 @@ final class InsertMutation implements DataMutation
         $this->sql = $sql;
         $this->validateConstraints = $validateConstraints;
         $this->candidateKeys = $candidateKeys ?? CandidateKeySet::fromSchema($primaryKeys);
+        $this->conflictPredicate = $conflictPredicate;
     }
 
     /**
@@ -91,7 +96,7 @@ final class InsertMutation implements DataMutation
                 $this->validateNotNullConstraints($row);
             }
 
-            $conflict = $this->candidateKeys->findConflict($row, $existingRows);
+            $conflict = $this->findConflict($row, $existingRows);
             if ($conflict !== null) {
                 if ($this->ignore) {
                     continue;
@@ -204,5 +209,28 @@ final class InsertMutation implements DataMutation
             $values[$col] = $row[$col] ?? null;
         }
         return $values;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<int, array<string, mixed>> $existingRows
+     */
+    private function findConflict(array $row, array $existingRows): ?\ZtdQuery\Schema\CandidateKeyConflict
+    {
+        if ($this->conflictPredicate === null) {
+            return $this->candidateKeys->findConflict($row, $existingRows);
+        }
+        if (!$this->conflictPredicate->matches($row, $row, $this->tableName)) {
+            return null;
+        }
+
+        $eligibleRows = [];
+        foreach ($existingRows as $index => $existingRow) {
+            if ($this->conflictPredicate->matches($existingRow, $existingRow, $this->tableName)) {
+                $eligibleRows[$index] = $existingRow;
+            }
+        }
+
+        return $this->candidateKeys->findConflict($row, $eligibleRows);
     }
 }

--- a/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/UpsertMutation.php
@@ -45,6 +45,8 @@ final class UpsertMutation implements DataMutation
 
     private ?UpsertExpression $updatePredicate;
 
+    private ?UpsertExpression $conflictPredicate;
+
     private bool $databaseEvaluated;
 
     /** @var array<string, string> */
@@ -74,6 +76,7 @@ final class UpsertMutation implements DataMutation
         bool $databaseEvaluated = false,
         array $updateSqlValues = [],
         ?string $updateSqlPredicate = null,
+        ?UpsertExpression $conflictPredicate = null,
     ) {
         $this->tableName = $tableName;
         $this->primaryKeys = $primaryKeys;
@@ -84,6 +87,7 @@ final class UpsertMutation implements DataMutation
         $this->candidateKeys = $candidateKeys ?? CandidateKeySet::fromSchema($primaryKeys);
         $this->updatePredicate = $updatePredicate;
         $this->databaseEvaluated = $databaseEvaluated;
+        $this->conflictPredicate = $conflictPredicate;
     }
 
     /**
@@ -99,7 +103,7 @@ final class UpsertMutation implements DataMutation
             $incomingRow = $this->databaseEvaluated
                 ? $codec->incomingRow($row, count($this->updateColumns))
                 : $row;
-            $conflict = $this->candidateKeys->findConflict($incomingRow, $existingRows);
+            $conflict = $this->findConflict($incomingRow, $existingRows);
             if ($conflict !== null) {
                 $existingIndex = $conflict->rowIndex;
                 $updatedRow = $existingRows[$existingIndex];
@@ -203,5 +207,27 @@ final class UpsertMutation implements DataMutation
     public function resultRows(): array
     {
         return $this->resultRows;
+    }
+    /**
+     * @param array<string, mixed> $incomingRow
+     * @param array<int, array<string, mixed>> $existingRows
+     */
+    private function findConflict(array $incomingRow, array $existingRows): ?\ZtdQuery\Schema\CandidateKeyConflict
+    {
+        if ($this->conflictPredicate === null) {
+            return $this->candidateKeys->findConflict($incomingRow, $existingRows);
+        }
+        if (!$this->conflictPredicate->matches($incomingRow, $incomingRow, $this->tableName)) {
+            return null;
+        }
+
+        $eligibleRows = [];
+        foreach ($existingRows as $index => $existingRow) {
+            if ($this->conflictPredicate->matches($existingRow, $existingRow, $this->tableName)) {
+                $eligibleRows[$index] = $existingRow;
+            }
+        }
+
+        return $this->candidateKeys->findConflict($incomingRow, $eligibleRows);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Schema/PartialUniqueIndexTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/PartialUniqueIndexTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Schema\PartialUniqueIndex;
+
+#[CoversClass(PartialUniqueIndex::class)]
+final class PartialUniqueIndexTest extends TestCase
+{
+    public function testRetainsStructuredIndexMetadata(): void
+    {
+        $index = new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'");
+
+        self::assertSame('users_active_email', $index->name);
+        self::assertSame(['email'], $index->columns);
+        self::assertSame("status = 'active'", $index->predicate);
+    }
+
+    /** @param list<string> $columns */
+    #[TestWith(['', ['email'], "status = 'active'"], 'missing name')]
+    #[TestWith(['users_active_email', [], "status = 'active'"], 'missing columns')]
+    #[TestWith(['users_active_email', ['email'], ' '], 'missing predicate')]
+    public function testRejectsIncompleteIndexMetadata(string $name, array $columns, string $predicate): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new PartialUniqueIndex($name, $columns, $predicate);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/PartialUniqueIndexTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/PartialUniqueIndexTest.php
@@ -23,6 +23,7 @@ final class PartialUniqueIndexTest extends TestCase
 
     /** @param list<string> $columns */
     #[TestWith(['', ['email'], "status = 'active'"], 'missing name')]
+    #[TestWith([' ', ['email'], "status = 'active'"], 'blank name')]
     #[TestWith(['users_active_email', [], "status = 'active'"], 'missing columns')]
     #[TestWith(['users_active_email', ['email'], ' '], 'missing predicate')]
     public function testRejectsIncompleteIndexMetadata(string $name, array $columns, string $predicate): void

--- a/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/TableDefinitionTest.php
@@ -10,6 +10,7 @@ use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
 use ZtdQuery\Schema\ForeignKeyDefinition;
+use ZtdQuery\Schema\PartialUniqueIndex;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TablePartitioning;
 use ZtdQuery\Schema\TablePartitionKey;
@@ -21,6 +22,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(ColumnType::class)]
 #[UsesClass(CandidateKeySet::class)]
 #[UsesClass(ForeignKeyDefinition::class)]
+#[UsesClass(PartialUniqueIndex::class)]
 #[UsesClass(TablePartitioning::class)]
 #[UsesClass(TablePartitionKey::class)]
 #[UsesClass(TablePartitionRelation::class)]
@@ -76,6 +78,7 @@ final class TableDefinitionTest extends TestCase
         self::assertNull($definition->partitioning);
         self::assertNull($definition->partitionKey);
         self::assertNull($definition->partitionRelation);
+        self::assertSame([], $definition->partialUniqueIndexes);
     }
 
     public function testWithPartitioningPreservesSchemaAndReturnsNewDefinition(): void
@@ -103,5 +106,18 @@ final class TableDefinitionTest extends TestCase
         self::assertSame($relation, $partition->partitionRelation);
         self::assertSame($definition->columns, $partition->columns);
         self::assertSame($definition->candidateKeys()->keys(), $partition->candidateKeys()->keys());
+    }
+
+    public function testWithPartialUniqueIndexPreservesSchemaAndIndexesByName(): void
+    {
+        $definition = new TableDefinition(['email', 'status'], ['email' => 'TEXT', 'status' => 'TEXT'], [], [], []);
+        $index = new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'");
+
+        $indexed = $definition->withPartialUniqueIndex($index);
+
+        self::assertNotSame($definition, $indexed);
+        self::assertSame([], $definition->partialUniqueIndexes);
+        self::assertSame($index, $indexed->partialUniqueIndexes['users_active_email']);
+        self::assertSame($definition->columns, $indexed->columns);
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/InsertMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/InsertMutationTest.php
@@ -10,6 +10,9 @@ use ZtdQuery\Schema\CandidateKeyConflict;
 use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
+use ZtdQuery\Shadow\Mutation\UpsertColumnSource;
+use ZtdQuery\Shadow\Mutation\UpsertExpression;
+use ZtdQuery\Shadow\Mutation\UpsertExpressionKind;
 use ZtdQuery\Shadow\ShadowStore;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -21,6 +24,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(ShadowStore::class)]
 #[UsesClass(CandidateKeyConflict::class)]
 #[UsesClass(CandidateKeySet::class)]
+#[UsesClass(UpsertExpression::class)]
 #[CoversClass(InsertMutation::class)]
 final class InsertMutationTest extends TestCase
 {
@@ -249,5 +253,36 @@ final class InsertMutationTest extends TestCase
 
         self::assertCount(1, $store->get('users'));
         self::assertSame('Alice', $store->get('users')[0]['name']);
+    }
+
+    public function testInsertIgnoreUsesPartialConflictPredicate(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [[
+            'email' => 'alice@example.com',
+            'status' => 'inactive',
+        ]]);
+        $mutation = new InsertMutation(
+            'users',
+            ignore: true,
+            candidateKeys: CandidateKeySet::fromSchema([], ['users_active_email' => ['email']]),
+            conflictPredicate: UpsertExpression::binary(
+                UpsertExpressionKind::Equal,
+                UpsertExpression::column(UpsertColumnSource::Existing, 'status'),
+                UpsertExpression::literal('active'),
+            ),
+        );
+
+        $mutation->apply($store, [
+            ['email' => 'alice@example.com', 'status' => 'active'],
+            ['email' => 'alice@example.com', 'status' => 'active'],
+            ['email' => 'alice@example.com', 'status' => 'inactive'],
+        ]);
+
+        self::assertSame([
+            ['email' => 'alice@example.com', 'status' => 'inactive'],
+            ['email' => 'alice@example.com', 'status' => 'active'],
+            ['email' => 'alice@example.com', 'status' => 'inactive'],
+        ], $store->get('users'));
     }
 }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/UpsertMutationTest.php
@@ -492,4 +492,42 @@ final class UpsertMutationTest extends TestCase
             ['id' => 1, 'quantity' => 7, $codec->valueColumn(0) => 107],
         ]);
     }
+
+    public function testConflictPredicateRestrictsIncomingAndExistingCandidateRows(): void
+    {
+        $store = new ShadowStore();
+        $store->set('users', [[
+            'email' => 'alice@example.com',
+            'status' => 'inactive',
+            'login_count' => 2,
+        ]]);
+        $mutation = new UpsertMutation(
+            'users',
+            [],
+            ['login_count'],
+            ['login_count' => UpsertExpression::binary(
+                UpsertExpressionKind::Add,
+                UpsertExpression::column(UpsertColumnSource::Existing, 'login_count'),
+                UpsertExpression::literal(1),
+            )],
+            CandidateKeySet::fromSchema([], ['users_active_email' => ['email']]),
+            conflictPredicate: UpsertExpression::binary(
+                UpsertExpressionKind::Equal,
+                UpsertExpression::column(UpsertColumnSource::Existing, 'status'),
+                UpsertExpression::literal('active'),
+            ),
+        );
+
+        $mutation->apply($store, [
+            ['email' => 'alice@example.com', 'status' => 'active', 'login_count' => 5],
+            ['email' => 'alice@example.com', 'status' => 'active', 'login_count' => 1],
+            ['email' => 'alice@example.com', 'status' => 'inactive', 'login_count' => 9],
+        ]);
+
+        self::assertSame([
+            ['email' => 'alice@example.com', 'status' => 'inactive', 'login_count' => 2],
+            ['email' => 'alice@example.com', 'status' => 'active', 'login_count' => 6],
+            ['email' => 'alice@example.com', 'status' => 'inactive', 'login_count' => 9],
+        ], $store->get('users'));
+    }
 }

--- a/packages/ztd-query-mysql/src/MySqlNativeUpsertProjector.php
+++ b/packages/ztd-query-mysql/src/MySqlNativeUpsertProjector.php
@@ -43,6 +43,7 @@ final class MySqlNativeUpsertProjector
         array $candidateKeys,
         array $assignments,
         ?string $predicate = null,
+        ?string $conflictPredicate = null,
         ?string $incomingNamespace = null,
     ): string {
         if ($assignments === [] || $candidateKeys === []) {
@@ -53,6 +54,23 @@ final class MySqlNativeUpsertProjector
         $existingAlias = $this->quoter->quote(self::EXISTING_ALIAS);
         $table = $this->quoter->quote($tableName);
         $conflict = $this->conflictPredicate($candidateKeys, $existingAlias, $incomingAlias);
+        if ($conflictPredicate !== null) {
+            $existingPredicate = $this->bindExpression(
+                $conflictPredicate,
+                $tableName,
+                $tableColumns,
+                self::EXISTING_ALIAS,
+                $incomingNamespace,
+            );
+            $incomingPredicate = $this->bindExpression(
+                $conflictPredicate,
+                $tableName,
+                $tableColumns,
+                self::INCOMING_ALIAS,
+                $incomingNamespace,
+            );
+            $conflict = "($conflict AND ($existingPredicate) AND ($incomingPredicate))";
+        }
         $selects = [];
         foreach ($tableColumns as $column) {
             $quoted = $this->quoter->quote($column);
@@ -61,12 +79,22 @@ final class MySqlNativeUpsertProjector
 
         $codec = new UpsertMutationRow();
         foreach (array_values($assignments) as $index => $expression) {
-            $evaluated = $this->bindExpression($expression, $tableName, $tableColumns, $incomingNamespace);
+            $evaluated = $this->bindExpression(
+                $expression,
+                $tableName,
+                $tableColumns,
+                incomingNamespace: $incomingNamespace,
+            );
             $metadata = $this->quoter->quote($codec->valueColumn($index));
             $selects[] = "(SELECT $evaluated FROM $table AS $existingAlias WHERE $conflict LIMIT 1) AS $metadata";
         }
         if ($predicate !== null) {
-            $evaluated = $this->bindExpression($predicate, $tableName, $tableColumns, $incomingNamespace);
+            $evaluated = $this->bindExpression(
+                $predicate,
+                $tableName,
+                $tableColumns,
+                incomingNamespace: $incomingNamespace,
+            );
             $metadata = $this->quoter->quote($codec->predicateColumn());
             $selects[] = "(SELECT $evaluated FROM $table AS $existingAlias WHERE $conflict LIMIT 1) AS $metadata";
         }
@@ -100,7 +128,8 @@ final class MySqlNativeUpsertProjector
         string $expression,
         string $tableName,
         array $tableColumns,
-        ?string $incomingNamespace,
+        string $unqualifiedAlias = self::EXISTING_ALIAS,
+        ?string $incomingNamespace = null,
     ): string {
         $tokens = SqlTokenStream::tokenize($expression, $this->dialect)->significantTokens();
         $subqueryTokens = $this->subqueryTokenIndexes($tokens);
@@ -160,7 +189,7 @@ final class MySqlNativeUpsertProjector
             $replacements[] = [
                 'offset' => $token->offset,
                 'length' => strlen($token->text),
-                'value' => $this->qualified(self::EXISTING_ALIAS, $name),
+                'value' => $this->qualified($unqualifiedAlias, $name),
             ];
         }
 

--- a/packages/ztd-query-mysql/tests/Unit/MySqlNativeUpsertProjectorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlNativeUpsertProjectorTest.php
@@ -181,4 +181,25 @@ final class MySqlNativeUpsertProjectorTest extends TestCase
             $result,
         );
     }
+
+    public function testBindsPartialConflictPredicateToExistingAndIncomingRows(): void
+    {
+        $result = (new MySqlNativeUpsertProjector())->project(
+            'SELECT \'alice@example.com\' AS `email`, \'active\' AS `status`, 1 AS `login_count`',
+            'users',
+            ['email', 'status', 'login_count'],
+            ['users_active_email' => ['email']],
+            ['login_count' => 'GREATEST(login_count, VALUES(login_count))'],
+            conflictPredicate: "status = 'active'",
+        );
+
+        self::assertStringContainsString(
+            '`__ztd_existing`.`email` = `__ztd_incoming`.`email`',
+            $result,
+        );
+        self::assertStringContainsString(
+            '(`__ztd_existing`.`status` = \'active\') AND (`__ztd_incoming`.`status` = \'active\')',
+            $result,
+        );
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/PartialIndexOnConflictTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/PostgreSql/PartialIndexOnConflictTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PostgreSql;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\PostgreSqlContainer;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_pgsql
+ * @group integration
+ * @group postgres
+ */
+#[CoversNothing]
+#[Large]
+final class PartialIndexOnConflictTest extends TestCase
+{
+    public function testPartialUniqueIndexUpsertsRemainInTheShadowStore(): void
+    {
+        [$schemaName, $rawPdo] = PostgreSqlContainer::createTestSchema();
+        $table = 'partial_' . bin2hex(random_bytes(8));
+
+        try {
+            $rawPdo->exec(
+                "CREATE TABLE {$table} (email TEXT NOT NULL, status TEXT NOT NULL, login_count INTEGER NOT NULL)",
+            );
+            $rawPdo->exec(
+                "CREATE UNIQUE INDEX {$table}_active_email ON {$table} (email) WHERE status = 'active'",
+            );
+            $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+            self::assertSame(1, $ztdPdo->exec(
+                "INSERT INTO {$table} VALUES ('alice@example.com', 'active', 5)",
+            ));
+
+            $prepared = $ztdPdo->prepare(
+                "INSERT INTO {$table} VALUES (\$1, \$2, \$3) "
+                . "ON CONFLICT (email) WHERE status = 'active' "
+                . "DO UPDATE SET login_count = {$table}.login_count + EXCLUDED.login_count",
+            );
+            self::assertInstanceOf(\PDOStatement::class, $prepared);
+            self::assertTrue($prepared->execute(['alice@example.com', 'active', 1]));
+            self::assertSame(1, $prepared->rowCount());
+
+            self::assertSame(1, $ztdPdo->exec(
+                "INSERT INTO {$table} VALUES ('alice@example.com', 'active', 4) "
+                . "ON CONFLICT (email) WHERE status = 'active' "
+                . "DO UPDATE SET login_count = GREATEST({$table}.login_count, EXCLUDED.login_count)",
+            ));
+            self::assertSame(0, $ztdPdo->exec(
+                "INSERT INTO {$table} VALUES ('alice@example.com', 'active', 99) "
+                . "ON CONFLICT (email) WHERE status = 'active' DO NOTHING",
+            ));
+            self::assertSame(1, $ztdPdo->exec(
+                "INSERT INTO {$table} VALUES ('alice@example.com', 'inactive', 7) "
+                . "ON CONFLICT (email) WHERE status = 'active' DO NOTHING",
+            ));
+
+            $rows = $ztdPdo->query("SELECT email, status, login_count FROM {$table} ORDER BY status");
+            self::assertNotFalse($rows);
+            self::assertSame([
+                ['email' => 'alice@example.com', 'status' => 'active', 'login_count' => 6],
+                ['email' => 'alice@example.com', 'status' => 'inactive', 'login_count' => 7],
+            ], $rows->fetchAll(PDO::FETCH_ASSOC));
+
+            $physical = $rawPdo->query("SELECT COUNT(*) FROM {$table}");
+            self::assertNotFalse($physical);
+            self::assertSame(0, (int) $physical->fetchColumn());
+        } finally {
+            $rawPdo->exec(sprintf('DROP SCHEMA IF EXISTS "%s" CASCADE', $schemaName));
+        }
+    }
+}

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/ClassifyTarget.php
@@ -65,6 +65,7 @@ final class ClassifyTarget
             fn (): string => $this->provider->doStatement(),
             fn (): string => $this->provider->mergeStatement(),
             fn (): string => $this->provider->copyStatement(maxDepth: 8),
+            fn (): string => $this->provider->partialIndexUpsertStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RewriteTarget.php
@@ -24,6 +24,7 @@ use ZtdQuery\Platform\Postgres\Transformer\InsertTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\PartialUniqueIndex;
 use ZtdQuery\Shadow\ShadowStore;
 
 final class RewriteTarget
@@ -93,6 +94,11 @@ final class RewriteTarget
         foreach ($schemas as $tableName => $createSql) {
             $definition = $schemaParser->parse($createSql);
             if ($definition !== null) {
+                if ($tableName === 'users') {
+                    $definition = $definition->withPartialUniqueIndex(
+                        new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'"),
+                    );
+                }
                 $registry->register($tableName, $definition);
             }
         }
@@ -149,6 +155,7 @@ final class RewriteTarget
             fn (): string => $this->provider->doStatement(),
             fn (): string => $this->provider->mergeStatement(),
             fn (): string => $this->provider->copyStatement(maxDepth: 8),
+            fn (): string => $this->provider->partialIndexUpsertStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
+++ b/packages/ztd-query-postgres/fuzz/Robustness/Target/RobustnessTarget.php
@@ -28,6 +28,7 @@ use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\PartialUniqueIndex;
 use ZtdQuery\Shadow\ShadowStore;
 
 final class RobustnessTarget
@@ -136,6 +137,11 @@ final class RobustnessTarget
         foreach ($schemas as $tableName => $createSql) {
             $definition = $schemaParser->parse($createSql);
             if ($definition !== null) {
+                if ($tableName === 'users') {
+                    $definition = $definition->withPartialUniqueIndex(
+                        new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'"),
+                    );
+                }
                 $registry->register($tableName, $definition);
             }
         }
@@ -193,6 +199,7 @@ final class RobustnessTarget
             fn (): string => $this->provider->doStatement(),
             fn (): string => $this->provider->mergeStatement(),
             fn (): string => $this->provider->copyStatement(maxDepth: 8),
+            fn (): string => $this->provider->partialIndexUpsertStatement(),
         ];
 
         $index = ord($input[0] ?? "\0") % count($generators);

--- a/packages/ztd-query-postgres/src/PgSqlConflictTarget.php
+++ b/packages/ztd-query-postgres/src/PgSqlConflictTarget.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Schema\CandidateKeySet;
+use ZtdQuery\Schema\PartialUniqueIndex;
+
+/**
+ * Structured ON CONFLICT arbiter target.
+ */
+final class PgSqlConflictTarget
+{
+    /**
+     * @param array<int, string> $columns
+     */
+    public function __construct(
+        public readonly bool $specified,
+        public readonly array $columns = [],
+        public readonly ?string $predicate = null,
+        public readonly ?string $constraint = null,
+    ) {
+        if ($constraint !== null && $columns !== []) {
+            throw new \InvalidArgumentException('A conflict target cannot use columns and a constraint together.');
+        }
+    }
+
+    /**
+     * @param array<string, PartialUniqueIndex> $partialIndexes
+     * @return array{keys: CandidateKeySet, predicate: string|null}
+     */
+    public function resolve(CandidateKeySet $candidateKeys, array $partialIndexes, string $sql): array
+    {
+        if (!$this->specified) {
+            return ['keys' => $candidateKeys, 'predicate' => null];
+        }
+
+        if ($this->constraint !== null) {
+            foreach ($candidateKeys->keys() as $name => $columns) {
+                if (strcasecmp($name, $this->constraint) === 0) {
+                    return ['keys' => new CandidateKeySet([$name => $columns]), 'predicate' => null];
+                }
+            }
+
+            throw new UnsupportedSqlException($sql, 'Cannot resolve ON CONFLICT constraint');
+        }
+
+        $targetColumns = self::normalizedColumns($this->columns);
+        $fullMatches = [];
+        foreach ($candidateKeys->keys() as $name => $columns) {
+            if (self::normalizedColumns($columns) === $targetColumns) {
+                $fullMatches[$name] = $columns;
+            }
+        }
+        if ($fullMatches !== []) {
+            return ['keys' => new CandidateKeySet($fullMatches), 'predicate' => null];
+        }
+
+        $partialMatches = [];
+        foreach ($partialIndexes as $name => $index) {
+            if (self::normalizedColumns($index->columns) === $targetColumns) {
+                $partialMatches[$name] = $index->columns;
+            }
+        }
+        if ($this->predicate === null || count($partialMatches) !== 1) {
+            throw new UnsupportedSqlException($sql, 'Cannot resolve ON CONFLICT partial index');
+        }
+
+        return ['keys' => new CandidateKeySet($partialMatches), 'predicate' => $this->predicate];
+    }
+
+    /**
+     * @param array<int, string> $columns
+     * @return list<string>
+     */
+    private static function normalizedColumns(array $columns): array
+    {
+        $normalized = [];
+        foreach ($columns as $column) {
+            $normalized[] = strtolower($column);
+        }
+        sort($normalized);
+
+        return $normalized;
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -83,12 +83,24 @@ final class PgSqlMutationResolver
         if ($this->parser->hasOnConflict($sql)) {
             $conflictInfo = $this->parser->extractOnConflictUpdateColumns($sql);
             $updateColumns = $conflictInfo['columns'];
+            $candidateKeys = $definition?->candidateKeys();
+            $conflictPredicate = null;
+            $target = $this->parser->extractOnConflictTarget($sql);
+            if ($target !== null && $definition !== null) {
+                $resolved = $target->resolve(
+                    $definition->candidateKeys(),
+                    $definition->partialUniqueIndexes,
+                    $sql,
+                );
+                $candidateKeys = $resolved['keys'];
+                $conflictPredicate = $resolved['predicate'];
+            }
+            $expressionParser = new PgSqlUpsertExpressionParser();
 
             if ($updateColumns !== []) {
-                $databaseEvaluated = $definition !== null && $definition->candidateKeys()->keys() !== [];
+                $databaseEvaluated = $candidateKeys !== null && $candidateKeys->keys() !== [];
                 /** @var array<string, \ZtdQuery\Shadow\Mutation\UpsertExpression|null> $resolvedValues */
                 $resolvedValues = [];
-                $expressionParser = new PgSqlUpsertExpressionParser();
                 foreach ($conflictInfo['values'] as $col => $value) {
                     $resolvedValues[$col] = $databaseEvaluated
                         ? $expressionParser->parseIfSupported($value, $tableName)
@@ -101,7 +113,7 @@ final class PgSqlMutationResolver
                     $primaryKeys,
                     $updateColumns,
                     $resolvedValues,
-                    $definition?->candidateKeys(),
+                    $candidateKeys,
                     $predicate !== null
                         ? ($databaseEvaluated
                             ? $expressionParser->parseIfSupported($predicate, $tableName)
@@ -110,6 +122,9 @@ final class PgSqlMutationResolver
                     databaseEvaluated: $databaseEvaluated,
                     updateSqlValues: $conflictInfo['values'],
                     updateSqlPredicate: $predicate,
+                    conflictPredicate: $conflictPredicate !== null
+                        ? $expressionParser->parse($conflictPredicate, $tableName)
+                        : null,
                 );
             }
 
@@ -117,7 +132,10 @@ final class PgSqlMutationResolver
                 $storageTable,
                 $primaryKeys,
                 true,
-                candidateKeys: $definition?->candidateKeys(),
+                candidateKeys: $candidateKeys,
+                conflictPredicate: $conflictPredicate !== null
+                    ? $expressionParser->parse($conflictPredicate, $tableName)
+                    : null,
             );
         }
 

--- a/packages/ztd-query-postgres/src/PgSqlNativeUpsertProjector.php
+++ b/packages/ztd-query-postgres/src/PgSqlNativeUpsertProjector.php
@@ -43,6 +43,7 @@ final class PgSqlNativeUpsertProjector
         array $candidateKeys,
         array $assignments,
         ?string $predicate = null,
+        ?string $conflictPredicate = null,
     ): string {
         if ($assignments === [] || $candidateKeys === []) {
             return $incomingSql;
@@ -52,6 +53,21 @@ final class PgSqlNativeUpsertProjector
         $existingAlias = $this->quoter->quote(self::EXISTING_ALIAS);
         $table = $this->quoter->quote($tableName);
         $conflict = $this->conflictPredicate($candidateKeys, $existingAlias, $incomingAlias);
+        if ($conflictPredicate !== null) {
+            $existingPredicate = $this->bindExpression(
+                $conflictPredicate,
+                $tableName,
+                $tableColumns,
+                self::EXISTING_ALIAS,
+            );
+            $incomingPredicate = $this->bindExpression(
+                $conflictPredicate,
+                $tableName,
+                $tableColumns,
+                self::INCOMING_ALIAS,
+            );
+            $conflict = "($conflict AND ($existingPredicate) AND ($incomingPredicate))";
+        }
         $selects = [];
         foreach ($tableColumns as $column) {
             $quoted = $this->quoter->quote($column);

--- a/packages/ztd-query-postgres/src/PgSqlNativeUpsertProjector.php
+++ b/packages/ztd-query-postgres/src/PgSqlNativeUpsertProjector.php
@@ -111,8 +111,12 @@ final class PgSqlNativeUpsertProjector
     }
 
     /** @param list<string> $tableColumns */
-    private function bindExpression(string $expression, string $tableName, array $tableColumns): string
-    {
+    private function bindExpression(
+        string $expression,
+        string $tableName,
+        array $tableColumns,
+        string $unqualifiedAlias = self::EXISTING_ALIAS,
+    ): string {
         $tokens = SqlTokenStream::tokenize($expression, $this->dialect)->significantTokens();
         $subqueryTokens = $this->subqueryTokenIndexes($tokens);
         $replacements = [];
@@ -150,7 +154,7 @@ final class PgSqlNativeUpsertProjector
             $replacements[] = [
                 'offset' => $token->offset,
                 'length' => strlen($token->text),
-                'value' => $this->qualified(self::EXISTING_ALIAS, $name),
+                'value' => $this->qualified($unqualifiedAlias, $name),
             ];
         }
 

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -122,6 +122,96 @@ final class PgSqlParser
         return preg_match('/\bON\s+CONFLICT\b/i', $sql) === 1;
     }
 
+    public function extractOnConflictTarget(string $sql): ?PgSqlConflictTarget
+    {
+        $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
+        $conflict = null;
+        foreach ($tokens as $index => $token) {
+            if ($token->isTopLevel()
+                && $token->isKeyword('ON')
+                && ($tokens[$index + 1] ?? null)?->isKeyword('CONFLICT') === true
+            ) {
+                $conflict = $index + 2;
+                break;
+            }
+        }
+        if ($conflict === null) {
+            return null;
+        }
+
+        $next = $tokens[$conflict] ?? null;
+        if ($next?->isKeyword('DO') === true) {
+            return new PgSqlConflictTarget(false);
+        }
+        if ($next?->isKeyword('ON') === true && ($tokens[$conflict + 1] ?? null)?->isKeyword('CONSTRAINT') === true) {
+            $constraintToken = $tokens[$conflict + 2] ?? null;
+            if ($constraintToken === null) {
+                return null;
+            }
+            $identifier = SqlTokenStream::tokenize($constraintToken->text)->identifierAt();
+            if ($identifier === null) {
+                return null;
+            }
+
+            return new PgSqlConflictTarget(true, constraint: $identifier['name']);
+        }
+        if ($next?->kind !== SqlTokenKind::Symbol || $next->text !== '(') {
+            return null;
+        }
+
+        $closing = null;
+        foreach ($tokens as $index => $token) {
+            if ($index > $conflict && $token->isTopLevel() && $token->kind === SqlTokenKind::Symbol && $token->text === ')') {
+                $closing = $index;
+                break;
+            }
+        }
+        if ($closing === null) {
+            return null;
+        }
+
+        $columnSql = substr(
+            $sql,
+            $next->endOffset(),
+            $tokens[$closing]->offset - $next->endOffset(),
+        );
+        $columns = [];
+        foreach (SqlTokenStream::tokenize($columnSql)->splitTopLevel() as $part) {
+            $stream = SqlTokenStream::tokenize($part);
+            $identifier = $stream->identifierAt();
+            if ($identifier === null || $identifier['next'] !== count($stream->significantTokens())) {
+                return null;
+            }
+            $columns[] = $identifier['name'];
+        }
+
+        $do = null;
+        foreach ($tokens as $index => $token) {
+            if ($index > $closing && $token->isTopLevel() && $token->isKeyword('DO')) {
+                $do = $index;
+                break;
+            }
+        }
+        if ($do === null) {
+            return null;
+        }
+
+        $predicate = null;
+        $afterColumns = $tokens[$closing + 1] ?? null;
+        if ($afterColumns?->isKeyword('WHERE') === true) {
+            $predicate = trim(substr(
+                $sql,
+                $afterColumns->endOffset(),
+                $tokens[$do]->offset - $afterColumns->endOffset(),
+            ));
+            if ($predicate === '') {
+                return null;
+            }
+        }
+
+        return new PgSqlConflictTarget(true, $columns, $predicate);
+    }
+
     /**
      * Extract ON CONFLICT ... DO UPDATE SET columns and values.
      *

--- a/packages/ztd-query-postgres/src/PgSqlParser.php
+++ b/packages/ztd-query-postgres/src/PgSqlParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Platform\Postgres;
 
+use ZtdQuery\Sql\SqlToken;
 use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
@@ -125,25 +126,26 @@ final class PgSqlParser
     public function extractOnConflictTarget(string $sql): ?PgSqlConflictTarget
     {
         $tokens = SqlTokenStream::tokenize($sql)->significantTokens();
-        $conflict = null;
-        foreach ($tokens as $index => $token) {
-            if ($token->isTopLevel()
-                && $token->isKeyword('ON')
-                && ($tokens[$index + 1] ?? null)?->isKeyword('CONFLICT') === true
-            ) {
-                $conflict = $index + 2;
-                break;
-            }
-        }
+        $conflict = self::findOnConflictTargetStart($tokens);
         if ($conflict === null) {
             return null;
         }
 
         $next = $tokens[$conflict] ?? null;
-        if ($next?->isKeyword('DO') === true) {
+        if ($next === null) {
+            return null;
+        }
+        if ($next->isKeyword('DO')) {
             return new PgSqlConflictTarget(false);
         }
-        if ($next?->isKeyword('ON') === true && ($tokens[$conflict + 1] ?? null)?->isKeyword('CONSTRAINT') === true) {
+        if ($next->isKeyword('ON')) {
+            $constraintKeyword = $tokens[$conflict + 1] ?? null;
+            if ($constraintKeyword === null) {
+                return null;
+            }
+            if (!$constraintKeyword->isKeyword('CONSTRAINT')) {
+                return null;
+            }
             $constraintToken = $tokens[$conflict + 2] ?? null;
             if ($constraintToken === null) {
                 return null;
@@ -155,17 +157,11 @@ final class PgSqlParser
 
             return new PgSqlConflictTarget(true, constraint: $identifier['name']);
         }
-        if ($next?->kind !== SqlTokenKind::Symbol || $next->text !== '(') {
+        if ($next->text !== '(') {
             return null;
         }
 
-        $closing = null;
-        foreach ($tokens as $index => $token) {
-            if ($index > $conflict && $token->isTopLevel() && $token->kind === SqlTokenKind::Symbol && $token->text === ')') {
-                $closing = $index;
-                break;
-            }
-        }
+        $closing = self::findTopLevelSymbol($tokens, $conflict, ')');
         if ($closing === null) {
             return null;
         }
@@ -179,37 +175,93 @@ final class PgSqlParser
         foreach (SqlTokenStream::tokenize($columnSql)->splitTopLevel() as $part) {
             $stream = SqlTokenStream::tokenize($part);
             $identifier = $stream->identifierAt();
-            if ($identifier === null || $identifier['next'] !== count($stream->significantTokens())) {
+            if ($identifier === null) {
+                return null;
+            }
+            if ($identifier['next'] !== count($stream->significantTokens())) {
                 return null;
             }
             $columns[] = $identifier['name'];
         }
 
-        $do = null;
-        foreach ($tokens as $index => $token) {
-            if ($index > $closing && $token->isTopLevel() && $token->isKeyword('DO')) {
-                $do = $index;
-                break;
-            }
-        }
+        $do = self::findTopLevelKeyword($tokens, $closing, 'DO');
         if ($do === null) {
             return null;
         }
 
         $predicate = null;
         $afterColumns = $tokens[$closing + 1] ?? null;
-        if ($afterColumns?->isKeyword('WHERE') === true) {
-            $predicate = trim(substr(
-                $sql,
-                $afterColumns->endOffset(),
-                $tokens[$do]->offset - $afterColumns->endOffset(),
-            ));
-            if ($predicate === '') {
-                return null;
+        if ($afterColumns !== null) {
+            if ($afterColumns->isKeyword('WHERE')) {
+                $predicate = trim(substr(
+                    $sql,
+                    $afterColumns->endOffset(),
+                    $tokens[$do]->offset - $afterColumns->endOffset(),
+                ));
+                if ($predicate === '') {
+                    return null;
+                }
             }
         }
 
         return new PgSqlConflictTarget(true, $columns, $predicate);
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function findOnConflictTargetStart(array $tokens): ?int
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isTopLevel()) {
+                continue;
+            }
+            if (!$token->isKeyword('ON')) {
+                continue;
+            }
+            $following = $tokens[$index + 1] ?? $token;
+            if ($following->isKeyword('CONFLICT')) {
+                return $index + 2;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function findTopLevelSymbol(array $tokens, int $start, string $symbol): ?int
+    {
+        for ($index = $start, $count = count($tokens); $index < $count; $index++) {
+            $token = $tokens[$index];
+            if (!$token->isTopLevel()) {
+                continue;
+            }
+            if ($token->kind !== SqlTokenKind::Symbol) {
+                continue;
+            }
+            if ($token->text === $symbol) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<SqlToken> $tokens
+     */
+    private static function findTopLevelKeyword(array $tokens, int $start, string $keyword): ?int
+    {
+        for ($index = $start, $count = count($tokens); $index < $count; $index++) {
+            $token = $tokens[$index];
+            if ($token->isTopLevel() && $token->isKeyword($keyword)) {
+                return $index;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -246,7 +246,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
                 continue;
             }
 
-            $context[$tableName] = [
+            $definitionContext = [
                 'rows' => [],
                 'columns' => $definition->columns,
                 'columnTypes' => $definition->typedColumns,
@@ -255,8 +255,9 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'generatedExpressions' => $definition->generatedExpressions,
                 'primaryKeys' => $definition->primaryKeys,
                 'candidateKeys' => $definition->candidateKeys()->keys(),
-                'partialUniqueIndexes' => $definition->partialUniqueIndexes,
             ];
+            $definitionContext['partialUniqueIndexes'] = $definition->partialUniqueIndexes;
+            $context[$tableName] = $definitionContext;
         }
 
         $quoter = new PgSqlIdentifierQuoter();

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -236,6 +236,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'generatedExpressions' => $generatedExpressions,
                 'primaryKeys' => $definition !== null ? $definition->primaryKeys : [],
                 'candidateKeys' => $definition !== null ? $definition->candidateKeys()->keys() : [],
+                'partialUniqueIndexes' => $definition !== null ? $definition->partialUniqueIndexes : [],
             ];
         }
 
@@ -254,6 +255,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
                 'generatedExpressions' => $definition->generatedExpressions,
                 'primaryKeys' => $definition->primaryKeys,
                 'candidateKeys' => $definition->candidateKeys()->keys(),
+                'partialUniqueIndexes' => $definition->partialUniqueIndexes,
             ];
         }
 

--- a/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
@@ -7,6 +7,7 @@ namespace ZtdQuery\Platform\Postgres;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\SchemaReflector;
 use ZtdQuery\Platform\ViewReflector;
+use ZtdQuery\Schema\PartialUniqueIndex;
 use ZtdQuery\Schema\ViewDefinition;
 
 /**
@@ -18,6 +19,9 @@ use ZtdQuery\Schema\ViewDefinition;
 final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
 {
     private ConnectionInterface $connection;
+
+    /** @var array<string, array<string, PartialUniqueIndex>> */
+    private array $partialUniqueIndexes = [];
 
     public function __construct(ConnectionInterface $connection)
     {
@@ -62,6 +66,12 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
         }
 
         return $result;
+    }
+
+    /** @return array<string, array<string, PartialUniqueIndex>> */
+    public function partialUniqueIndexes(): array
+    {
+        return $this->partialUniqueIndexes;
     }
 
     /** {@inheritDoc} */
@@ -135,28 +145,64 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
         }
 
         $uniqueStmt = $this->connection->query(
-            "SELECT tc.constraint_name, kcu.column_name "
-            . "FROM information_schema.table_constraints tc "
-            . "JOIN information_schema.key_column_usage kcu "
-            . "  ON tc.constraint_name = kcu.constraint_name "
-            . "  AND tc.table_schema = kcu.table_schema "
-            . "WHERE tc.table_schema = current_schema() "
-            . "  AND tc.table_name = '" . str_replace("'", "''", $tableName) . "' "
-            . "  AND tc.constraint_type = 'UNIQUE' "
-            . "ORDER BY tc.constraint_name, kcu.ordinal_position"
+            'SELECT index_relation.relname AS constraint_name, attribute.attname AS column_name, '
+            . 'pg_get_expr(index_metadata.indpred, index_metadata.indrelid) AS predicate '
+            . 'FROM pg_catalog.pg_class table_relation '
+            . 'JOIN pg_catalog.pg_namespace namespace ON namespace.oid = table_relation.relnamespace '
+            . 'JOIN pg_catalog.pg_index index_metadata ON index_metadata.indrelid = table_relation.oid '
+            . 'JOIN pg_catalog.pg_class index_relation ON index_relation.oid = index_metadata.indexrelid '
+            . 'JOIN LATERAL unnest(index_metadata.indkey) WITH ORDINALITY key_column(attnum, ordinality) '
+            . '  ON key_column.ordinality <= index_metadata.indnkeyatts '
+            . 'LEFT JOIN pg_catalog.pg_attribute attribute '
+            . '  ON attribute.attrelid = table_relation.oid AND attribute.attnum = key_column.attnum '
+            . 'WHERE namespace.nspname = current_schema() '
+            . "  AND table_relation.relname = '" . str_replace("'", "''", $tableName) . "' "
+            . '  AND index_metadata.indisunique '
+            . '  AND index_metadata.indisvalid '
+            . '  AND NOT index_metadata.indisprimary '
+            . 'ORDER BY index_relation.relname, key_column.ordinality'
         );
 
         /** @var array<string, list<string>> $uniqueConstraints */
         $uniqueConstraints = [];
+        /** @var array<string, array{columns: list<string>, predicate: string}> $partialIndexes */
+        $partialIndexes = [];
+        /** @var array<string, true> $invalidIndexes */
+        $invalidIndexes = [];
         if ($uniqueStmt !== false) {
             $uniqueRows = $uniqueStmt->fetchAll();
             foreach ($uniqueRows as $uRow) {
                 $constraintName = $uRow['constraint_name'] ?? '';
                 $colName = $uRow['column_name'] ?? null;
-                if (is_string($constraintName) && is_string($colName)) {
+                $predicate = $uRow['predicate'] ?? null;
+                if (!is_string($constraintName) || $constraintName === '') {
+                    continue;
+                }
+                if (!is_string($colName)) {
+                    $invalidIndexes[$constraintName] = true;
+                    continue;
+                }
+                if (is_string($predicate) && trim($predicate) !== '') {
+                    $partialIndexes[$constraintName] ??= ['columns' => [], 'predicate' => $predicate];
+                    $partialIndexes[$constraintName]['columns'][] = $colName;
+                } else {
                     $uniqueConstraints[$constraintName][] = '"' . $colName . '"';
                 }
             }
+        }
+        foreach (array_keys($invalidIndexes) as $invalidIndex) {
+            unset($uniqueConstraints[$invalidIndex], $partialIndexes[$invalidIndex]);
+        }
+        $this->partialUniqueIndexes[$tableName] = [];
+        foreach ($partialIndexes as $name => $index) {
+            if ($index['columns'] === []) {
+                continue;
+            }
+            $this->partialUniqueIndexes[$tableName][$name] = new PartialUniqueIndex(
+                $name,
+                $index['columns'],
+                $index['predicate'],
+            );
         }
 
         $foreignKeyStmt = $this->connection->query(

--- a/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
+++ b/packages/ztd-query-postgres/src/PgSqlSchemaReflector.php
@@ -99,12 +99,13 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
 
     private function buildCreateTableSql(string $tableName): ?string
     {
+        $escapedTableName = str_replace("'", "''", $tableName);
         $stmt = $this->connection->query(
             "SELECT column_name, data_type, character_maximum_length, "
             . "numeric_precision, numeric_scale, is_nullable, column_default, "
             . "udt_name, is_identity, identity_generation, is_generated, generation_expression "
             . "FROM information_schema.columns "
-            . "WHERE table_schema = current_schema() AND table_name = '" . str_replace("'", "''", $tableName) . "' "
+            . "WHERE table_schema = current_schema() AND table_name = '" . $escapedTableName . "' "
             . "ORDER BY ordinal_position"
         );
         if ($stmt === false) {
@@ -128,7 +129,7 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
             . "  ON tc.constraint_name = kcu.constraint_name "
             . "  AND tc.table_schema = kcu.table_schema "
             . "WHERE tc.table_schema = current_schema() "
-            . "  AND tc.table_name = '" . str_replace("'", "''", $tableName) . "' "
+            . "  AND tc.table_name = '" . $escapedTableName . "' "
             . "  AND tc.constraint_type = 'PRIMARY KEY' "
             . "ORDER BY kcu.ordinal_position"
         );
@@ -156,7 +157,7 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
             . 'LEFT JOIN pg_catalog.pg_attribute attribute '
             . '  ON attribute.attrelid = table_relation.oid AND attribute.attnum = key_column.attnum '
             . 'WHERE namespace.nspname = current_schema() '
-            . "  AND table_relation.relname = '" . str_replace("'", "''", $tableName) . "' "
+            . "  AND table_relation.relname = '" . $escapedTableName . "' "
             . '  AND index_metadata.indisunique '
             . '  AND index_metadata.indisvalid '
             . '  AND NOT index_metadata.indisprimary '
@@ -167,7 +168,7 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
         $uniqueConstraints = [];
         /** @var array<string, array{columns: list<string>, predicate: string}> $partialIndexes */
         $partialIndexes = [];
-        /** @var array<string, true> $invalidIndexes */
+        /** @var array<string, string> $invalidIndexes */
         $invalidIndexes = [];
         if ($uniqueStmt !== false) {
             $uniqueRows = $uniqueStmt->fetchAll();
@@ -175,22 +176,30 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
                 $constraintName = $uRow['constraint_name'] ?? '';
                 $colName = $uRow['column_name'] ?? null;
                 $predicate = $uRow['predicate'] ?? null;
-                if (!is_string($constraintName) || $constraintName === '') {
+                if (!is_string($constraintName)) {
+                    continue;
+                }
+                if ($constraintName === '') {
                     continue;
                 }
                 if (!is_string($colName)) {
-                    $invalidIndexes[$constraintName] = true;
+                    $invalidIndexes[$constraintName] = $constraintName;
                     continue;
                 }
-                if (is_string($predicate) && trim($predicate) !== '') {
-                    $partialIndexes[$constraintName] ??= ['columns' => [], 'predicate' => $predicate];
-                    $partialIndexes[$constraintName]['columns'][] = $colName;
-                } else {
+                if (!is_string($predicate) || trim($predicate) === '') {
                     $uniqueConstraints[$constraintName][] = '"' . $colName . '"';
+
+                    continue;
                 }
+                if (!isset($partialIndexes[$constraintName])) {
+                    $partialIndexes[$constraintName] = ['columns' => [$colName], 'predicate' => $predicate];
+
+                    continue;
+                }
+                $partialIndexes[$constraintName]['columns'][] = $colName;
             }
         }
-        foreach (array_keys($invalidIndexes) as $invalidIndex) {
+        foreach ($invalidIndexes as $invalidIndex) {
             unset($uniqueConstraints[$invalidIndex], $partialIndexes[$invalidIndex]);
         }
         $this->partialUniqueIndexes[$tableName] = [];
@@ -220,7 +229,7 @@ final class PgSqlSchemaReflector implements SchemaReflector, ViewReflector
             . "  AND pk.constraint_name = rc.unique_constraint_name "
             . "  AND pk.ordinal_position = fk.position_in_unique_constraint "
             . "WHERE fk.table_schema = current_schema() "
-            . "  AND fk.table_name = '" . str_replace("'", "''", $tableName) . "' "
+            . "  AND fk.table_name = '" . $escapedTableName . "' "
             . "ORDER BY fk.constraint_name, fk.ordinal_position"
         );
 

--- a/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
+++ b/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
@@ -40,6 +40,16 @@ final class PgSqlSessionFactory implements SessionFactory
                 $registry->register($tableName, $definition);
             }
         }
+        foreach ($reflector->partialUniqueIndexes() as $tableName => $indexes) {
+            $definition = $registry->get($tableName);
+            if ($definition === null) {
+                continue;
+            }
+            foreach ($indexes as $index) {
+                $definition = $definition->withPartialUniqueIndex($index);
+            }
+            $registry->register($tableName, $definition);
+        }
         $partitionMetadata = (new PgSqlPartitionReflector($connection))->reflect();
         foreach ($partitionMetadata['keys'] as $tableName => $partitionKey) {
             $definition = $registry->get($tableName);

--- a/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
+++ b/packages/ztd-query-postgres/src/Transformer/InsertTransformer.php
@@ -12,8 +12,10 @@ use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\PgSqlCteShadowComposer;
 use ZtdQuery\Rewrite\ShadowIdentityAllocator;
 use ZtdQuery\Rewrite\SqlTransformer;
+use ZtdQuery\Schema\CandidateKeySet;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Schema\PartialUniqueIndex;
 use ZtdQuery\Sql\SqlTokenStream;
 
 /**
@@ -139,7 +141,10 @@ final class InsertTransformer implements SqlTransformer
 
     /**
      * @param list<string> $tableColumns
-     * @param array<string, array{candidateKeys?: array<string, array<int, string>>}> $tables
+     * @param array<string, array{
+     *     candidateKeys?: array<string, array<int, string>>,
+     *     partialUniqueIndexes?: array<string, PartialUniqueIndex>
+     * }> $tables
      */
     private function projectUpsert(
         string $sql,
@@ -149,14 +154,31 @@ final class InsertTransformer implements SqlTransformer
         array $tables,
     ): string {
         $conflict = $this->parser->extractOnConflictUpdateColumns($sql);
+        $candidateKeys = new CandidateKeySet(
+            isset($tables[$tableName]['candidateKeys']) ? $tables[$tableName]['candidateKeys'] : [],
+        );
+        $conflictPredicate = null;
+        $target = $this->parser->extractOnConflictTarget($sql);
+        if ($target !== null) {
+            $resolved = $target->resolve(
+                $candidateKeys,
+                isset($tables[$tableName]['partialUniqueIndexes'])
+                    ? $tables[$tableName]['partialUniqueIndexes']
+                    : [],
+                $sql,
+            );
+            $candidateKeys = $resolved['keys'];
+            $conflictPredicate = $resolved['predicate'];
+        }
 
         return $this->upsertProjector->project(
             $selectSql,
             $tableName,
             $tableColumns,
-            isset($tables[$tableName]['candidateKeys']) ? $tables[$tableName]['candidateKeys'] : [],
+            $candidateKeys->keys(),
             $conflict['values'],
             $this->parser->extractOnConflictUpdateWhere($sql),
+            $conflictPredicate,
         );
     }
 

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlConflictTargetTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlConflictTargetTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Exception\UnsupportedSqlException;
+use ZtdQuery\Platform\Postgres\PgSqlConflictTarget;
+use ZtdQuery\Schema\CandidateKeySet;
+use ZtdQuery\Schema\PartialUniqueIndex;
+
+#[CoversClass(PgSqlConflictTarget::class)]
+final class PgSqlConflictTargetTest extends TestCase
+{
+    public function testUnspecifiedTargetKeepsEveryRegularCandidateKey(): void
+    {
+        $keys = CandidateKeySet::fromSchema(['id'], ['users_email' => ['email']]);
+
+        $resolved = (new PgSqlConflictTarget(false))->resolve($keys, [], 'INSERT');
+
+        self::assertSame($keys, $resolved['keys']);
+        self::assertNull($resolved['predicate']);
+    }
+
+    public function testRegularUniqueIndexTakesPrecedenceOverPartialIndexInference(): void
+    {
+        $target = new PgSqlConflictTarget(true, ['email'], "status = 'active'");
+        $keys = CandidateKeySet::fromSchema([], ['users_email' => ['email']]);
+        $partial = new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'");
+
+        $resolved = $target->resolve($keys, [$partial->name => $partial], 'INSERT');
+
+        self::assertSame(['users_email' => ['email']], $resolved['keys']->keys());
+        self::assertNull($resolved['predicate']);
+    }
+
+    public function testResolvesPartialIndexWithOrderIndependentColumns(): void
+    {
+        $target = new PgSqlConflictTarget(true, ['email', 'tenant_id'], "status = 'active'");
+        $partial = new PartialUniqueIndex(
+            'users_active_email',
+            ['tenant_id', 'email'],
+            "status = 'active'::text",
+        );
+
+        $resolved = $target->resolve(new CandidateKeySet([]), [$partial->name => $partial], 'INSERT');
+
+        self::assertSame(['users_active_email' => ['tenant_id', 'email']], $resolved['keys']->keys());
+        self::assertSame("status = 'active'", $resolved['predicate']);
+    }
+
+    public function testResolvesNamedConstraintCaseInsensitively(): void
+    {
+        $keys = CandidateKeySet::fromSchema([], ['Users_Email' => ['email'], 'users_name' => ['name']]);
+
+        $resolved = (new PgSqlConflictTarget(true, constraint: 'users_email'))->resolve($keys, [], 'INSERT');
+
+        self::assertSame(['Users_Email' => ['email']], $resolved['keys']->keys());
+    }
+
+    public function testRejectsAmbiguousPartialIndexes(): void
+    {
+        $target = new PgSqlConflictTarget(true, ['email'], "status = 'active'");
+        $active = new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'");
+        $pending = new PartialUniqueIndex('users_pending_email', ['email'], "status = 'pending'");
+
+        $this->expectException(UnsupportedSqlException::class);
+
+        $target->resolve(new CandidateKeySet([]), [$active->name => $active, $pending->name => $pending], 'INSERT');
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlConflictTargetTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlConflictTargetTest.php
@@ -38,7 +38,7 @@ final class PgSqlConflictTargetTest extends TestCase
 
     public function testResolvesPartialIndexWithOrderIndependentColumns(): void
     {
-        $target = new PgSqlConflictTarget(true, ['email', 'tenant_id'], "status = 'active'");
+        $target = new PgSqlConflictTarget(true, ['EMAIL', 'TENANT_ID'], "status = 'active'");
         $partial = new PartialUniqueIndex(
             'users_active_email',
             ['tenant_id', 'email'],
@@ -49,6 +49,16 @@ final class PgSqlConflictTargetTest extends TestCase
 
         self::assertSame(['users_active_email' => ['tenant_id', 'email']], $resolved['keys']->keys());
         self::assertSame("status = 'active'", $resolved['predicate']);
+    }
+
+    public function testRejectsPartialIndexWithDifferentColumnArity(): void
+    {
+        $target = new PgSqlConflictTarget(true, ['email', 'tenant_id'], "status = 'active'");
+        $partial = new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'");
+
+        $this->expectException(UnsupportedSqlException::class);
+
+        $target->resolve(new CandidateKeySet([]), [$partial->name => $partial], 'INSERT');
     }
 
     public function testResolvesNamedConstraintCaseInsensitively(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlMutationResolverTest.php
@@ -15,6 +15,7 @@ use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Schema\TableDefinition;
 use ZtdQuery\Schema\TableDefinitionRegistry;
+use ZtdQuery\Schema\PartialUniqueIndex;
 use ZtdQuery\Shadow\Mutation\CreateTableAsSelectMutation;
 use ZtdQuery\Shadow\Mutation\CreateTableLikeMutation;
 use ZtdQuery\Shadow\Mutation\CreateTableMutation;
@@ -35,6 +36,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlConflictTarget::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(PgSqlPartitionParser::class)]
@@ -2948,6 +2950,48 @@ final class PgSqlMutationResolverTest extends TestCase
         $rows = $shadowStore->get('users');
         self::assertNotEmpty($rows);
         self::assertSame('Bob', $rows[0]['name']);
+    }
+
+    public function testResolveUpsertUsesPartialIndexPredicateForConflictDetection(): void
+    {
+        $shadowStore = new ShadowStore();
+        $registry = new TableDefinitionRegistry();
+        $definition = new TableDefinition(
+            ['email', 'status', 'login_count'],
+            ['email' => 'TEXT', 'status' => 'TEXT', 'login_count' => 'INTEGER'],
+            [],
+            [],
+            [],
+        );
+        $registry->register('users', $definition->withPartialUniqueIndex(
+            new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'::text"),
+        ));
+        $shadowStore->set('users', [
+            ['email' => 'alice@example.com', 'status' => 'inactive', 'login_count' => 2],
+            ['email' => 'alice@example.com', 'status' => 'active', 'login_count' => 5],
+        ]);
+        $resolver = new PgSqlMutationResolver(
+            $shadowStore,
+            $registry,
+            new PgSqlSchemaParser(),
+            new PgSqlParser(),
+        );
+        $sql = "INSERT INTO users VALUES ('alice@example.com', 'active', 1) "
+            . "ON CONFLICT (email) WHERE status = 'active' "
+            . 'DO UPDATE SET login_count = users.login_count + EXCLUDED.login_count';
+
+        $mutation = $resolver->resolve($sql, 'INSERT', QueryKind::WRITE_SIMULATED);
+        self::assertInstanceOf(UpsertMutation::class, $mutation);
+        $mutation->apply($shadowStore, [[
+            'email' => 'alice@example.com',
+            'status' => 'active',
+            'login_count' => 1,
+        ]]);
+
+        self::assertSame([
+            ['email' => 'alice@example.com', 'status' => 'inactive', 'login_count' => 2],
+            ['email' => 'alice@example.com', 'status' => 'active', 'login_count' => 6],
+        ], $shadowStore->get('users'));
     }
 
     public function testUpdateDoesNotTreatRowsFromUnknownInsertAsSchema(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlNativeUpsertProjectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlNativeUpsertProjectorTest.php
@@ -109,4 +109,25 @@ final class PgSqlNativeUpsertProjectorTest extends TestCase
             $result,
         );
     }
+
+    public function testBindsPartialConflictPredicateToExistingAndIncomingRows(): void
+    {
+        $result = (new PgSqlNativeUpsertProjector())->project(
+            'SELECT \'alice@example.com\' AS "email", \'active\' AS "status", 1 AS "login_count"',
+            'users',
+            ['email', 'status', 'login_count'],
+            ['users_active_email' => ['email']],
+            ['login_count' => 'GREATEST(login_count, EXCLUDED.login_count)'],
+            conflictPredicate: "status = 'active'",
+        );
+
+        self::assertStringContainsString(
+            '"__ztd_existing"."email" = "__ztd_incoming"."email"',
+            $result,
+        );
+        self::assertStringContainsString(
+            '("__ztd_existing"."status" = \'active\') AND ("__ztd_incoming"."status" = \'active\')',
+            $result,
+        );
+    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -9,6 +9,7 @@ use ZtdQuery\Platform\Postgres\PgSqlParser;
 use ZtdQuery\Platform\Postgres\PgSqlConflictTarget;
 use ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 
 #[CoversClass(PgSqlParser::class)]
@@ -3720,9 +3721,41 @@ SELECT * FROM users'));
         );
 
         self::assertInstanceOf(PgSqlConflictTarget::class, $named);
+        self::assertTrue($named->specified);
         self::assertSame('Users_Email', $named->constraint);
         self::assertInstanceOf(PgSqlConflictTarget::class, $unspecified);
         self::assertFalse($unspecified->specified);
         self::assertNull($parser->extractOnConflictTarget('INSERT INTO users VALUES (1)'));
+    }
+
+    public function testConflictTargetSkipsNestedAnchorsAndStopsAtTheActionBoundary(): void
+    {
+        $target = (new PgSqlParser())->extractOnConflictTarget(
+            "INSERT INTO users VALUES ((on conflict)) ON CONFLICT (email)"
+                . " WHERE coalesce((status = 'active'), false)"
+                . ' DO UPDATE SET do = lower(EXCLUDED.email)',
+        );
+
+        self::assertInstanceOf(PgSqlConflictTarget::class, $target);
+        self::assertSame(['email'], $target->columns);
+        self::assertSame("coalesce((status = 'active'), false)", $target->predicate);
+    }
+
+    #[TestWith(['INSERT INTO users VALUES (1) ON'], 'trailing ON')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT'], 'missing target')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT ON'], 'missing constraint keyword')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT ON INVALID users_email DO NOTHING'], 'invalid constraint keyword')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT ON CONSTRAINT'], 'missing constraint name')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT ON CONSTRAINT 123 DO NOTHING'], 'invalid constraint name')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT email DO NOTHING'], 'target without parentheses')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT email) DO NOTHING'], 'target word before closing parenthesis')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT [email] DO NOTHING'], 'invalid opening symbol')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT (email DO NOTHING'], 'unclosed target')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT (email + tenant_id) DO NOTHING'], 'non-identifier target')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT (email)'], 'missing action')]
+    #[TestWith(['INSERT INTO users VALUES (1) ON CONFLICT (email) WHERE DO UPDATE SET email = EXCLUDED.email'], 'empty predicate')]
+    public function testRejectsMalformedConflictTargets(string $sql): void
+    {
+        self::assertNull((new PgSqlParser())->extractOnConflictTarget($sql));
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlParserTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
+use ZtdQuery\Platform\Postgres\PgSqlConflictTarget;
 use ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -13,6 +14,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[CoversClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 #[UsesClass(PostgreSqlLexicalMasker::class)]
+#[UsesClass(PgSqlConflictTarget::class)]
 final class PgSqlParserTest extends TestCase
 {
     public function testClassifiesAnonymousDoBlockWithoutSplittingItsBody(): void
@@ -3690,5 +3692,37 @@ SELECT * FROM users'));
         $sql = 'SELECT EXTRACT(YEAR FROM event_date) FROM events WHERE id IN (SELECT event_id FROM archived_events)';
 
         self::assertSame(['events', 'archived_events'], $parser->extractSelectTableNames($sql));
+    }
+
+    public function testExtractsPartialConflictTargetStructurally(): void
+    {
+        $target = (new PgSqlParser())->extractOnConflictTarget(
+            "INSERT INTO users (email, status) VALUES ('a@example.com', 'active') "
+            . "ON CONFLICT (email, tenant_id) WHERE status = 'active' "
+            . 'DO UPDATE SET status = EXCLUDED.status',
+        );
+
+        self::assertInstanceOf(PgSqlConflictTarget::class, $target);
+        self::assertTrue($target->specified);
+        self::assertSame(['email', 'tenant_id'], $target->columns);
+        self::assertSame("status = 'active'", $target->predicate);
+        self::assertNull($target->constraint);
+    }
+
+    public function testExtractsNamedAndUnspecifiedConflictTargets(): void
+    {
+        $parser = new PgSqlParser();
+        $named = $parser->extractOnConflictTarget(
+            'INSERT INTO users VALUES (1) ON CONFLICT ON CONSTRAINT "Users_Email" DO NOTHING',
+        );
+        $unspecified = $parser->extractOnConflictTarget(
+            'INSERT INTO users VALUES (1) ON CONFLICT DO NOTHING',
+        );
+
+        self::assertInstanceOf(PgSqlConflictTarget::class, $named);
+        self::assertSame('Users_Email', $named->constraint);
+        self::assertInstanceOf(PgSqlConflictTarget::class, $unspecified);
+        self::assertFalse($unspecified->specified);
+        self::assertNull($parser->extractOnConflictTarget('INSERT INTO users VALUES (1)'));
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlRewriterTest.php
@@ -50,6 +50,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser::class)]
 #[UsesClass(PgSqlParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlConflictTarget::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
@@ -599,6 +599,29 @@ final class PgSqlSchemaReflectorTest extends TestCase
         );
     }
 
+    public function testReflectsPartialUniqueIndexesWithoutFlatteningTheirPredicate(): void
+    {
+        $reflector = new PgSqlSchemaReflector(new FakeSequentialConnection([
+            new FakeStatement([
+                ['column_name' => 'email', 'data_type' => 'text', 'character_maximum_length' => null, 'numeric_precision' => null, 'numeric_scale' => null, 'is_nullable' => 'YES', 'column_default' => null, 'udt_name' => 'text'],
+                ['column_name' => 'status', 'data_type' => 'text', 'character_maximum_length' => null, 'numeric_precision' => null, 'numeric_scale' => null, 'is_nullable' => 'YES', 'column_default' => null, 'udt_name' => 'text'],
+            ]),
+            new FakeStatement([]),
+            new FakeStatement([
+                ['constraint_name' => 'users_active_email', 'column_name' => 'email', 'predicate' => "status = 'active'::text"],
+                ['constraint_name' => 'users_expression', 'column_name' => null, 'predicate' => 'lower(email) IS NOT NULL'],
+            ]),
+        ]));
+
+        $createSql = $reflector->getCreateStatement('users');
+        $indexes = $reflector->partialUniqueIndexes();
+
+        self::assertSame("CREATE TABLE \"users\" (\n  \"email\" TEXT,\n  \"status\" TEXT\n)", $createSql);
+        self::assertSame(['users_active_email'], array_keys($indexes['users']));
+        self::assertSame(['email'], $indexes['users']['users_active_email']->columns);
+        self::assertSame("status = 'active'::text", $indexes['users']['users_active_email']->predicate);
+    }
+
     public function testVerifyColumnsQueryExact(): void
     {
         $queries = [];
@@ -748,15 +771,22 @@ final class PgSqlSchemaReflectorTest extends TestCase
         );
 
         self::assertSame(
-            "SELECT tc.constraint_name, kcu.column_name "
-            . "FROM information_schema.table_constraints tc "
-            . "JOIN information_schema.key_column_usage kcu "
-            . "  ON tc.constraint_name = kcu.constraint_name "
-            . "  AND tc.table_schema = kcu.table_schema "
-            . "WHERE tc.table_schema = current_schema() "
-            . "  AND tc.table_name = 'my_table' "
-            . "  AND tc.constraint_type = 'UNIQUE' "
-            . "ORDER BY tc.constraint_name, kcu.ordinal_position",
+            'SELECT index_relation.relname AS constraint_name, attribute.attname AS column_name, '
+            . 'pg_get_expr(index_metadata.indpred, index_metadata.indrelid) AS predicate '
+            . 'FROM pg_catalog.pg_class table_relation '
+            . 'JOIN pg_catalog.pg_namespace namespace ON namespace.oid = table_relation.relnamespace '
+            . 'JOIN pg_catalog.pg_index index_metadata ON index_metadata.indrelid = table_relation.oid '
+            . 'JOIN pg_catalog.pg_class index_relation ON index_relation.oid = index_metadata.indexrelid '
+            . 'JOIN LATERAL unnest(index_metadata.indkey) WITH ORDINALITY key_column(attnum, ordinality) '
+            . '  ON key_column.ordinality <= index_metadata.indnkeyatts '
+            . 'LEFT JOIN pg_catalog.pg_attribute attribute '
+            . '  ON attribute.attrelid = table_relation.oid AND attribute.attnum = key_column.attnum '
+            . 'WHERE namespace.nspname = current_schema() '
+            . "  AND table_relation.relname = 'my_table' "
+            . '  AND index_metadata.indisunique '
+            . '  AND index_metadata.indisvalid '
+            . '  AND NOT index_metadata.indisprimary '
+            . 'ORDER BY index_relation.relname, key_column.ordinality',
             $queries[2]
         );
     }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaReflectorTest.php
@@ -622,6 +622,64 @@ final class PgSqlSchemaReflectorTest extends TestCase
         self::assertSame("status = 'active'::text", $indexes['users']['users_active_email']->predicate);
     }
 
+    public function testCollectsCompositePartialIndexesAndDiscardsMalformedMetadata(): void
+    {
+        $reflector = new PgSqlSchemaReflector(new FakeSequentialConnection([
+            new FakeStatement([
+                ['column_name' => 'email', 'data_type' => 'text', 'is_nullable' => 'YES', 'udt_name' => 'text'],
+                ['column_name' => 'tenant_id', 'data_type' => 'integer', 'is_nullable' => 'NO', 'udt_name' => 'int4'],
+                ['column_name' => 'status', 'data_type' => 'text', 'is_nullable' => 'YES', 'udt_name' => 'text'],
+            ]),
+            new FakeStatement([]),
+            new FakeStatement([
+                ['constraint_name' => null, 'column_name' => null, 'predicate' => null],
+                ['constraint_name' => '', 'column_name' => 'email', 'predicate' => null],
+                ['constraint_name' => 'users_active_email', 'column_name' => 'email', 'predicate' => "status = 'active'"],
+                ['constraint_name' => 'users_active_email', 'column_name' => 'tenant_id', 'predicate' => "status = 'active'"],
+                ['constraint_name' => 'users_broken', 'column_name' => null, 'predicate' => 'lower(email) IS NOT NULL'],
+                ['constraint_name' => 'users_broken', 'column_name' => 'email', 'predicate' => 'lower(email) IS NOT NULL'],
+                ['constraint_name' => 'users_status', 'column_name' => 'status', 'predicate' => '   '],
+                ['constraint_name' => 'users_pending_email', 'column_name' => 'email', 'predicate' => "status = 'pending'"],
+            ]),
+            new FakeStatement([]),
+        ]));
+
+        $createSql = $reflector->getCreateStatement('users');
+        $indexes = $reflector->partialUniqueIndexes()['users'];
+
+        self::assertNotNull($createSql);
+        self::assertStringContainsString('CONSTRAINT "users_status" UNIQUE ("status")', $createSql);
+        self::assertStringNotContainsString('users_broken', $createSql);
+        self::assertSame(['users_active_email', 'users_pending_email'], array_keys($indexes));
+        self::assertSame(['email', 'tenant_id'], $indexes['users_active_email']->columns);
+        self::assertSame("status = 'active'", $indexes['users_active_email']->predicate);
+    }
+
+    public function testEscapesTableNameInEveryMetadataQuery(): void
+    {
+        $queries = [];
+        $columns = new FakeStatement([
+            ['column_name' => 'id', 'data_type' => 'integer', 'is_nullable' => 'NO', 'udt_name' => 'int4'],
+        ]);
+        $empty = new FakeStatement([]);
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            function (string $sql) use (&$queries, $columns, $empty): StatementInterface {
+                $queries[] = $sql;
+
+                return str_contains($sql, 'information_schema.columns') ? $columns : $empty;
+            },
+        );
+
+        self::assertNotNull((new PgSqlSchemaReflector($connection))->getCreateStatement("it's"));
+
+        self::assertCount(4, $queries);
+        self::assertStringContainsString("'it''s'", $queries[0]);
+        self::assertStringContainsString("'it''s'", $queries[1]);
+        self::assertStringContainsString("'it''s'", $queries[2]);
+        self::assertStringContainsString("'it''s'", $queries[3]);
+    }
+
     public function testVerifyColumnsQueryExact(): void
     {
         $queries = [];

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -34,6 +34,7 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[CoversClass(PgSqlSessionFactory::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlForeignKeyDefinitionParser::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlConflictTarget::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(PgSqlSchemaParser::class)]
 #[UsesClass(PgSqlPartitionParser::class)]

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -386,4 +386,45 @@ final class PgSqlSessionFactoryTest extends TestCase
         $session = $factory->create($connection, ZtdConfig::default());
         self::assertInstanceOf(Session::class, $session);
     }
+
+    public function testCreateRegistersReflectedPartialUniqueIndexes(): void
+    {
+        $tables = new FakeStatement([
+            ['table_name' => 'users'],
+        ]);
+        $columns = new FakeStatement([
+            ['column_name' => 'id', 'data_type' => 'integer', 'is_nullable' => 'NO', 'udt_name' => 'int4'],
+            ['column_name' => 'email', 'data_type' => 'text', 'is_nullable' => 'NO', 'udt_name' => 'text'],
+            ['column_name' => 'status', 'data_type' => 'text', 'is_nullable' => 'NO', 'udt_name' => 'text'],
+        ]);
+        $primaryKey = new FakeStatement([
+            ['column_name' => 'id'],
+        ]);
+        $unique = new FakeStatement([
+            ['constraint_name' => 'users_active_email', 'column_name' => 'email', 'predicate' => "status = 'active'"],
+        ]);
+        $empty = new FakeStatement([]);
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            static function (string $sql) use ($tables, $columns, $primaryKey, $unique, $empty): StatementInterface {
+                return match (true) {
+                    str_contains($sql, 'information_schema.tables') => $tables,
+                    str_contains($sql, 'information_schema.columns') => $columns,
+                    str_contains($sql, "constraint_type = 'PRIMARY KEY'") => $primaryKey,
+                    str_contains($sql, 'pg_catalog.pg_index') => $unique,
+                    default => $empty,
+                };
+            },
+        );
+
+        $session = (new PgSqlSessionFactory())->create($connection, ZtdConfig::default());
+        $plan = $session->rewrite(
+            "INSERT INTO users (id, email, status) VALUES (1, 'a@example.com', 'active') "
+                . "ON CONFLICT (email) WHERE status = 'active' "
+                . 'DO UPDATE SET status = EXCLUDED.status',
+        );
+
+        self::assertStringContainsString('"__ztd_existing"."email" = "__ztd_incoming"."email"', $plan->sql());
+        self::assertStringContainsString('"__ztd_existing"."status" = \'active\'', $plan->sql());
+    }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -65,6 +65,8 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlViewShadowRenderer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlGeneratedColumnProjector::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlPartitionPredicateRenderer::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlReturningProjectionParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser::class)]
 final class PgSqlSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedPartitionMetadata(): void

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Schema\IdentityGenerationStrategy;
+use ZtdQuery\Schema\PartialUniqueIndex;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use ZtdQuery\Platform\Postgres\PgSqlCastRenderer;
@@ -22,6 +23,7 @@ use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 #[CoversClass(InsertTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
 #[UsesClass(PgSqlParser::class)]
+#[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlConflictTarget::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PostgreSqlLexicalMasker::class)]
 #[UsesClass(SelectTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlTableSampleParser::class)]
@@ -56,6 +58,34 @@ final class InsertTransformerTest extends TestCase
         self::assertStringContainsString('"__ztd_incoming"."name"', $result);
         self::assertStringContainsString('__ztd_upsert_value_0', $result);
         self::assertStringNotContainsString('EXCLUDED.', $result);
+    }
+
+    public function testProjectsPartialIndexPredicateForBothCandidateRows(): void
+    {
+        $transformer = new InsertTransformer(new PgSqlParser(), new SelectTransformer());
+        $partial = new PartialUniqueIndex('users_active_email', ['email'], "status = 'active'::text");
+        $tables = [
+            'users' => [
+                'rows' => [],
+                'columns' => ['email', 'status', 'login_count'],
+                'columnTypes' => [],
+                'candidateKeys' => [],
+                'partialUniqueIndexes' => [$partial->name => $partial],
+            ],
+        ];
+
+        $result = $transformer->transform(
+            "INSERT INTO users VALUES ('alice@example.com', 'active', 1) "
+            . "ON CONFLICT (email) WHERE status = 'active' "
+            . 'DO UPDATE SET login_count = users.login_count + EXCLUDED.login_count',
+            $tables,
+        );
+
+        self::assertStringContainsString(
+            '("__ztd_existing"."status" = \'active\') AND ("__ztd_incoming"."status" = \'active\')',
+            $result,
+        );
+        self::assertStringContainsString('__ztd_upsert_value_0', $result);
     }
 
     public function testUsesInjectedCastRendererForTypedValue(): void

--- a/packages/ztd-query-sqlite/src/SqliteNativeUpsertProjector.php
+++ b/packages/ztd-query-sqlite/src/SqliteNativeUpsertProjector.php
@@ -111,8 +111,12 @@ final class SqliteNativeUpsertProjector
     }
 
     /** @param list<string> $tableColumns */
-    private function bindExpression(string $expression, string $tableName, array $tableColumns): string
-    {
+    private function bindExpression(
+        string $expression,
+        string $tableName,
+        array $tableColumns,
+        string $unqualifiedAlias = self::EXISTING_ALIAS,
+    ): string {
         $tokens = SqlTokenStream::tokenize($expression, $this->dialect)->significantTokens();
         $subqueryTokens = $this->subqueryTokenIndexes($tokens);
         $replacements = [];
@@ -150,7 +154,7 @@ final class SqliteNativeUpsertProjector
             $replacements[] = [
                 'offset' => $token->offset,
                 'length' => strlen($token->text),
-                'value' => $this->qualified(self::EXISTING_ALIAS, $name),
+                'value' => $this->qualified($unqualifiedAlias, $name),
             ];
         }
 

--- a/packages/ztd-query-sqlite/src/SqliteNativeUpsertProjector.php
+++ b/packages/ztd-query-sqlite/src/SqliteNativeUpsertProjector.php
@@ -43,6 +43,7 @@ final class SqliteNativeUpsertProjector
         array $candidateKeys,
         array $assignments,
         ?string $predicate = null,
+        ?string $conflictPredicate = null,
     ): string {
         if ($assignments === [] || $candidateKeys === []) {
             return $incomingSql;
@@ -52,6 +53,21 @@ final class SqliteNativeUpsertProjector
         $existingAlias = $this->quoter->quote(self::EXISTING_ALIAS);
         $table = $this->quoter->quote($tableName);
         $conflict = $this->conflictPredicate($candidateKeys, $existingAlias, $incomingAlias);
+        if ($conflictPredicate !== null) {
+            $existingPredicate = $this->bindExpression(
+                $conflictPredicate,
+                $tableName,
+                $tableColumns,
+                self::EXISTING_ALIAS,
+            );
+            $incomingPredicate = $this->bindExpression(
+                $conflictPredicate,
+                $tableName,
+                $tableColumns,
+                self::INCOMING_ALIAS,
+            );
+            $conflict = "($conflict AND ($existingPredicate) AND ($incomingPredicate))";
+        }
         $selects = [];
         foreach ($tableColumns as $column) {
             $quoted = $this->quoter->quote($column);

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteNativeUpsertProjectorTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteNativeUpsertProjectorTest.php
@@ -109,4 +109,25 @@ final class SqliteNativeUpsertProjectorTest extends TestCase
             $result,
         );
     }
+
+    public function testBindsConflictPredicateToExistingAndIncomingRows(): void
+    {
+        $result = (new SqliteNativeUpsertProjector())->project(
+            'SELECT \'alice@example.com\' AS "email", \'active\' AS "status", 1 AS "login_count"',
+            'users',
+            ['email', 'status', 'login_count'],
+            ['users_active_email' => ['email']],
+            ['login_count' => 'MAX(login_count, EXCLUDED.login_count)'],
+            conflictPredicate: "status = 'active'",
+        );
+
+        self::assertStringContainsString(
+            '"__ztd_existing"."email" = "__ztd_incoming"."email"',
+            $result,
+        );
+        self::assertStringContainsString(
+            '("__ztd_existing"."status" = \'active\') AND ("__ztd_incoming"."status" = \'active\')',
+            $result,
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- reflect standalone and partial PostgreSQL unique indexes from `pg_index`
- parse `ON CONFLICT` targets structurally and resolve the exact arbiter index
- apply the partial-index predicate to both conflict detection and rewritten SQL
- add SQLFaker generation and all three PostgreSQL fuzz targets for this grammar

## Regression prevention

- unit coverage for schema metadata, conflict-target parsing/resolution, projection, and shadow mutations
- real PostgreSQL integration coverage for prepared parameters, `DO UPDATE`, `DO NOTHING`, predicate-mismatching rows, and physical-database isolation
- PostgreSQL mutation run: 1,496 mutations, 1,348 killed, 0 uncovered (90.1% MSI)
- SQLFaker mutation run: 6/6 killed (100% MSI)

## Verification

- Core: 805 tests / 1,379 assertions
- PostgreSQL: 1,474 tests / 2,509 assertions
- SQLFaker: 1,079 tests / 1,931 assertions
- PostgreSQL integration: 1 test / 11 assertions
- lint and PHPStan pass in all touched packages

PostgreSQL semantics follow the official [INSERT conflict-target rules](https://www.postgresql.org/docs/17/sql-insert.html) and [`pg_index` catalog definition](https://www.postgresql.org/docs/16/catalog-pg-index.html).

Closes #169