### PR TITLE
fix(pdo): execute SQL batches sequentially

### DIFF
--- a/packages/sql-faker/src/Sqlite/GenerationPlans.php
+++ b/packages/sql-faker/src/Sqlite/GenerationPlans.php
@@ -4,11 +4,44 @@ declare(strict_types=1);
 
 namespace SqlFaker\Sqlite;
 
+use InvalidArgumentException;
 use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\ProductionPattern;
 
 final class GenerationPlans
 {
+    /** @return GenerationPlan<true> */
+    public static function multiDmlStatement(int $firstChoice, int $secondChoice): GenerationPlan
+    {
+        $dml = [
+            ProductionPattern::containing('insert_cmd'),
+            ProductionPattern::containing('UPDATE'),
+            ProductionPattern::containing('DELETE'),
+        ];
+        $first = $dml[$firstChoice] ?? throw new InvalidArgumentException('Unknown first DML choice.');
+        $second = $dml[$secondChoice] ?? throw new InvalidArgumentException('Unknown second DML choice.');
+
+        return GenerationPlan::constrained('input', [
+            'cmdlist' => [
+                ProductionPattern::exactly('cmdlist', 'ecmd'),
+                ProductionPattern::exactly('ecmd'),
+            ],
+            'ecmd' => [
+                ProductionPattern::exactly('cmdx', 'SEMI'),
+                ProductionPattern::exactly('cmdx', 'SEMI'),
+            ],
+            'cmd' => [$first, $second],
+            'insert_cmd' => [
+                ProductionPattern::containing('INSERT'),
+                ProductionPattern::containing('INSERT'),
+            ],
+            'with' => [
+                ProductionPattern::exactly(),
+                ProductionPattern::exactly(),
+            ],
+        ])->requiringNonEmpty();
+    }
+
     /** @return GenerationPlan<true> */
     public static function insertFunctionUpsertStatement(): GenerationPlan
     {

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -272,7 +272,12 @@ final class SqliteProvider extends Base
     /** @return non-empty-string */
     public function multiDmlStatement(int $maxDepth = 40): string
     {
-        return $this->sql->generateMultiDmlStatement($maxDepth);
+        $plan = GenerationPlans::multiDmlStatement(
+            $this->generator->numberBetween(0, 2),
+            $this->generator->numberBetween(0, 2),
+        );
+
+        return $this->sql->generate($plan->withMaxDepth($maxDepth));
     }
 
     /** @return non-empty-string */

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -270,6 +270,12 @@ final class SqliteProvider extends Base
     }
 
     /** @return non-empty-string */
+    public function multiDmlStatement(int $maxDepth = 40): string
+    {
+        return $this->sql->generateMultiDmlStatement($maxDepth);
+    }
+
+    /** @return non-empty-string */
     public function temporaryTableStatement(int $maxDepth = 40): string
     {
         return $this->sql->generate(

--- a/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/GenerationPlansTest.php
@@ -16,6 +16,37 @@ use SqlFaker\Sqlite\GenerationPlans;
 #[UsesClass(ProductionPattern::class)]
 final class GenerationPlansTest extends TestCase
 {
+    public function testMultiDmlPlanDirectsBothStatementOccurrences(): void
+    {
+        $plan = GenerationPlans::multiDmlStatement(0, 2);
+
+        self::assertSame('input', $plan->startRule());
+        self::assertTrue($plan->patternAt('cmdlist', 0)?->matches(['cmdlist', 'ecmd']) ?? false);
+        self::assertTrue($plan->patternAt('cmdlist', 1)?->matches(['ecmd']) ?? false);
+        self::assertTrue($plan->patternAt('ecmd', 0)?->matches(['cmdx', 'SEMI']) ?? false);
+        self::assertTrue($plan->patternAt('ecmd', 1)?->matches(['cmdx', 'SEMI']) ?? false);
+        self::assertTrue($plan->patternAt('cmd', 0)?->matches(['insert_cmd']) ?? false);
+        self::assertTrue($plan->patternAt('cmd', 1)?->matches(['DELETE']) ?? false);
+        self::assertTrue($plan->patternAt('insert_cmd', 0)?->matches(['INSERT']) ?? false);
+        self::assertTrue($plan->patternAt('insert_cmd', 1)?->matches(['INSERT']) ?? false);
+        self::assertTrue($plan->patternAt('with', 0)?->matches([]) ?? false);
+        self::assertTrue($plan->patternAt('with', 1)?->matches([]) ?? false);
+    }
+
+    public function testMultiDmlPlanRejectsAnUnknownFirstChoice(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        GenerationPlans::multiDmlStatement(3, 0);
+    }
+
+    public function testMultiDmlPlanRejectsAnUnknownSecondChoice(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        GenerationPlans::multiDmlStatement(0, 3);
+    }
+
     public function testForeignKeyPlanRestrictsTheTableConstraintGrammar(): void
     {
         $plan = GenerationPlans::foreignKeyConstraint();

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -77,6 +77,35 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
+    #[DataProvider('providerMultiDmlSeed')]
+    public function testMultiDmlStatementGeneratesExecutableBatch(int $seed, string $expected): void
+    {
+        $faker = Factory::create();
+        $provider = new SqliteProvider($faker);
+        $faker->seed($seed);
+
+        self::assertSame($expected, $provider->multiDmlStatement());
+    }
+
+    /** @return iterable<string, array{int, string}> */
+    public static function providerMultiDmlSeed(): iterable
+    {
+        yield 'insert then insert' => [
+            0,
+            "INSERT INTO users (id, name, email) VALUES (144, 'batch-a', 'a@example.com'); "
+                . "INSERT INTO users (id, name, email) VALUES (145, 'batch-b', 'b@example.com')",
+        ];
+        yield 'insert then update' => [
+            7,
+            "INSERT INTO users (id, name, email) VALUES (415, 'before', 'before@example.com'); "
+                . "UPDATE users SET name = 'after' WHERE id = 415",
+        ];
+        yield 'delete then delete' => [
+            1,
+            'DELETE FROM users WHERE id = 545; DELETE FROM users WHERE id = 546',
+        ];
+    }
+
     #[DataProvider('providerTargetedGenerationSeed')]
     public function testTemporaryTableStatement(int $seed): void
     {

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -78,56 +78,73 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
-    public function testMultiDmlStatementGeneratesExecutableBatch(): void
+    #[DataProvider('providerTargetedGenerationSeed')]
+    public function testMultiDmlStatementDerivesTwoStatementBatchFromGrammar(int $seed): void
     {
-        $minimum = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return $int1 === 100 && $int2 === 999 ? 100 : 0;
-            }
-        };
-        $middle = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return $int1 === 100 && $int2 === 999 ? 500 : 1;
-            }
-        };
-        $maximum = new class () extends Generator {
-            /**
-             * @param mixed $int1
-             * @param mixed $int2
-             */
-            #[\Override]
-            public function numberBetween($int1 = 0, $int2 = 2147483647): int
-            {
-                return $int1 === 100 && $int2 === 999 ? 999 : 2;
-            }
-        };
+        $faker = Factory::create();
+        $faker->seed($seed);
+        $provider = new SqliteProvider($faker);
+        $sql = $provider->multiDmlStatement();
+        $faker->seed($seed);
+        $tokens = (new LexicalGrammar($faker, 'sqlite-3.47.2', true))->tokenize($sql);
+        $separator = array_search('SEMI', $tokens, true);
 
-        self::assertSame(
-            "INSERT INTO users (id, name, email) VALUES (100, 'batch-a', 'a@example.com'); "
-                . "INSERT INTO users (id, name, email) VALUES (101, 'batch-b', 'b@example.com')",
-            (new SqliteProvider($minimum))->multiDmlStatement(),
-        );
-        self::assertSame(
-            "INSERT INTO users (id, name, email) VALUES (500, 'before', 'before@example.com'); "
-                . "UPDATE users SET name = 'after' WHERE id = 500",
-            (new SqliteProvider($middle))->multiDmlStatement(),
-        );
-        self::assertSame(
-            'DELETE FROM users WHERE id = 999; DELETE FROM users WHERE id = 1000',
-            (new SqliteProvider($maximum))->multiDmlStatement(),
-        );
+        self::assertSame($sql, $provider->multiDmlStatement(40));
+        self::assertIsInt($separator);
+        self::assertContains($tokens[0], ['INSERT', 'UPDATE', 'DELETE']);
+        self::assertContains($tokens[$separator + 1], ['INSERT', 'UPDATE', 'DELETE']);
+        self::assertSame(2, count(array_filter($tokens, static fn (string $token): bool => $token === 'SEMI')));
+    }
+
+    #[DataProvider('providerMultiDmlSelection')]
+    public function testMultiDmlStatementCanSelectEveryDmlFamily(
+        int $firstChoice,
+        int $secondChoice,
+        string $first,
+        string $second,
+    ): void {
+        $generator = new class ([$firstChoice, $secondChoice]) extends Generator {
+            /** @var list<int> */
+            private readonly array $choices;
+            private int $call = 0;
+
+            /** @param list<int> $choices */
+            public function __construct(array $choices)
+            {
+                parent::__construct();
+                $this->choices = $choices;
+            }
+
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if ($this->call < count($this->choices)) {
+                    $choice = $this->choices[$this->call];
+                    ++$this->call;
+                    if ($min !== 0 || $max !== 2 || $choice < $min || $choice > $max) {
+                        throw new \UnexpectedValueException();
+                    }
+
+                    return $choice;
+                }
+                if (!is_int($min)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $min;
+            }
+        };
+        $sql = (new SqliteProvider($generator))->multiDmlStatement();
+        $tokens = (new LexicalGrammar(Factory::create(), 'sqlite-3.47.2', true))->tokenize($sql);
+        $separator = array_search('SEMI', $tokens, true);
+
+        self::assertIsInt($separator);
+        self::assertSame($first, $tokens[0]);
+        self::assertSame($second, $tokens[$separator + 1]);
     }
 
     #[DataProvider('providerTargetedGenerationSeed')]
@@ -793,6 +810,16 @@ final class SqliteProviderTest extends TestCase
         foreach (range(0, 31) as $seed) {
             yield "seed {$seed}" => [$seed];
         }
+    }
+
+    /**
+     * @return iterable<string, array{int, int, string, string}>
+     */
+    public static function providerMultiDmlSelection(): iterable
+    {
+        yield 'insert' => [0, 0, 'INSERT', 'INSERT'];
+        yield 'update' => [1, 1, 'UPDATE', 'UPDATE'];
+        yield 'delete' => [2, 2, 'DELETE', 'DELETE'];
     }
 
     /**

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\SqlFaker;
 
 use Faker\Factory;
+use Faker\Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\Grammar\GenerationPlan;
@@ -77,33 +78,56 @@ final class SqliteProviderTest extends TestCase
         self::assertContains('UPDATE', $tokens);
     }
 
-    #[DataProvider('providerMultiDmlSeed')]
-    public function testMultiDmlStatementGeneratesExecutableBatch(int $seed, string $expected): void
+    public function testMultiDmlStatementGeneratesExecutableBatch(): void
     {
-        $faker = Factory::create();
-        $provider = new SqliteProvider($faker);
-        $faker->seed($seed);
+        $minimum = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return $int1 === 100 && $int2 === 999 ? 100 : 0;
+            }
+        };
+        $middle = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return $int1 === 100 && $int2 === 999 ? 500 : 1;
+            }
+        };
+        $maximum = new class () extends Generator {
+            /**
+             * @param mixed $int1
+             * @param mixed $int2
+             */
+            #[\Override]
+            public function numberBetween($int1 = 0, $int2 = 2147483647): int
+            {
+                return $int1 === 100 && $int2 === 999 ? 999 : 2;
+            }
+        };
 
