### PR TITLE
refactor(pdo): delegate parameter SQL binding to dialects

### DIFF
--- a/packages/ztd-query-core/src/Platform/ParameterBindingCompiler.php
+++ b/packages/ztd-query-core/src/Platform/ParameterBindingCompiler.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform;
+
+interface ParameterBindingCompiler
+{
+    /**
+     * @param array<int|string, mixed>|null $params
+     * @return array{sql: string, params: array<int|string, mixed>|null}
+     */
+    public function compile(string $sql, ?array $params): array;
+}

--- a/packages/ztd-query-core/src/Schema/ColumnType.php
+++ b/packages/ztd-query-core/src/Schema/ColumnType.php
@@ -55,4 +55,5 @@ final class ColumnType
 
         return new self($family, $nativeType);
     }
+
 }

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -17,7 +17,7 @@ use ZtdQuery\Exception\UnknownSchemaException;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\CopySupport;
 use ZtdQuery\Platform\CopyTarget;
-use ZtdQuery\Platform\SqlPlaceholderEscaper;
+use ZtdQuery\Platform\ParameterBindingCompiler;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -87,7 +87,7 @@ final class Session
 
     private ?CopySupport $copySupport;
 
-    private ?SqlPlaceholderEscaper $sqlPlaceholderEscaper;
+    private ?ParameterBindingCompiler $parameterBindingCompiler;
 
     private ?string $lastInsertId = null;
 
@@ -107,7 +107,7 @@ final class Session
         ?ShadowTransactionManager $transactions = null,
         ?TableDefinitionRegistry $registry = null,
         ?CopySupport $copySupport = null,