-        self::assertSame($expected, $provider->multiDmlStatement());
-    }
-
-    /** @return iterable<string, array{int, string}> */
-    public static function providerMultiDmlSeed(): iterable
-    {
-        yield 'insert then insert' => [
-            0,
-            "INSERT INTO users (id, name, email) VALUES (144, 'batch-a', 'a@example.com'); "
-                . "INSERT INTO users (id, name, email) VALUES (145, 'batch-b', 'b@example.com')",
-        ];
-        yield 'insert then update' => [
-            7,
-            "INSERT INTO users (id, name, email) VALUES (415, 'before', 'before@example.com'); "
-                . "UPDATE users SET name = 'after' WHERE id = 415",
-        ];
-        yield 'delete then delete' => [
-            1,
-            'DELETE FROM users WHERE id = 545; DELETE FROM users WHERE id = 546',
-        ];
+        self::assertSame(
+            "INSERT INTO users (id, name, email) VALUES (100, 'batch-a', 'a@example.com'); "
+                . "INSERT INTO users (id, name, email) VALUES (101, 'batch-b', 'b@example.com')",
+            (new SqliteProvider($minimum))->multiDmlStatement(),
+        );
+        self::assertSame(
+            "INSERT INTO users (id, name, email) VALUES (500, 'before', 'before@example.com'); "
+                . "UPDATE users SET name = 'after' WHERE id = 500",
+            (new SqliteProvider($middle))->multiDmlStatement(),
+        );
+        self::assertSame(
+            'DELETE FROM users WHERE id = 999; DELETE FROM users WHERE id = 1000',
+            (new SqliteProvider($maximum))->multiDmlStatement(),
+        );
     }
 
     #[DataProvider('providerTargetedGenerationSeed')]

--- a/packages/ztd-query-core/src/Rewrite/SqlRewriter.php
+++ b/packages/ztd-query-core/src/Rewrite/SqlRewriter.php
@@ -19,6 +19,13 @@ interface SqlRewriter
     public function emptyResultSelect(): string;
 
     /**
+     * Split a SQL batch using the platform's lexical rules.
+     *
+     * @return list<string>
+     */
+    public function splitStatements(string $sql): array;
+
+    /**
      * Rewrite a SQL string into a structured plan.
      * For multiple statements, only returns plan for the first statement.
      */

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -277,6 +277,12 @@ final class Session
         }
     }
 
+    /** @return list<string> */
+    public function splitStatements(string $sql): array
+    {
+        return $this->rewriter->splitStatements($sql);
+    }
+
     /**
      * Process an already-executed statement based on the rewrite plan.
      *

--- a/packages/ztd-query-core/tests/Fake/ExceptionThrowingRewriter.php
+++ b/packages/ztd-query-core/tests/Fake/ExceptionThrowingRewriter.php
@@ -31,6 +31,11 @@ final class ExceptionThrowingRewriter implements SqlRewriter
         throw $this->exception;
     }
 
+    public function splitStatements(string $sql): array
+    {
+        return [$sql];
+    }
+
     public function rewriteMultiple(string $sql): MultiRewritePlan
     {
         throw $this->exception;

--- a/packages/ztd-query-core/tests/Fake/FakeSqlRewriter.php
+++ b/packages/ztd-query-core/tests/Fake/FakeSqlRewriter.php
@@ -75,10 +75,7 @@ final class FakeSqlRewriter implements SqlRewriter
 
     public function rewriteMultiple(string $sql): MultiRewritePlan
     {
-        $statements = array_filter(
-            array_map('trim', explode(';', $sql)),
-            static fn (string $s): bool => $s !== ''
-        );
+        $statements = $this->splitStatements($sql);
 
         $plans = [];
         foreach ($statements as $stmt) {
@@ -86,6 +83,14 @@ final class FakeSqlRewriter implements SqlRewriter
         }
 
         return new MultiRewritePlan($plans);
+    }
+
+    public function splitStatements(string $sql): array
+    {
+        return array_values(array_filter(
+            array_map('trim', explode(';', $sql)),
+            static fn (string $s): bool => $s !== ''
+        ));
     }
 
     private function classify(string $sql): ?QueryKind

--- a/packages/ztd-query-core/tests/Fake/FixedRewriter.php
+++ b/packages/ztd-query-core/tests/Fake/FixedRewriter.php
@@ -33,6 +33,11 @@ final class FixedRewriter implements SqlRewriter
         return $this->plan;
     }
 
+    public function splitStatements(string $sql): array
+    {
+        return [$sql];
+    }
+
     public function rewriteMultiple(string $sql): MultiRewritePlan
     {
         return new MultiRewritePlan([$this->plan]);

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -131,6 +131,24 @@ final class SessionTest extends TestCase
         self::assertSame($escaper, $session->sqlPlaceholderEscaper());
     }
 
+    public function testSplitStatementsUsesPlatformRewriter(): void
+    {
+        $shadowStore = new ShadowStore();
+        $rewriter = new FakeSqlRewriter($shadowStore, new TableDefinitionRegistry());
+        $session = new Session(
+            $rewriter,
+            $shadowStore,
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            new FakeConnection(),
+        );
+
+        self::assertSame(
+            ['SELECT 1', 'SELECT 2'],
+            $session->splitStatements(' SELECT 1; SELECT 2 '),
+        );
+    }
+
     public function testUsesProvidedTransactionManagerForSchemaRollback(): void
     {
         $shadowStore = new ShadowStore();

--- a/packages/ztd-query-mysql/src/MySqlRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlRewriter.php
@@ -100,7 +100,7 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
      */
     public function rewriteMultiple(string $sql): MultiRewritePlan
     {
-        $statements = $this->parser->splitStatements($sql);
+        $statements = $this->splitStatements($sql);
 
         if ($statements === []) {
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
@@ -112,6 +112,12 @@ final class MySqlRewriter implements SqlRewriter, RewriteStateCommitter
         }
 
         return new MultiRewritePlan($plans);
+    }
+
+    /** {@inheritDoc} */
+    public function splitStatements(string $sql): array
+    {
+        return $this->parser->splitStatements($sql);
     }
 
     public function commitRewriteState(): void