-        ?SqlPlaceholderEscaper $sqlPlaceholderEscaper = null,
+        ?ParameterBindingCompiler $parameterBindingCompiler = null,
     ) {
         $this->rewriter = $rewriter;
         $this->shadowStore = $shadowStore;
@@ -118,7 +118,7 @@ final class Session
         $this->registry = $registry ?? new TableDefinitionRegistry();
         $this->referentialIntegrity = new ReferentialIntegrityEnforcer($this->registry);
         $this->copySupport = $copySupport;
-        $this->sqlPlaceholderEscaper = $sqlPlaceholderEscaper;
+        $this->parameterBindingCompiler = $parameterBindingCompiler;
     }
 
     /**
@@ -223,9 +223,9 @@ final class Session
         return $this->copySupport->target($relation, $fields, $definition);
     }
 
-    public function sqlPlaceholderEscaper(): ?SqlPlaceholderEscaper
+    public function parameterBindingCompiler(): ?ParameterBindingCompiler
     {
-        return $this->sqlPlaceholderEscaper;
+        return $this->parameterBindingCompiler;
     }
 
     /**

--- a/packages/ztd-query-core/tests/Unit/Platform/ParameterBindingCompilerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Platform/ParameterBindingCompilerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\ParameterBindingCompiler;
+
+#[CoversNothing]
+final class ParameterBindingCompilerTest extends TestCase
+{
+    public function testDeclaresDialectParameterCompilationContract(): void
+    {
+        $reflection = new \ReflectionClass(ParameterBindingCompiler::class);
+
+        self::assertTrue($reflection->isInterface());
+        self::assertTrue($reflection->hasMethod('compile'));
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/Schema/ColumnTypeTest.php
+++ b/packages/ztd-query-core/tests/Unit/Schema/ColumnTypeTest.php
@@ -45,4 +45,5 @@ final class ColumnTypeTest extends TestCase
 
         self::assertSame('numeric(10, 2)', $type->nativeType);
     }
+
 }

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -17,7 +17,7 @@ use ZtdQuery\Exception\MissingPrimaryKeyException;
 use ZtdQuery\Exception\ForeignKeyViolationException;
 use ZtdQuery\Platform\CopySupport;
 use ZtdQuery\Platform\CopyTarget;
-use ZtdQuery\Platform\SqlPlaceholderEscaper;
+use ZtdQuery\Platform\ParameterBindingCompiler;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
@@ -72,7 +72,7 @@ final class SessionTest extends TestCase
         self::assertNull($session->tableDefinition('users'));
         self::assertNull($session->copySupport());
         self::assertNull($session->copyTarget('users', null));
-        self::assertNull($session->sqlPlaceholderEscaper());
+        self::assertNull($session->parameterBindingCompiler());
 
         $session->disable();
         self::assertFalse($session->isEnabled());
@@ -113,7 +113,7 @@ final class SessionTest extends TestCase
             ['missing', 'missing'],
         ]);
         $copy->method('target')->willReturn($target);
-        $escaper = self::createStub(SqlPlaceholderEscaper::class);
+        $compiler = self::createStub(ParameterBindingCompiler::class);
         $session = new Session(
             new FakeSqlRewriter($shadowStore, $registry),
             $shadowStore,
@@ -122,13 +122,13 @@ final class SessionTest extends TestCase
             new FakeConnection(),
             registry: $registry,
             copySupport: $copy,
-            sqlPlaceholderEscaper: $escaper,
+            parameterBindingCompiler: $compiler,
         );
 
         self::assertSame($copy, $session->copySupport());
         self::assertSame($target, $session->copyTarget('public.users', 'id'));
         self::assertNull($session->copyTarget('missing', null));
-        self::assertSame($escaper, $session->sqlPlaceholderEscaper());
+        self::assertSame($compiler, $session->parameterBindingCompiler());
     }
 
     public function testSplitStatementsUsesPlatformRewriter(): void

--- a/packages/ztd-query-pdo-adapter/src/PdoParameterBinder.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoParameterBinder.php
@@ -5,103 +5,9 @@ declare(strict_types=1);
 namespace ZtdQuery\Adapter\Pdo;
 
 use PDOStatement;
-use ZtdQuery\Platform\SqlPlaceholderEscaper;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 final class PdoParameterBinder
 {
-    /**
-     * @param array<int|string, mixed>|null $params
-     * @return array{sql: string, params: array<int|string, mixed>|null}
-     */
-    public function compile(
-        string $sql,
-        string $driver,
-        ?array $params,
-        ?SqlPlaceholderEscaper $placeholderEscaper = null,
-    ): array {
-        if ($driver !== 'pgsql' && $driver !== 'sqlite') {
-            return ['sql' => $sql, 'params' => $params];
-        }
-        if ($driver === 'sqlite' && $params === null) {
-            return ['sql' => $sql, 'params' => null];
-        }
-
-        $tokens = SqlTokenStream::tokenize($sql)->tokens();
-        $replacements = [];
-        $positionalIndex = 0;
-        $nativePositions = [];
-
-        foreach ($tokens as $token) {
-            if ($token->kind !== SqlTokenKind::Parameter) {
-                continue;
-            }
-
-            if ($driver === 'pgsql') {
-                if (!str_starts_with($token->text, '$')) {
-                    continue;
-                }
-                $position = filter_var(
-                    substr($token->text, 1),
-                    FILTER_VALIDATE_INT,
-                    ['options' => ['min_range' => 1]],
-                );
-                if (!is_int($position)) {
-                    continue;
-                }
-                $nativePositions[$position] = $position;
-                $replacements[$token->offset] = [
-                    'length' => strlen($token->text),
-                    'sql' => ':__ztd_pdo_' . $position,
-                ];
-                continue;
-            }
-
-            if ($token->text === '?') {
-                $parameterKey = $positionalIndex;
-                $positionalIndex++;
-            } else {
-                $name = ltrim($token->text, ':');
-                $parameterKey = array_key_exists($name, $params) ? $name : $token->text;
-            }
-            if (!array_key_exists($parameterKey, $params)) {
-                continue;
-            }
-            $cast = $this->sqliteCast($params[$parameterKey]);
-            if ($cast !== null) {
-                $replacements[$token->offset] = [
-                    'length' => strlen($token->text),
-                    'sql' => 'CAST(' . $token->text . ' AS ' . $cast . ')',
-                ];
-            }
-        }
-
-        if ($replacements !== []) {
-            krsort($replacements);
-            foreach ($replacements as $offset => $replacement) {
-                $sql = substr_replace($sql, $replacement['sql'], $offset, $replacement['length']);
-            }
-        }
-
-        if ($driver === 'pgsql' && $placeholderEscaper !== null) {
-            $sql = $placeholderEscaper->escape($sql);
-        }
-
-        if ($nativePositions === [] || $params === null) {
-            return ['sql' => $sql, 'params' => $params];
-        }
-
-        $mapped = [];
-        foreach ($nativePositions as $position) {
-            if (array_key_exists($position - 1, $params)) {
-                $mapped['__ztd_pdo_' . $position] = $params[$position - 1];
-            }
-        }
-
-        return ['sql' => $sql, 'params' => $mapped];
-    }
-
     /** @param array<int|string, mixed>|null $params */
     public function execute(PDOStatement $statement, ?array $params): bool
     {
@@ -127,17 +33,5 @@ final class PdoParameterBinder
         }
 
         return sprintf(':%s', $parameter);