--- a/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
+++ b/packages/ztd-query-pdo-adapter/src/ZtdPdo.php
@@ -234,6 +234,11 @@ class ZtdPdo extends PDO
             return $this->pdo->exec($statement);
         }
 
+        $statements = $this->session->splitStatements($statement);
+        if (count($statements) > 1) {
+            return $this->execMultiple($statements);
+        }
+
         $this->guardRawPostgreSqlCopy($statement);
 
         $transactionStatement = $this->session->transactionStatement($statement);
@@ -251,6 +256,27 @@ class ZtdPdo extends PDO
         } catch (DatabaseException $e) {
             throw new ZtdPdoException($e->getMessage(), 0, $e);
         }
+    }
+
+    /**
+     * @param non-empty-list<string> $statements
+     */
+    private function execMultiple(array $statements): int|false
+    {
+        $affectedRows = $this->exec($statements[0]);
+        if ($affectedRows === false) {
+            return false;
+        }
+
+        foreach (array_slice($statements, 1) as $statement) {
+            $result = $this->exec($statement);
+            if ($result === false) {
+                return false;
+            }
+            $affectedRows = $result;
+        }
+
+        return $affectedRows;
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/MultiStatementExecTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Integration/Sqlite/MultiStatementExecTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Sqlite;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Adapter\Pdo\ZtdPdo;
+
+/**
+ * @requires extension pdo_sqlite
+ * @group integration
+ * @group sqlite
+ */
+#[CoversNothing]
+#[Large]
+final class MultiStatementExecTest extends TestCase
+{
+    public function testExecProcessesStatementsAgainstEachPrecedingShadowState(): void
+    {
+        $rawPdo = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $rawPdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        self::assertSame(2, $ztdPdo->exec(
+            "INSERT INTO items VALUES (1, 'a'); INSERT INTO items VALUES (2, 'b'), (3, 'c')",
+        ));
+        self::assertSame(1, $ztdPdo->exec(
+            "INSERT INTO items VALUES (4, 'before'); UPDATE items SET name = 'after' WHERE id = 4",
+        ));
+        self::assertSame(2, $ztdPdo->exec(
+            'DELETE FROM items WHERE id = 1; DELETE FROM items WHERE id IN (2, 3)',
+        ));
+        self::assertSame(1, $ztdPdo->exec(
+            "UPDATE items SET name = 'semi;colon' WHERE id = 4; -- not a ; statement\n"
+            . "UPDATE items SET name = name || ';done' WHERE id = 4",
+        ));
+
+        $shadow = $ztdPdo->query('SELECT id, name FROM items');
+        self::assertNotFalse($shadow);
+        self::assertSame([['id' => 4, 'name' => 'semi;colon;done']], $shadow->fetchAll(PDO::FETCH_ASSOC));
+        $physical = $rawPdo->query('SELECT COUNT(*) FROM items');
+        self::assertNotFalse($physical);
+        self::assertSame(0, (int) $physical->fetchColumn());
+    }
+
+    public function testTransactionStatementsInBatchControlShadowRollback(): void
+    {
+        $rawPdo = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $rawPdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+        $ztdPdo = ZtdPdo::fromPdo($rawPdo);
+
+        self::assertSame(0, $ztdPdo->exec(
+            "BEGIN; INSERT INTO items VALUES (1, 'rolled back'); ROLLBACK",
+        ));
+
+        $shadow = $ztdPdo->query('SELECT COUNT(*) FROM items');
+        self::assertNotFalse($shadow);
+        self::assertSame(0, (int) $shadow->fetchColumn());
+    }
+}

--- a/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoTest.php
@@ -17,8 +17,11 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\SessionFactory;
 use ZtdQuery\ResultSelectRunner;
+use ZtdQuery\Rewrite\QueryKind;
+use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Session;
+use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(ZtdPdo::class)]
@@ -257,6 +260,111 @@ final class ZtdPdoTest extends TestCase
         ZtdPdo::fromPdo($pdo, $expectedConfig, $mockFactory);
 
         self::assertSame($expectedConfig, $receivedConfig);
+    }
+
+    public function testExecRunsEachStatementSequentiallyAndReturnsLastAffectedRows(): void
+    {
+        $store = new ShadowStore();
+        $rewriter = static::createMock(SqlRewriter::class);
+        $rewriter->expects(self::exactly(3))
+            ->method('splitStatements')
+            ->willReturnCallback(static fn (string $sql): array => match ($sql) {
+                'first; second' => ['first', 'second'],
+                default => [$sql],
+            });
+        $rewriter->expects(self::exactly(2))
+            ->method('rewrite')
+            ->willReturnCallback(static fn (string $sql): RewritePlan => match ($sql) {
+                'first' => new RewritePlan(
+                    'SELECT 1 AS id UNION ALL SELECT 2 AS id',
+                    QueryKind::WRITE_SIMULATED,
+                    new InsertMutation('first_items'),
+                ),
+                'second' => new RewritePlan(
+                    'SELECT 3 AS id',
+                    QueryKind::WRITE_SIMULATED,
+                    new InsertMutation('second_items'),
+                ),
+                default => throw new RuntimeException("Unexpected SQL: $sql"),
+            });
+        $factory = static::createMock(SessionFactory::class);
+        $factory->expects(self::once())
+            ->method('create')
+            ->willReturnCallback(static fn (ConnectionInterface $connection, ZtdConfig $config): Session => new Session(
+                $rewriter,
+                $store,
+                new ResultSelectRunner(),
+                $config,
+                $connection,
+            ));
+        $ztdPdo = ZtdPdo::fromPdo(new PDO('sqlite::memory:'), null, $factory);
+
+        self::assertSame(1, $ztdPdo->exec('first; second'));
+        self::assertSame([['id' => 1], ['id' => 2]], $store->get('first_items'));
+        self::assertSame([['id' => 3]], $store->get('second_items'));
+    }
+
+    public function testExecStopsBatchWhenFirstStatementFails(): void
+    {
+        $rewriter = static::createMock(SqlRewriter::class);
+        $rewriter->expects(self::exactly(2))
+            ->method('splitStatements')
+            ->willReturnCallback(static fn (string $sql): array => match ($sql) {
+                'first; second' => ['first', 'second'],
+                default => [$sql],
+            });
+        $rewriter->expects(self::once())
+            ->method('rewrite')
+            ->with('first')
+            ->willReturn(new RewritePlan('SELECT * FROM missing_table', QueryKind::READ));
+        $factory = static::createMock(SessionFactory::class);
+        $factory->expects(self::once())
+            ->method('create')
+            ->willReturnCallback(static fn (ConnectionInterface $connection, ZtdConfig $config): Session => new Session(
+                $rewriter,
+                new ShadowStore(),
+                new ResultSelectRunner(),
+                $config,
+                $connection,
+            ));
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+        $ztdPdo = ZtdPdo::fromPdo($pdo, null, $factory);
+
+        self::assertFalse($ztdPdo->exec('first; second'));
+    }
+
+    public function testExecStopsBatchWhenLaterStatementFails(): void
+    {
+        $rewriter = static::createMock(SqlRewriter::class);
+        $rewriter->expects(self::exactly(3))
+            ->method('splitStatements')
+            ->willReturnCallback(static fn (string $sql): array => match ($sql) {
+                'first; second; third' => ['first', 'second', 'third'],
+                default => [$sql],
+            });
+        $rewriter->expects(self::exactly(2))
+            ->method('rewrite')
+            ->willReturnCallback(static fn (string $sql): RewritePlan => match ($sql) {
+                'first' => new RewritePlan('SELECT 1', QueryKind::READ),
+                'second' => new RewritePlan('SELECT * FROM missing_table', QueryKind::READ),
+                default => throw new RuntimeException("Unexpected SQL: $sql"),
+            });
+        $factory = static::createMock(SessionFactory::class);
+        $factory->expects(self::once())
+            ->method('create')
+            ->willReturnCallback(static fn (ConnectionInterface $connection, ZtdConfig $config): Session => new Session(
+                $rewriter,
+                new ShadowStore(),
+                new ResultSelectRunner(),
+                $config,
+                $connection,
+            ));
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+        $ztdPdo = ZtdPdo::fromPdo($pdo, null, $factory);
+
+        self::assertFalse($ztdPdo->exec('first; second; third'));
     }
 
     /**

--- a/packages/ztd-query-postgres/src/PgSqlRewriter.php
+++ b/packages/ztd-query-postgres/src/PgSqlRewriter.php
@@ -75,7 +75,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
         }
 
-        $statements = $this->parser->splitStatements($sql);
+        $statements = $this->splitStatements($sql);
         if ($statements === []) {
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
         }
@@ -100,7 +100,7 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
         }
 
-        $statements = $this->parser->splitStatements($sql);
+        $statements = $this->splitStatements($sql);
         if ($statements === []) {
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
         }
@@ -111,6 +111,12 @@ final class PgSqlRewriter implements SqlRewriter, RewriteStateCommitter
         }
 
         return new MultiRewritePlan($plans);
+    }
+
+    /** {@inheritDoc} */
+    public function splitStatements(string $sql): array
+    {
+        return $this->parser->splitStatements($sql);
     }
 
     public function commitRewriteState(): void