-    }
-
-    private function sqliteCast(mixed $value): ?string
-    {
-        if (is_int($value) || is_bool($value)) {
-            return 'INTEGER';
-        }
-        if (is_float($value)) {
-            return 'REAL';
-        }
-
-        return null;
     }
 }

--- a/packages/ztd-query-pdo-adapter/src/PdoPreparedExecution.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoPreparedExecution.php
@@ -29,13 +29,8 @@ final class PdoPreparedExecution
     public function prepare(?array $params): array
     {
         $plan = $this->session->rewrite($this->sql);
-        $driver = $this->driver();
-        $compiled = $this->parameterBinder->compile(
-            $plan->sql(),
-            $driver,
-            $params,
-            $this->session->sqlPlaceholderEscaper(),
-        );
+        $compiled = $this->session->parameterBindingCompiler()?->compile($plan->sql(), $params)
+            ?? ['sql' => $plan->sql(), 'params' => $params];
         $statement = $this->pdo->prepare($compiled['sql'], $this->options);
         if ($statement === false) {
             throw new RuntimeException('PDO failed to prepare rewritten SQL.');
@@ -47,13 +42,5 @@ final class PdoPreparedExecution
     public function parameterBinder(): PdoParameterBinder
     {
         return $this->parameterBinder;
-    }
-
-    private function driver(): string
-    {
-        /** @var string $driver */
-        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
-
-        return $driver;
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterBinderTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoParameterBinderTest.php
@@ -10,96 +10,11 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\PdoParameterBinder;
 use ZtdQuery\Adapter\Pdo\PdoParameterType;
-use ZtdQuery\Platform\SqlPlaceholderEscaper;
 
 #[CoversClass(PdoParameterBinder::class)]
 #[UsesClass(PdoParameterType::class)]
 final class PdoParameterBinderTest extends TestCase
 {
-    public function testMapsNativePostgreSqlPositionsWithoutTouchingQuotedText(): void
-    {
-        $compiled = (new PdoParameterBinder())->compile(
-            'SELECT $2, $1, $2, \'$3\' FROM docs WHERE meta ? $1 -- $4',
-            'pgsql',
-            ['first', 'second'],
-            new class () implements SqlPlaceholderEscaper {
-                public function escape(string $sql): string
-                {
-                    return str_replace('meta ? ', 'meta ?? ', $sql);
-                }
-            },
-        );
-
-        self::assertSame(
-            'SELECT :__ztd_pdo_2, :__ztd_pdo_1, :__ztd_pdo_2, \'$3\' FROM docs WHERE meta ?? :__ztd_pdo_1 -- $4',
-            $compiled['sql'],
-        );
-        self::assertSame(
-            ['__ztd_pdo_2' => 'second', '__ztd_pdo_1' => 'first'],
-            $compiled['params'],
-        );
-    }
-
-    public function testGivesSqliteParametersNumericStorageClasses(): void
-    {
-        $compiled = (new PdoParameterBinder())->compile(
-            'SELECT ?, ?, :ratio, :integer, \'?\', "?"',
-            'sqlite',
-            [0 => 12, 1 => 2.5, 'ratio' => 2.5, ':integer' => 9],
-        );
-
-        self::assertSame(
-            'SELECT CAST(? AS INTEGER), CAST(? AS REAL), CAST(:ratio AS REAL), CAST(:integer AS INTEGER), \'?\', "?"',
-            $compiled['sql'],
-        );
-    }
-
-    public function testLeavesUnboundParametersAndOtherDriversUnchanged(): void
-    {
-        $binder = new PdoParameterBinder();
-
-        self::assertSame(
-            ['sql' => 'SELECT ?, :missing', 'params' => null],
-            $binder->compile('SELECT ?, :missing', 'sqlite', null),
-        );
-        self::assertSame(
-            ['sql' => 'SELECT ?, :missing', 'params' => []],
-            $binder->compile('SELECT ?, :missing', 'sqlite', []),
-        );
-        self::assertSame(
-            ['sql' => "SELECT meta ? 'key'", 'params' => ['key']],
-            $binder->compile("SELECT meta ? 'key'", 'mysql', ['key']),
-        );
-        self::assertSame(
-            ['sql' => 'SELECT ?', 'params' => [1]],
-            $binder->compile('SELECT ?', 'pgsql', [1]),
-        );
-        self::assertSame(
-            ['sql' => 'SELECT $0, :__ztd_pdo_1', 'params' => ['__ztd_pdo_1' => 1]],
-            $binder->compile('SELECT $0, $1', 'pgsql', [1]),
-        );
-        self::assertSame(
-            ['sql' => 'SELECT :__ztd_pdo_1', 'params' => null],
-            $binder->compile('SELECT $1', 'pgsql', null),
-        );
-        self::assertSame(
-            ['sql' => 'SELECT $1', 'params' => [1]],
-            $binder->compile('SELECT $1', 'mysql', [1]),
-        );
-        self::assertSame(
-            ['sql' => 'SELECT ?', 'params' => [7]],
-            $binder->compile('SELECT ?', 'mysql', [7]),
-        );
-        self::assertSame(
-            ['sql' => 'SELECT ?, :__ztd_pdo_1', 'params' => ['__ztd_pdo_1' => 1]],
-            $binder->compile('SELECT ?, $1', 'pgsql', [1]),
-        );
-        self::assertSame(
-            ['sql' => 'SELECT :missing, CAST(:value AS INTEGER)', 'params' => ['value' => 7]],
-            $binder->compile('SELECT :missing, :value', 'sqlite', ['value' => 7]),
-        );
-    }
-
     public function testBindsExecuteArrayUsingPhpValueTypes(): void
     {
         $pdo = new PDO('sqlite::memory:');

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoPreparedExecutionTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoPreparedExecutionTest.php
@@ -14,7 +14,15 @@ use ZtdQuery\Adapter\Pdo\PdoParameterType;
 use ZtdQuery\Adapter\Pdo\PdoPreparedExecution;
 use ZtdQuery\Adapter\Pdo\PdoStatement;
 use ZtdQuery\Config\ZtdConfig;
+use ZtdQuery\Connection\ConnectionInterface;
+use ZtdQuery\Platform\ParameterBindingCompiler;
 use ZtdQuery\Platform\Sqlite\SqliteSessionFactory;
+use ZtdQuery\ResultSelectRunner;
+use ZtdQuery\Rewrite\QueryKind;
+use ZtdQuery\Rewrite\RewritePlan;
+use ZtdQuery\Rewrite\SqlRewriter;
+use ZtdQuery\Session;
+use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(PdoPreparedExecution::class)]
 #[UsesClass(PdoConnection::class)]
@@ -39,5 +47,50 @@ final class PdoPreparedExecutionTest extends TestCase
         $after = $execution->prepare([1]);
         self::assertTrue($execution->parameterBinder()->execute($after['statement'], $after['params']));
         self::assertSame('after', $after['statement']->fetchColumn());
+    }
+
+    public function testUsesThePlatformParameterBindingCompilerResult(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $rewriter = static::createStub(SqlRewriter::class);
+        $rewriter->method('rewrite')->willReturn(new RewritePlan('SELECT :original AS value', QueryKind::READ));
+        $compiler = static::createMock(ParameterBindingCompiler::class);
+        $compiler->expects(self::once())
+            ->method('compile')
+            ->with('SELECT :original AS value', ['original' => 11])
+            ->willReturn(['sql' => 'SELECT :compiled AS value', 'params' => ['compiled' => 11]]);
+        $session = new Session(
+            $rewriter,
+            new ShadowStore(),
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            static::createStub(ConnectionInterface::class),
+            parameterBindingCompiler: $compiler,
+        );
+
+        $prepared = (new PdoPreparedExecution($pdo, $session, 'SELECT :original AS value', []))
+            ->prepare(['original' => 11]);
+
+        self::assertSame('SELECT :compiled AS value', $prepared['statement']->queryString);
+        self::assertSame(['compiled' => 11], $prepared['params']);
+    }
+
+    public function testFallsBackWhenTheSessionHasNoParameterBindingCompiler(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $rewriter = static::createStub(SqlRewriter::class);
+        $rewriter->method('rewrite')->willReturn(new RewritePlan('SELECT ? AS value', QueryKind::READ));
+        $session = new Session(
+            $rewriter,
+            new ShadowStore(),
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            static::createStub(ConnectionInterface::class),
+        );
+
+        $prepared = (new PdoPreparedExecution($pdo, $session, 'SELECT ? AS value', []))->prepare([12]);
+
+        self::assertSame('SELECT ? AS value', $prepared['statement']->queryString);
+        self::assertSame([12], $prepared['params']);
     }
 }

--- a/packages/ztd-query-postgres/src/PgSqlPdoParameterBindingCompiler.php
+++ b/packages/ztd-query-postgres/src/PgSqlPdoParameterBindingCompiler.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Postgres;
+
+use ZtdQuery\Platform\ParameterBindingCompiler;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PgSqlPdoParameterBindingCompiler implements ParameterBindingCompiler
+{
+    public function __construct(
+        private readonly PgSqlPdoPlaceholderEscaper $placeholderEscaper = new PgSqlPdoPlaceholderEscaper(),
+    ) {
+    }
+
+    public function compile(string $sql, ?array $params): array
+    {
+        $replacements = [];
+        $nativePositions = [];
+        foreach (SqlTokenStream::tokenize($sql)->tokens() as $token) {
+            if ($token->kind !== SqlTokenKind::Parameter || !str_starts_with($token->text, '$')) {
+                continue;
+            }
+            $position = filter_var(
+                substr($token->text, 1),
+                FILTER_VALIDATE_INT,
+                ['options' => ['min_range' => 1]],
+            );
+            if (!is_int($position)) {
+                continue;
+            }
+            $nativePositions[$position] = $position;
+            $replacements[$token->offset] = [
+                'length' => strlen($token->text),
+                'sql' => ':__ztd_pdo_' . $position,
+            ];
+        }
+
+        if ($replacements !== []) {
+            krsort($replacements);
+            foreach ($replacements as $offset => $replacement) {
+                $sql = substr_replace($sql, $replacement['sql'], $offset, $replacement['length']);
+            }
+        }
+        $sql = $this->placeholderEscaper->escape($sql);
+        if ($nativePositions === [] || $params === null) {
+            return ['sql' => $sql, 'params' => $params];
+        }
+
+        $mapped = [];
+        foreach ($nativePositions as $position) {
+            if (array_key_exists($position - 1, $params)) {
+                $mapped['__ztd_pdo_' . $position] = $params[$position - 1];
+            }
+        }
+
+        return ['sql' => $sql, 'params' => $mapped];
+    }
+}

--- a/packages/ztd-query-postgres/src/PgSqlPdoParameterBindingCompiler.php
+++ b/packages/ztd-query-postgres/src/PgSqlPdoParameterBindingCompiler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ZtdQuery\Platform\Postgres;
 
 use ZtdQuery\Platform\ParameterBindingCompiler;
-use ZtdQuery\Sql\SqlTokenKind;
 use ZtdQuery\Sql\SqlTokenStream;
 
 final class PgSqlPdoParameterBindingCompiler implements ParameterBindingCompiler
@@ -20,7 +19,7 @@ final class PgSqlPdoParameterBindingCompiler implements ParameterBindingCompiler
         $replacements = [];
         $nativePositions = [];
         foreach (SqlTokenStream::tokenize($sql)->tokens() as $token) {
-            if ($token->kind !== SqlTokenKind::Parameter || !str_starts_with($token->text, '$')) {
+            if (!str_starts_with($token->text, '$')) {
                 continue;
             }
             $position = filter_var(

--- a/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
+++ b/packages/ztd-query-postgres/src/PgSqlSessionFactory.php
@@ -86,7 +86,7 @@ final class PgSqlSessionFactory implements SessionFactory
             transactions: new ShadowTransactionManager($shadowStore, $registry),
             registry: $registry,
             copySupport: new PgSqlCopySupport(),
-            sqlPlaceholderEscaper: new PgSqlPdoPlaceholderEscaper(),
+            parameterBindingCompiler: new PgSqlPdoParameterBindingCompiler(),
         );
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPdoParameterBindingCompilerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPdoParameterBindingCompilerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Postgres\PgSqlPdoParameterBindingCompiler;
+use ZtdQuery\Platform\Postgres\PgSqlPdoPlaceholderEscaper;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(PgSqlPdoParameterBindingCompiler::class)]
+#[UsesClass(PgSqlPdoPlaceholderEscaper::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class PgSqlPdoParameterBindingCompilerTest extends TestCase
+{
+    public function testMapsNativePositionsAndEscapesPostgreSqlOperators(): void
+    {
+        $compiled = (new PgSqlPdoParameterBindingCompiler())->compile(
+            'SELECT $2, $1, $2, \'$3\' FROM docs WHERE meta ? $1 -- $4',
+            ['first', 'second'],
+        );
+
+        self::assertSame(
+            'SELECT :__ztd_pdo_2, :__ztd_pdo_1, :__ztd_pdo_2, \'$3\' FROM docs WHERE meta ?? :__ztd_pdo_1 -- $4',
+            $compiled['sql'],
+        );
+        self::assertSame(
+            ['__ztd_pdo_2' => 'second', '__ztd_pdo_1' => 'first'],
+            $compiled['params'],
+        );
+    }
+
+    public function testPreservesPdoPlaceholdersAndHandlesMissingNativeValues(): void
+    {
+        $compiler = new PgSqlPdoParameterBindingCompiler();
+
+        self::assertSame(
+            ['sql' => 'SELECT ?', 'params' => [1]],
+            $compiler->compile('SELECT ?', [1]),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT $0, :__ztd_pdo_1', 'params' => ['__ztd_pdo_1' => 1]],
+            $compiler->compile('SELECT $0, $1', [1]),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT :__ztd_pdo_1', 'params' => null],
+            $compiler->compile('SELECT $1', null),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT ?, :__ztd_pdo_1', 'params' => ['__ztd_pdo_1' => 1]],
+            $compiler->compile('SELECT ?, $1', [1]),
+        );
+    }
+}

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPdoParameterBindingCompilerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPdoParameterBindingCompilerTest.php
@@ -9,15 +9,9 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlPdoParameterBindingCompiler;
 use ZtdQuery\Platform\Postgres\PgSqlPdoPlaceholderEscaper;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(PgSqlPdoParameterBindingCompiler::class)]
 #[UsesClass(PgSqlPdoPlaceholderEscaper::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class PgSqlPdoParameterBindingCompilerTest extends TestCase
 {
     public function testMapsNativePositionsAndEscapesPostgreSqlOperators(): void
@@ -56,6 +50,10 @@ final class PgSqlPdoParameterBindingCompilerTest extends TestCase
         self::assertSame(
             ['sql' => 'SELECT ?, :__ztd_pdo_1', 'params' => ['__ztd_pdo_1' => 1]],
             $compiler->compile('SELECT ?, $1', [1]),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT $$ $1 $$, :__ztd_pdo_1', 'params' => ['__ztd_pdo_1' => 1]],
+            $compiler->compile('SELECT $$ $1 $$, $1', [1]),
         );
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSessionFactoryTest.php
@@ -20,6 +20,7 @@ use ZtdQuery\Platform\Postgres\PgSqlCopySupport;
 use ZtdQuery\Platform\Postgres\PgSqlIdentifierQuoter;
 use ZtdQuery\Platform\Postgres\PgSqlMutationResolver;
 use ZtdQuery\Platform\Postgres\PgSqlParser;
+use ZtdQuery\Platform\Postgres\PgSqlPdoParameterBindingCompiler;
 use ZtdQuery\Platform\Postgres\PgSqlPdoPlaceholderEscaper;
 use ZtdQuery\Platform\Postgres\PgSqlQueryGuard;
 use ZtdQuery\Platform\Postgres\PgSqlRewriter;
@@ -48,6 +49,7 @@ use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 #[UsesClass(PgSqlSchemaReflector::class)]
 #[UsesClass(PgSqlCastRenderer::class)]
 #[UsesClass(PgSqlCopySupport::class)]
+#[UsesClass(PgSqlPdoParameterBindingCompiler::class)]
 #[UsesClass(PgSqlPdoPlaceholderEscaper::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlValueRenderer::class)]
 #[UsesClass(PgSqlIdentifierQuoter::class)]
@@ -182,7 +184,7 @@ final class PgSqlSessionFactoryTest extends TestCase
 
         self::assertInstanceOf(Session::class, $session);
         self::assertInstanceOf(PgSqlCopySupport::class, $session->copySupport());
-        self::assertInstanceOf(PgSqlPdoPlaceholderEscaper::class, $session->sqlPlaceholderEscaper());
+        self::assertInstanceOf(PgSqlPdoParameterBindingCompiler::class, $session->parameterBindingCompiler());
     }
 
     public function testCreatedSessionIsEnabledByDefault(): void

--- a/packages/ztd-query-sqlite/src/SqlitePdoParameterBindingCompiler.php
+++ b/packages/ztd-query-sqlite/src/SqlitePdoParameterBindingCompiler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\Sqlite;
+
+use ZtdQuery\Platform\ParameterBindingCompiler;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class SqlitePdoParameterBindingCompiler implements ParameterBindingCompiler
+{
+    public function __construct(
+        private readonly SqliteCastRenderer $castRenderer = new SqliteCastRenderer(),
+    ) {
+    }
+
+    public function compile(string $sql, ?array $params): array
+    {
+        if ($params === null) {
+            return ['sql' => $sql, 'params' => null];
+        }
+
+        $replacements = [];
+        $positionalIndex = 0;
+        foreach (SqlTokenStream::tokenize($sql)->tokens() as $token) {
+            if ($token->kind !== SqlTokenKind::Parameter) {
+                continue;
+            }
+            if ($token->text === '?') {
+                $parameterKey = $positionalIndex++;
+            } else {
+                $name = ltrim($token->text, ':');
+                $parameterKey = array_key_exists($name, $params) ? $name : $token->text;
+            }
+            if (!array_key_exists($parameterKey, $params)) {
+                continue;
+            }
+            $type = $this->parameterType($params[$parameterKey]);
+            if ($type !== null) {
+                $replacements[$token->offset] = [
+                    'length' => strlen($token->text),
+                    'sql' => $this->castRenderer->renderCast($token->text, $type),
+                ];
+            }
+        }
+
+        if ($replacements !== []) {
+            krsort($replacements);
+            foreach ($replacements as $offset => $replacement) {
+                $sql = substr_replace($sql, $replacement['sql'], $offset, $replacement['length']);
+            }
+        }
+
+        return ['sql' => $sql, 'params' => $params];
+    }
+
+    private function parameterType(mixed $value): ?ColumnType
+    {
+        return match (true) {
+            is_bool($value) => new ColumnType(ColumnTypeFamily::BOOLEAN, 'INTEGER'),
+            is_int($value) => new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'),
+            is_float($value) => new ColumnType(ColumnTypeFamily::DOUBLE, 'REAL'),
+            default => null,
+        };
+    }
+}

--- a/packages/ztd-query-sqlite/src/SqliteSessionFactory.php
+++ b/packages/ztd-query-sqlite/src/SqliteSessionFactory.php
@@ -61,8 +61,9 @@ final class SqliteSessionFactory implements SessionFactory
             new ResultSelectRunner(),
             $config,
             $connection,
-            new ShadowTransactionManager($shadowStore, $registry),
-            $registry,
+            transactions: new ShadowTransactionManager($shadowStore, $registry),
+            registry: $registry,
+            parameterBindingCompiler: new SqlitePdoParameterBindingCompiler(),
         );
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqlitePdoParameterBindingCompilerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqlitePdoParameterBindingCompilerTest.php
@@ -10,16 +10,9 @@ use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
 use ZtdQuery\Platform\Sqlite\SqlitePdoParameterBindingCompiler;
 use ZtdQuery\Schema\ColumnType;
-use ZtdQuery\Sql\SqlToken;
-use ZtdQuery\Sql\SqlTokenKind;
-use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(SqlitePdoParameterBindingCompiler::class)]
 #[UsesClass(SqliteCastRenderer::class)]