--- a/packages/ztd-query-sqlite/fuzz/RewriteFuzzTest.php
+++ b/packages/ztd-query-sqlite/fuzz/RewriteFuzzTest.php
@@ -151,6 +151,20 @@ final class RewriteFuzzTest extends TestCase
         self::addToAssertionCount(self::ITERATIONS);
     }
 
+    public function testRewriteMultipleDmlStatements(): void
+    {
+        for ($i = 0; $i < self::ITERATIONS; $i++) {
+            $sql = $this->provider->multiDmlStatement();
+            $statements = $this->rewriter->splitStatements($sql);
+            $plans = $this->rewriter->rewriteMultiple($sql);
+
+            self::assertCount(2, $statements, "SQL batch should contain two statements on iteration $i");
+            self::assertSame(2, $plans->count(), "SQL batch should produce two plans on iteration $i");
+            self::assertSame(QueryKind::WRITE_SIMULATED, $plans->get(0)?->kind());
+            self::assertSame(QueryKind::WRITE_SIMULATED, $plans->get(1)?->kind());
+        }
+    }
+
     public function testRewriteCreateTableReturnsDdlSimulatedKind(): void
     {
         for ($i = 0; $i < self::ITERATIONS; $i++) {

--- a/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
+++ b/packages/ztd-query-sqlite/fuzz/Robustness/Target/RewriteTarget.php
@@ -29,6 +29,7 @@ final class RewriteTarget
 {
     private Generator $faker;
     private SqliteProvider $provider;
+    private SqliteRewriter $rewriter;
     /** @var array<int, InvariantChecker> */
     private array $checkers;
 
@@ -52,14 +53,14 @@ final class RewriteTarget
         $deleteTransformer = new DeleteTransformer($parser, $selectTransformer);
         $transformer = new SqliteTransformer($parser, $selectTransformer, $insertTransformer, $updateTransformer, $deleteTransformer);
         $mutationResolver = new SqliteMutationResolver($shadowStore, $registry, $schemaParser, $parser);
-        $rewriter = new SqliteRewriter($guard, $shadowStore, $registry, $transformer, $mutationResolver, $parser);
+        $this->rewriter = new SqliteRewriter($guard, $shadowStore, $registry, $transformer, $mutationResolver, $parser);
 
         $this->checkers = [
             new ClassifyNeverThrowsChecker($guard),
             new ClassifyDeterministicChecker($guard),
-            new RewriteExceptionTypeChecker($rewriter),
-            new RewritePlanConsistencyChecker($rewriter),
-            new ClassifyRewriteAgreementChecker($guard, $rewriter),
+            new RewriteExceptionTypeChecker($this->rewriter),
+            new RewritePlanConsistencyChecker($this->rewriter),
+            new ClassifyRewriteAgreementChecker($guard, $this->rewriter),
         ];
     }
 
@@ -75,6 +76,13 @@ final class RewriteTarget
             if ($violation !== null) {
                 throw new \Error("Invariant violation: seed=$seed\n$violation");
             }
+        }
+
+        $batch = $this->provider->multiDmlStatement();
+        $statements = $this->rewriter->splitStatements($batch);
+        $plans = $this->rewriter->rewriteMultiple($batch);
+        if (count($statements) !== 2 || $plans->count() !== 2) {
+            throw new \Error("Invariant violation: seed=$seed\nMulti-statement DML batch was not split into two plans: $batch");
         }
     }
 

--- a/packages/ztd-query-sqlite/src/SqliteParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteParser.php
@@ -75,7 +75,7 @@ final class SqliteParser
     /**
      * Split a SQL string into individual statements.
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public function splitStatements(string $sql): array
     {

--- a/packages/ztd-query-sqlite/src/SqliteRewriter.php
+++ b/packages/ztd-query-sqlite/src/SqliteRewriter.php
@@ -91,7 +91,7 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
      */
     public function rewriteMultiple(string $sql): MultiRewritePlan
     {
-        $statements = $this->parser->splitStatements($sql);
+        $statements = $this->splitStatements($sql);
 
         if ($statements === []) {
             throw new UnsupportedSqlException($sql, 'Empty or unparseable');
@@ -103,6 +103,12 @@ final class SqliteRewriter implements SqlRewriter, RewriteStateCommitter
         }
 
         return new MultiRewritePlan($plans);
+    }
+
+    /** {@inheritDoc} */
+    public function splitStatements(string $sql): array
+    {
+        return $this->parser->splitStatements($sql);
     }
 
     public function commitRewriteState(): void


### PR DESCRIPTION
Closes #78

## Summary
- expose dialect-aware SQL statement splitting through the rewriter/session contract
- execute `PDO::exec()` batches one statement at a time so each statement observes the preceding shadow mutation
- preserve native last-statement affected-row semantics and stop after an execution failure
- add SQLite integration coverage for INSERT/UPDATE/DELETE batches, lexical semicolons, and transaction rollback
- add SQLFaker multi-DML generation plus PHPUnit and CLI fuzz coverage

## Verification
- core: 806 unit tests
- PDO adapter: 309 unit tests plus SQLite batch integration tests
- SQLite: 1340 unit/fuzz tests; CLI fuzz 500 rewrite + 300 full + 300 classify runs
- MySQL: 1071 unit tests
- PostgreSQL: 1478 unit tests
- SQLFaker: 1089 unit tests
- PHP-CS-Fixer and PHPStan for all changed packages
- Infection: PDO 14/14, SQLFaker 35/35, core 1/1 mutants killed