-#[UsesClass(ColumnType::class)]
-#[UsesClass(SqlToken::class)]
-#[UsesClass(SqlTokenKind::class)]
-#[UsesClass(SqlTokenStream::class)]
 final class SqlitePdoParameterBindingCompilerTest extends TestCase
 {
     public function testUsesSqliteRendererForStorageSensitiveParameterTypes(): void
@@ -50,6 +43,16 @@ final class SqlitePdoParameterBindingCompilerTest extends TestCase
         self::assertSame(
             ['sql' => 'SELECT :missing, CAST(:value AS INTEGER)', 'params' => ['value' => 7]],
             $compiler->compile('SELECT :missing, :value', ['value' => 7]),
+        );
+    }
+
+    public function testLeavesBoundValuesWithoutStorageSensitiveTypesUnchanged(): void
+    {
+        $params = [null, 'text', []];
+
+        self::assertSame(
+            ['sql' => 'SELECT ?, ?, ?', 'params' => $params],
+            (new SqlitePdoParameterBindingCompiler())->compile('SELECT ?, ?, ?', $params),
         );
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqlitePdoParameterBindingCompilerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqlitePdoParameterBindingCompilerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\Sqlite\SqliteCastRenderer;
+use ZtdQuery\Platform\Sqlite\SqlitePdoParameterBindingCompiler;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
+
+#[CoversClass(SqlitePdoParameterBindingCompiler::class)]
+#[UsesClass(SqliteCastRenderer::class)]
+#[UsesClass(ColumnType::class)]
+#[UsesClass(SqlToken::class)]
+#[UsesClass(SqlTokenKind::class)]
+#[UsesClass(SqlTokenStream::class)]
+final class SqlitePdoParameterBindingCompilerTest extends TestCase
+{
+    public function testUsesSqliteRendererForStorageSensitiveParameterTypes(): void
+    {
+        $compiled = (new SqlitePdoParameterBindingCompiler())->compile(
+            'SELECT ?, ?, :ratio, :integer, :enabled, \'?\', "?"',
+            [0 => 12, 1 => 2.5, 'ratio' => 2.5, ':integer' => 9, 'enabled' => true],
+        );
+
+        self::assertSame(
+            'SELECT CAST(? AS INTEGER), CAST(? AS REAL), CAST(:ratio AS REAL), CAST(:integer AS INTEGER), CAST(:enabled AS INTEGER), \'?\', "?"',
+            $compiled['sql'],
+        );
+    }
+
+    public function testLeavesNullAndUnboundParametersUnchanged(): void
+    {
+        $compiler = new SqlitePdoParameterBindingCompiler();
+
+        self::assertSame(
+            ['sql' => 'SELECT ?, :missing', 'params' => null],
+            $compiler->compile('SELECT ?, :missing', null),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT ?, :missing', 'params' => []],
+            $compiler->compile('SELECT ?, :missing', []),
+        );
+        self::assertSame(
+            ['sql' => 'SELECT :missing, CAST(:value AS INTEGER)', 'params' => ['value' => 7]],
+            $compiler->compile('SELECT :missing, :value', ['value' => 7]),
+        );
+    }
+}

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSessionFactoryTest.php
@@ -14,6 +14,7 @@ use ZtdQuery\Platform\Sqlite\SqliteInMemoryAttachStatement;
 use ZtdQuery\Platform\Sqlite\SqliteMutationResolver;
 use ZtdQuery\Platform\Sqlite\SqliteLexicalMasker;
 use ZtdQuery\Platform\Sqlite\SqliteParser;
+use ZtdQuery\Platform\Sqlite\SqlitePdoParameterBindingCompiler;
 use ZtdQuery\Platform\Sqlite\SqliteQueryGuard;
 use ZtdQuery\Platform\Sqlite\SqliteRewriter;
 use ZtdQuery\Platform\Sqlite\SqliteSchemaParser;
@@ -38,6 +39,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(SqliteMutationResolver::class)]
 #[UsesClass(SqliteParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
+#[UsesClass(SqlitePdoParameterBindingCompiler::class)]
 #[UsesClass(SqliteQueryGuard::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteReadOnlyDiagnosticStatement::class)]
 #[UsesClass(SqliteRewriter::class)]
@@ -93,6 +95,7 @@ final class SqliteSessionFactoryTest extends TestCase
         $session = $factory->create($connection, $config);
 
         self::assertInstanceOf(Session::class, $session);
+        self::assertInstanceOf(SqlitePdoParameterBindingCompiler::class, $session->parameterBindingCompiler());
     }
 
     public function testCreateWithExistingTablesRegistersDefinitions(): void


### PR DESCRIPTION
## What

Move parameter binding compilation behind dialect contracts and provide MySQL, PostgreSQL, and SQLite implementations.

## Why

PDO adapter was interpreting and rewriting dialect-specific parameter syntax.

## Verification

- Core, dialect, and PDO adapter unit suites; PHPStan and formatting.
- Final stack: 7,188 unit tests and 16,469 assertions passed.

Stack: agent/issue-zero-55-issue-43 -> agent/issue-zero-56-pdo-parameter-binding