### PR TITLE
refactor(sql-faker): delegate provider lexemes to generators

### DIFF
--- a/packages/sql-faker/src/Grammar/GenerationPlan.php
+++ b/packages/sql-faker/src/Grammar/GenerationPlan.php
@@ -13,6 +13,7 @@ final class GenerationPlan
      * @param array<string, non-empty-list<ProductionPattern>> $patterns
      * @param array<string, ProductionPattern> $patternsForEveryOccurrence
      * @param array<string, non-empty-list<non-empty-string>> $lexemes
+     * @param array<string, int> $parameters
      * @param TRequiresNonEmpty $requiresNonEmpty
      */
     private function __construct(
@@ -20,6 +21,8 @@ final class GenerationPlan
         private readonly array $patterns,
         private readonly array $patternsForEveryOccurrence,
         private readonly array $lexemes,
+        private readonly ?string $lexicalTarget,
+        private readonly array $parameters,
         private readonly bool $requiresNonEmpty,
         private readonly int $maxDepth,
     ) {
@@ -28,7 +31,7 @@ final class GenerationPlan
     /** @return self<false> */
     public static function all(): self
     {
-        return new self(null, [], [], [], false, PHP_INT_MAX);
+        return new self(null, [], [], [], null, [], false, PHP_INT_MAX);
     }
 
     /** @return self<false> */
@@ -36,7 +39,7 @@ final class GenerationPlan
     {
         self::assertStartRule($startRule);
 
-        return new self($startRule, [], [], [], false, PHP_INT_MAX);
+        return new self($startRule, [], [], [], null, [], false, PHP_INT_MAX);
     }
 
     /**
@@ -50,7 +53,20 @@ final class GenerationPlan
             throw new InvalidArgumentException('A constrained generation plan requires production patterns.');
         }
 
-        return new self($startRule, $patterns, [], [], false, PHP_INT_MAX);
+        return new self($startRule, $patterns, [], [], null, [], false, PHP_INT_MAX);
+    }
+
+    /**
+     * @param array<string, int> $parameters
+     * @return self<true>
+     */
+    public static function lexical(string $target, array $parameters): self
+    {
+        if ($target === '') {
+            throw new InvalidArgumentException('A lexical generation target must not be empty.');
+        }
+
+        return new self(null, [], [], [], $target, $parameters, true, PHP_INT_MAX);
     }
 
     /** @return self<true> */
@@ -61,6 +77,8 @@ final class GenerationPlan
             $this->patterns,
             $this->patternsForEveryOccurrence,
             $this->lexemes,
+            $this->lexicalTarget,
+            $this->parameters,
             true,
             $this->maxDepth,
         );
@@ -81,6 +99,8 @@ final class GenerationPlan
             $this->patterns,
             $this->patternsForEveryOccurrence,
             $lexemes,
+            $this->lexicalTarget,
+            $this->parameters,
             $this->requiresNonEmpty,
             $this->maxDepth,
         );
@@ -94,6 +114,8 @@ final class GenerationPlan
             $this->patterns,
             $this->patternsForEveryOccurrence,
             $this->lexemes,
+            $this->lexicalTarget,
+            $this->parameters,
             $this->requiresNonEmpty,
             max(1, $maxDepth),
         );
@@ -121,6 +143,8 @@ final class GenerationPlan
             $this->patterns,
             [...$this->patternsForEveryOccurrence, $rule => $pattern],
             $this->lexemes,
+            $this->lexicalTarget,
+            $this->parameters,
             $this->requiresNonEmpty,
             $this->maxDepth,
         );
@@ -130,6 +154,17 @@ final class GenerationPlan
     public function lexemeAt(string $terminal, int $occurrence): ?string
     {
         return $this->lexemes[$terminal][$occurrence] ?? null;
+    }
+
+    public function lexicalTarget(): ?string
+    {
+        return $this->lexicalTarget;
+    }
+
+    /** @return array<string, int> */
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 
     /** @return TRequiresNonEmpty */

--- a/packages/sql-faker/src/Grammar/LexicalGrammar.php
+++ b/packages/sql-faker/src/Grammar/LexicalGrammar.php
@@ -9,6 +9,12 @@ namespace SqlFaker\Grammar;
  */
 interface LexicalGrammar
 {
+    /**
+     * @param GenerationPlan<bool> $plan
+     * @return non-empty-string
+     */
+    public function generate(GenerationPlan $plan): string;
+
     public function version(): string;
 
     public function supports(string $terminal): bool;

--- a/packages/sql-faker/src/Grammar/RandomStringGenerator.php
+++ b/packages/sql-faker/src/Grammar/RandomStringGenerator.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace SqlFaker\Grammar;
 
 use Faker\Generator as FakerGenerator;
+use InvalidArgumentException;
+use LogicException;
 
 /**
  * Generates random strings for SQL token production.
  *
- * Shared by all SQL generators and providers to produce identifiers,
- * string literals, numeric literals, and other lexical tokens.
+ * Shared by dialect lexical grammars to produce identifiers, string literals,
+ * numeric literals, and other lexical tokens.
  */
 final class RandomStringGenerator
 {
@@ -93,6 +95,8 @@ final class RandomStringGenerator
 
     /**
      * Generate a random hostname string.
+     *
+     * @return non-empty-string
      */
     public function hostnameString(int $minParts = 1, int $maxParts = 3, int $minPartLength = 1, int $maxPartLength = 12): string
     {
@@ -102,11 +106,18 @@ final class RandomStringGenerator
             $segments[] = $this->randomString(self::HOSTNAME_CHARS, $this->faker->numberBetween($minPartLength, $maxPartLength));
         }
 
-        return implode('.', $segments);
+        $hostname = implode('.', $segments);
+        if ($hostname === '') {
+            throw new LogicException('Hostname generation produced an empty result.');
+        }
+
+        return $hostname;
     }
 
     /**
      * Generate a random unsigned big integer string.
+     *
+     * @return non-empty-string
      */
     public function unsignedBigIntString(int $minLength = 1, int $maxLength = 20): string
     {
@@ -118,6 +129,8 @@ final class RandomStringGenerator
 
     /**
      * Generate a random long integer string.
+     *
+     * @return non-empty-string
      */
     public function longIntString(int $min = 0, int $max = 2147483647): string
     {
@@ -146,6 +159,38 @@ final class RandomStringGenerator
         $val = $this->faker->numberBetween($min, $max);
 
         return "{$val}";
+    }
+
+    /**
+     * @param array<string, list<string>> $lexemesByTerminal
+     * @return non-empty-string
+     */
+    public function lexicalSequence(array $lexemesByTerminal, int $minTerms = 2, int $maxTerms = 4): string
+    {
+        if ($minTerms < 1 || $maxTerms < $minTerms) {
+            throw new InvalidArgumentException('Lexical sequence bounds must be positive and ordered.');
+        }
+        $lexemeSets = array_values(array_filter(
+            $lexemesByTerminal,
+            static fn (array $lexemes): bool => $lexemes !== [],
+        ));
+        if ($lexemeSets === []) {
+            throw new InvalidArgumentException('A lexical sequence requires at least one terminal lexeme.');
+        }
+
+        $terms = $this->faker->numberBetween($minTerms, $maxTerms);
+        $lexemes = [];
+        for ($index = 0; $index < $terms; $index++) {
+            $set = $lexemeSets[$this->faker->numberBetween(0, count($lexemeSets) - 1)];
+            $lexemes[] = $set[$this->faker->numberBetween(0, count($set) - 1)];
+        }
+
+        $sequence = implode(' ', $lexemes);
+        if ($sequence === '') {
+            throw new LogicException('The lexical catalog produced an empty sequence.');
+        }
+
+        return $sequence;
     }
 
     /**

--- a/packages/sql-faker/src/MySql/GenerationPlans.php
+++ b/packages/sql-faker/src/MySql/GenerationPlans.php
@@ -23,6 +23,91 @@ final class GenerationPlans
     }
 
     /** @return GenerationPlan<true> */
+    public static function quotedIdentifier(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('quoted_identifier', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function stringLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('string_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function nationalStringLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('national_string_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function dollarQuotedString(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('dollar_quoted_string', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function integerLiteral(int $min, int $max): GenerationPlan
+    {
+        return GenerationPlan::lexical('integer_literal', compact('min', 'max'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function longIntegerLiteral(int $min, int $max): GenerationPlan
+    {
+        return GenerationPlan::lexical('long_integer_literal', compact('min', 'max'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function unsignedBigIntLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('unsigned_big_int_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function decimalLiteral(int $precision, int $scale): GenerationPlan
+    {
+        return GenerationPlan::lexical('decimal_literal', compact('precision', 'scale'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function floatLiteral(
+        int $precision,
+        int $scale,
+        int $minExponent,
+        int $maxExponent,
+    ): GenerationPlan {
+        return GenerationPlan::lexical(
+            'float_literal',
+            compact('precision', 'scale', 'minExponent', 'maxExponent'),
+        );
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function hexLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('hex_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function quotedHexLiteral(int $minBytes, int $maxBytes): GenerationPlan
+    {
+        return GenerationPlan::lexical('quoted_hex_literal', compact('minBytes', 'maxBytes'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function binaryLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('binary_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function hostname(int $minParts, int $maxParts, int $maxPartLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('hostname', compact('minParts', 'maxParts', 'maxPartLength'));
+    }
+
+    /** @return GenerationPlan<true> */
     public static function foreignKeyConstraint(Grammar $grammar): GenerationPlan
     {
         $startRule = isset($grammar->ruleMap['table_constraint_def'])

--- a/packages/sql-faker/src/MySql/LexicalGrammar.php
+++ b/packages/sql-faker/src/MySql/LexicalGrammar.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SqlFaker\MySql;
 
 use Faker\Generator as FakerGenerator;
+use InvalidArgumentException;
 use RuntimeException;
 use SqlFaker\Grammar\LexicalCatalog;
 use SqlFaker\Grammar\LexicalException;
@@ -113,6 +114,94 @@ final class LexicalGrammar implements LexicalGrammarContract
         }
 
         return $sql;
+    }
+
+    /** @return non-empty-string */
+    public function generateQuotedIdentifier(int $minLength = 1, int $maxLength = 64): string
+    {
+        return '`' . $this->strings->rawIdentifier($minLength, $maxLength) . '`';
+    }
+
+    /** @return non-empty-string */
+    public function generateStringLiteral(int $minLength = 1, int $maxLength = 255): string
+    {
+        return "'" . $this->strings->mixedAlnumString($minLength, $maxLength) . "'";
+    }
+
+    /** @return non-empty-string */
+    public function generateNationalStringLiteral(int $minLength = 1, int $maxLength = 255): string
+    {
+        return 'N' . $this->generateStringLiteral($minLength, $maxLength);
+    }
+
+    /** @return non-empty-string */
+    public function generateDollarQuotedString(int $minLength = 1, int $maxLength = 255): string
+    {
+        return '$$' . $this->strings->mixedAlnumString($minLength, $maxLength) . '$$';
+    }
+
+    /** @return non-empty-string */
+    public function generateIntegerLiteral(int $min = 1, int $max = 2147483647): string
+    {
+        return $this->strings->integerString($min, $max);
+    }
+
+    /** @return non-empty-string */
+    public function generateLongIntegerLiteral(int $min = 0, int $max = 2147483647): string
+    {
+        return $this->strings->longIntString($min, $max);
+    }
+
+    /** @return non-empty-string */
+    public function generateUnsignedBigIntLiteral(int $minLength = 1, int $maxLength = 20): string
+    {
+        return $this->strings->unsignedBigIntString($minLength, $maxLength);
+    }
+
+    /** @return non-empty-string */
+    public function generateDecimalLiteral(int $precision = 10, int $scale = 2): string
+    {
+        return $this->strings->decimalString($precision, $scale);
+    }
+
+    /** @return non-empty-string */
+    public function generateFloatLiteral(
+        int $precision = 10,
+        int $scale = 2,
+        int $minExponent = -38,
+        int $maxExponent = 38,
+    ): string {
+        return $this->strings->floatString(
+            $this->generateDecimalLiteral($precision, $scale),
+            $minExponent,
+            $maxExponent,
+        );
+    }
+
+    /** @return non-empty-string */
+    public function generateHexLiteral(int $minLength = 1, int $maxLength = 16): string
+    {
+        return '0x' . $this->strings->hexString($minLength, $maxLength);
+    }
+
+    /** @return non-empty-string */
+    public function generateQuotedHexLiteral(int $minBytes = 1, int $maxBytes = 8): string
+    {
+        $bytes = $this->faker->numberBetween($minBytes, $maxBytes);
+
+        return "X'" . $this->strings->hexString($bytes * 2, $bytes * 2) . "'";
+    }
+
+    /** @return non-empty-string */
+    public function generateBinaryLiteral(int $minLength = 1, int $maxLength = 64): string
+    {
+        return '0b' . $this->strings->binaryString($minLength, $maxLength);
+    }
+
+    /** @return non-empty-string */
+    public function generateHostname(int $minParts = 1, int $maxParts = 4, int $maxPartLength = 63): string
+    {
+        return $this->strings->hostnameString($minParts, $maxParts, 1, $maxPartLength);
     }
 
     /**
@@ -352,8 +441,7 @@ final class LexicalGrammar implements LexicalGrammarContract
     private function stringLiteral(): string
     {
         $body = match ($this->faker->numberBetween(0, 6)) {
-            0 => 'SELECT FROM WHERE',
-            1 => '/* UPDATE */ -- DELETE',
+            0, 1 => $this->strings->lexicalSequence($this->symbols + $this->functions),
             2 => "a'b",
             3 => 'a\\b',
             default => $this->strings->mixedAlnumString(0, 24),
@@ -364,7 +452,7 @@ final class LexicalGrammar implements LexicalGrammarContract
 
     private function dollarQuotedString(): string
     {
-        return '$$' . str_replace('$$', '$', $this->strings->mixedAlnumString(0, 24)) . '$$';
+        return '$$' . $this->strings->mixedAlnumString(0, 24) . '$$';
     }
 
     private function hexadecimalLiteral(): string
@@ -514,5 +602,41 @@ final class LexicalGrammar implements LexicalGrammarContract
             json_encode($actual, JSON_THROW_ON_ERROR),
             $sql,
         );
+    }
+
+    /**
+     * @param GenerationPlan<bool> $plan
+     * @return non-empty-string
+     */
+    public function generate(GenerationPlan $plan): string
+    {
+        $target = $plan->lexicalTarget();
+        $parameters = $plan->parameters();
+
+        return match ($target) {
+            'quoted_identifier' => $this->generateQuotedIdentifier($parameters['minLength'], $parameters['maxLength']),
+            'string_literal' => $this->generateStringLiteral($parameters['minLength'], $parameters['maxLength']),
+            'national_string_literal' => $this->generateNationalStringLiteral($parameters['minLength'], $parameters['maxLength']),
+            'dollar_quoted_string' => $this->generateDollarQuotedString($parameters['minLength'], $parameters['maxLength']),
+            'integer_literal' => $this->generateIntegerLiteral($parameters['min'], $parameters['max']),
+            'long_integer_literal' => $this->generateLongIntegerLiteral($parameters['min'], $parameters['max']),
+            'unsigned_big_int_literal' => $this->generateUnsignedBigIntLiteral($parameters['minLength'], $parameters['maxLength']),
+            'decimal_literal' => $this->generateDecimalLiteral($parameters['precision'], $parameters['scale']),
+            'float_literal' => $this->generateFloatLiteral(
+                $parameters['precision'],
+                $parameters['scale'],
+                $parameters['minExponent'],
+                $parameters['maxExponent'],
+            ),
+            'hex_literal' => $this->generateHexLiteral($parameters['minLength'], $parameters['maxLength']),
+            'quoted_hex_literal' => $this->generateQuotedHexLiteral($parameters['minBytes'], $parameters['maxBytes']),
+            'binary_literal' => $this->generateBinaryLiteral($parameters['minLength'], $parameters['maxLength']),
+            'hostname' => $this->generateHostname(
+                $parameters['minParts'],
+                $parameters['maxParts'],
+                $parameters['maxPartLength'],
+            ),
+            default => throw new InvalidArgumentException("Unknown MySQL lexical generation target: {$target}"),
+        };
     }
 }

--- a/packages/sql-faker/src/MySql/SqlGenerator.php
+++ b/packages/sql-faker/src/MySql/SqlGenerator.php
@@ -15,7 +15,6 @@ use SqlFaker\MySql\Grammar\Symbol;
 use SqlFaker\MySql\Grammar\Terminal;
 use SqlFaker\MySql\Grammar\TerminalInventory;
 use SqlFaker\MySql\Grammar\TerminationAnalyzer;
-use SqlFaker\MySqlProvider;
 
 /**
  * Derives MySQL parser terminals and realizes them through the versioned lexer model.
@@ -29,16 +28,13 @@ final class SqlGenerator
     private FakerGenerator $faker;
     private LexicalGrammar $lexicalGrammar;
     private TerminationAnalyzer $terminationAnalyzer;
-    private int $targetDepth = PHP_INT_MAX;
     private int $derivationSteps = 0;
 
     public function __construct(
         Grammar $grammar,
         FakerGenerator $faker,
-        MySqlProvider $provider,
         ?string $version = null,
     ) {
-        unset($provider);
         $this->grammar = $grammar;
         $this->faker = $faker;
         $this->lexicalGrammar = new LexicalGrammar(
@@ -59,7 +55,9 @@ final class SqlGenerator
      */
     public function generate(GenerationPlan $plan): string
     {
-        $this->targetDepth = $plan->maxDepth();
+        if ($plan->lexicalTarget() !== null) {
+            return $this->lexicalGrammar->generate($plan);
+        }
         $startSymbol = $this->resolveStartSymbol($plan->startRule());
         $lastException = null;
         for ($attempt = 0; $attempt < self::LEXICAL_ATTEMPT_LIMIT; $attempt++) {
@@ -247,7 +245,7 @@ final class SqlGenerator
                 }
             }
 
-            $production = $this->selectProduction($alternatives);
+            $production = $this->selectProduction($alternatives, $plan);
             $form = [
                 ...array_slice($form, 0, $index),
                 ...$production->symbols,
@@ -275,10 +273,11 @@ final class SqlGenerator
 
     /**
      * @param non-empty-array<int, Production> $alternatives
+     * @param GenerationPlan<bool> $plan
      */
-    private function selectProduction(array $alternatives): Production
+    private function selectProduction(array $alternatives, GenerationPlan $plan): Production
     {
-        if ($this->derivationSteps < $this->targetDepth) {
+        if ($this->derivationSteps < $plan->maxDepth()) {
             $keys = array_keys($alternatives);
 
             return $alternatives[$keys[$this->faker->numberBetween(0, count($keys) - 1)]];

--- a/packages/sql-faker/src/MySqlProvider.php
+++ b/packages/sql-faker/src/MySqlProvider.php
@@ -7,7 +7,6 @@ namespace SqlFaker;
 use Faker\Generator;
 use Faker\Provider\Base;
 use SqlFaker\Grammar\GenerationPlan;
-use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\MySql\GenerationPlans;
 use SqlFaker\MySql\Grammar\Grammar;
 use SqlFaker\MySql\SqlGenerator;
@@ -55,7 +54,6 @@ final class MySqlProvider extends Base
 {
     private Grammar $grammar;
     private SqlGenerator $sql;
-    private RandomStringGenerator $rsg;
 
     /**
      * @param Generator $generator Faker generator
@@ -69,8 +67,7 @@ final class MySqlProvider extends Base
 
         $resolvedVersion = Grammar::resolveVersion($version);
         $this->grammar = Grammar::load($resolvedVersion);
-        $this->rsg = new RandomStringGenerator($generator);
-        $this->sql = new SqlGenerator($this->grammar, $generator, $this, $resolvedVersion);
+        $this->sql = new SqlGenerator($this->grammar, $generator, $resolvedVersion);
     }
 
     /**
@@ -256,7 +253,7 @@ final class MySqlProvider extends Base
      */
     public function quotedIdentifier(int $minLength = 1, int $maxLength = 64): string
     {
-        return '`' . $this->rsg->rawIdentifier($minLength, $maxLength) . '`';
+        return $this->sql->generate(GenerationPlans::quotedIdentifier($minLength, $maxLength));
     }
 
     /**
@@ -268,7 +265,7 @@ final class MySqlProvider extends Base
      */
     public function stringLiteral(int $minLength = 1, int $maxLength = 255): string
     {
-        return "'" . $this->rsg->mixedAlnumString($minLength, $maxLength) . "'";
+        return $this->sql->generate(GenerationPlans::stringLiteral($minLength, $maxLength));
     }
 
     /**
@@ -280,7 +277,7 @@ final class MySqlProvider extends Base
      */
     public function nationalStringLiteral(int $minLength = 1, int $maxLength = 255): string
     {
-        return 'N' . $this->stringLiteral($minLength, $maxLength);
+        return $this->sql->generate(GenerationPlans::nationalStringLiteral($minLength, $maxLength));
     }
 
     /**
@@ -292,7 +289,7 @@ final class MySqlProvider extends Base
      */
     public function dollarQuotedString(int $minLength = 1, int $maxLength = 255): string
     {
-        return '$$' . $this->rsg->mixedAlnumString($minLength, $maxLength) . '$$';
+        return $this->sql->generate(GenerationPlans::dollarQuotedString($minLength, $maxLength));
     }
 
     /**
@@ -304,7 +301,7 @@ final class MySqlProvider extends Base
      */
     public function integerLiteral(int $min = 1, int $max = 2147483647): string
     {
-        return $this->rsg->integerString($min, $max);
+        return $this->sql->generate(GenerationPlans::integerLiteral($min, $max));
     }
 
     /**
@@ -316,7 +313,7 @@ final class MySqlProvider extends Base
      */
     public function longIntegerLiteral(int $min = 0, int $max = 2147483647): string
     {
-        return $this->rsg->longIntString($min, $max);
+        return $this->sql->generate(GenerationPlans::longIntegerLiteral($min, $max));
     }
 
     /**
@@ -328,7 +325,7 @@ final class MySqlProvider extends Base
      */
     public function unsignedBigIntLiteral(int $minLength = 1, int $maxLength = 20): string
     {
-        return $this->rsg->unsignedBigIntString($minLength, $maxLength);
+        return $this->sql->generate(GenerationPlans::unsignedBigIntLiteral($minLength, $maxLength));
     }
 
     /**
@@ -340,7 +337,7 @@ final class MySqlProvider extends Base
      */
     public function decimalLiteral(int $precision = 10, int $scale = 2): string
     {
-        return $this->rsg->decimalString($precision, $scale);
+        return $this->sql->generate(GenerationPlans::decimalLiteral($precision, $scale));
     }
 
     /**
@@ -352,7 +349,9 @@ final class MySqlProvider extends Base
      */
     public function floatLiteral(int $precision = 10, int $scale = 2, int $minExponent = -38, int $maxExponent = 38): string
     {
-        return $this->rsg->floatString($this->decimalLiteral($precision, $scale), $minExponent, $maxExponent);
+        return $this->sql->generate(
+            GenerationPlans::floatLiteral($precision, $scale, $minExponent, $maxExponent),
+        );
     }
 
     /**
@@ -364,7 +363,7 @@ final class MySqlProvider extends Base
      */
     public function hexLiteral(int $minLength = 1, int $maxLength = 16): string
     {
-        return '0x' . $this->rsg->hexString($minLength, $maxLength);
+        return $this->sql->generate(GenerationPlans::hexLiteral($minLength, $maxLength));
     }
 
     /**
@@ -376,9 +375,7 @@ final class MySqlProvider extends Base
      */
     public function quotedHexLiteral(int $minBytes = 1, int $maxBytes = 8): string
     {
-        $bytes = $this->generator->numberBetween($minBytes, $maxBytes);
-
-        return "X'" . $this->rsg->hexString($bytes * 2, $bytes * 2) . "'";
+        return $this->sql->generate(GenerationPlans::quotedHexLiteral($minBytes, $maxBytes));
     }
 
     /**
@@ -390,7 +387,7 @@ final class MySqlProvider extends Base
      */
     public function binaryLiteral(int $minLength = 1, int $maxLength = 64): string
     {
-        return '0b' . $this->rsg->binaryString($minLength, $maxLength);
+        return $this->sql->generate(GenerationPlans::binaryLiteral($minLength, $maxLength));
     }
 
     /**
@@ -402,7 +399,7 @@ final class MySqlProvider extends Base
      */
     public function hostname(int $minParts = 1, int $maxParts = 4, int $maxPartLength = 63): string
     {
-        return $this->rsg->hostnameString($minParts, $maxParts, 1, $maxPartLength);
+        return $this->sql->generate(GenerationPlans::hostname($minParts, $maxParts, $maxPartLength));
     }
 
     /**

--- a/packages/sql-faker/src/PostgreSql/GenerationPlans.php
+++ b/packages/sql-faker/src/PostgreSql/GenerationPlans.php
@@ -10,6 +10,67 @@ use SqlFaker\Grammar\ProductionPattern;
 final class GenerationPlans
 {
     /** @return GenerationPlan<true> */
+    public static function quotedIdentifier(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('quoted_identifier', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function stringLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('string_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function integerLiteral(int $min, int $max): GenerationPlan
+    {
+        return GenerationPlan::lexical('integer_literal', compact('min', 'max'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function decimalLiteral(int $precision, int $scale): GenerationPlan
+    {
+        return GenerationPlan::lexical('decimal_literal', compact('precision', 'scale'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function floatLiteral(
+        int $precision,
+        int $scale,
+        int $minExponent,
+        int $maxExponent,
+    ): GenerationPlan {
+        return GenerationPlan::lexical(
+            'float_literal',
+            compact('precision', 'scale', 'minExponent', 'maxExponent'),
+        );
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function hexLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('hex_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function binaryLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('binary_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function dollarQuotedString(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('dollar_quoted_string', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function parameterMarker(int $min, int $max): GenerationPlan
+    {
+        return GenerationPlan::lexical('parameter_marker', compact('min', 'max'));
+    }
+
+    /** @return GenerationPlan<true> */
     public static function insertFunctionUpsertStatement(): GenerationPlan
     {
         return GenerationPlan::constrained('InsertStmt', [

--- a/packages/sql-faker/src/PostgreSql/LexicalGrammar.php
+++ b/packages/sql-faker/src/PostgreSql/LexicalGrammar.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SqlFaker\PostgreSql;
 
 use Faker\Generator as FakerGenerator;
+use InvalidArgumentException;
 use RuntimeException;
 use SqlFaker\Grammar\LexicalCatalog;
 use SqlFaker\Grammar\LexicalException;
@@ -109,6 +110,68 @@ final class LexicalGrammar implements LexicalGrammarContract
         }
 
         return $sql;
+    }
+
+    /** @return non-empty-string */
+    public function generateQuotedIdentifier(int $minLength = 1, int $maxLength = 63): string
+    {
+        return '"' . $this->strings->rawIdentifier($minLength, $maxLength) . '"';
+    }
+
+    /** @return non-empty-string */
+    public function generateStringLiteral(int $minLength = 1, int $maxLength = 255): string
+    {
+        return "'" . $this->strings->mixedAlnumString($minLength, $maxLength) . "'";
+    }
+
+    /** @return non-empty-string */
+    public function generateIntegerLiteral(int $min = 1, int $max = 2147483647): string
+    {
+        return $this->strings->integerString($min, $max);
+    }
+
+    /** @return non-empty-string */
+    public function generateDecimalLiteral(int $precision = 10, int $scale = 2): string
+    {
+        return $this->strings->decimalString($precision, $scale);
+    }
+
+    /** @return non-empty-string */
+    public function generateFloatLiteral(
+        int $precision = 10,
+        int $scale = 2,
+        int $minExponent = -307,
+        int $maxExponent = 308,
+    ): string {
+        return $this->strings->floatString(
+            $this->generateDecimalLiteral($precision, $scale),
+            $minExponent,
+            $maxExponent,
+        );
+    }
+
+    /** @return non-empty-string */
+    public function generateHexLiteral(int $minLength = 1, int $maxLength = 16): string
+    {
+        return "X'" . $this->strings->hexString($minLength, $maxLength) . "'";
+    }
+
+    /** @return non-empty-string */
+    public function generateBinaryLiteral(int $minLength = 1, int $maxLength = 64): string
+    {
+        return "B'" . $this->strings->binaryString($minLength, $maxLength) . "'";
+    }
+
+    /** @return non-empty-string */
+    public function generateDollarQuotedString(int $minLength = 1, int $maxLength = 255): string
+    {
+        return '$$' . $this->strings->mixedAlnumString($minLength, $maxLength) . '$$';
+    }
+
+    /** @return non-empty-string */
+    public function generateParameterMarker(int $min = 1, int $max = 99): string
+    {
+        return '$' . $this->strings->parameterIndex($min, $max);
     }
 
     /**
@@ -364,8 +427,7 @@ final class LexicalGrammar implements LexicalGrammarContract
     private function standardStringLiteral(): string
     {
         $body = match ($this->faker->numberBetween(0, 4)) {
-            0 => 'SELECT FROM WHERE',
-            1 => '/* UPDATE */ -- DELETE',
+            0, 1 => $this->strings->lexicalSequence($this->keywords),
             2 => "a'b",
             default => $this->strings->mixedAlnumString(0, 24),
         };
@@ -377,7 +439,9 @@ final class LexicalGrammar implements LexicalGrammarContract
     {
         $tag = $this->faker->numberBetween(0, 1) === 0 ? '' : $this->strings->rawIdentifier(1, 8);
         $delimiter = '$' . $tag . '$';
-        $body = str_replace($delimiter, '$', 'SELECT ? FROM /* UPDATE */ ' . $this->strings->mixedAlnumString(0, 12));
+        $body = $this->strings->lexicalSequence($this->keywords)
+            . ' ? '
+            . $this->strings->mixedAlnumString(0, 12);
 
         return $delimiter . $body . $delimiter;
     }
@@ -577,5 +641,33 @@ final class LexicalGrammar implements LexicalGrammarContract
             json_encode($actual, JSON_THROW_ON_ERROR),
             $sql,
         );
+    }
+
+    /**
+     * @param GenerationPlan<bool> $plan
+     * @return non-empty-string
+     */
+    public function generate(GenerationPlan $plan): string
+    {
+        $target = $plan->lexicalTarget();
+        $parameters = $plan->parameters();
+
+        return match ($target) {
+            'quoted_identifier' => $this->generateQuotedIdentifier($parameters['minLength'], $parameters['maxLength']),
+            'string_literal' => $this->generateStringLiteral($parameters['minLength'], $parameters['maxLength']),
+            'integer_literal' => $this->generateIntegerLiteral($parameters['min'], $parameters['max']),
+            'decimal_literal' => $this->generateDecimalLiteral($parameters['precision'], $parameters['scale']),
+            'float_literal' => $this->generateFloatLiteral(
+                $parameters['precision'],
+                $parameters['scale'],
+                $parameters['minExponent'],
+                $parameters['maxExponent'],
+            ),
+            'hex_literal' => $this->generateHexLiteral($parameters['minLength'], $parameters['maxLength']),
+            'binary_literal' => $this->generateBinaryLiteral($parameters['minLength'], $parameters['maxLength']),
+            'dollar_quoted_string' => $this->generateDollarQuotedString($parameters['minLength'], $parameters['maxLength']),
+            'parameter_marker' => $this->generateParameterMarker($parameters['min'], $parameters['max']),
+            default => throw new InvalidArgumentException("Unknown PostgreSQL lexical generation target: {$target}"),
+        };
     }
 }

--- a/packages/sql-faker/src/PostgreSql/SqlGenerator.php
+++ b/packages/sql-faker/src/PostgreSql/SqlGenerator.php
@@ -16,7 +16,6 @@ use SqlFaker\Grammar\Terminal;
 use SqlFaker\Grammar\TerminalInventory;
 use SqlFaker\Grammar\TerminationAnalyzer;
 use SqlFaker\PostgreSql\Grammar\PgGrammar;
-use SqlFaker\PostgreSqlProvider;
 
 /**
  * Derives PostgreSQL parser terminals and realizes them through the versioned lexer model.
@@ -30,16 +29,13 @@ final class SqlGenerator
     private FakerGenerator $faker;
     private LexicalGrammar $lexicalGrammar;
     private TerminationAnalyzer $terminationAnalyzer;
-    private int $targetDepth = PHP_INT_MAX;
     private int $derivationSteps = 0;
 
     public function __construct(
         Grammar $grammar,
         FakerGenerator $faker,
-        PostgreSqlProvider $provider,
         ?string $version = null,
     ) {
-        unset($provider);
         $this->grammar = $grammar;
         $this->faker = $faker;
         $this->lexicalGrammar = new LexicalGrammar(
@@ -60,7 +56,9 @@ final class SqlGenerator
      */
     public function generate(GenerationPlan $plan): string
     {
-        $this->targetDepth = $plan->maxDepth();
+        if ($plan->lexicalTarget() !== null) {
+            return $this->lexicalGrammar->generate($plan);
+        }
         $lastException = null;
         for ($attempt = 0; $attempt < self::LEXICAL_ATTEMPT_LIMIT; $attempt++) {
             $this->derivationSteps = 0;
@@ -262,7 +260,7 @@ final class SqlGenerator
                 }
             }
 
-            $production = $this->selectProduction($alternatives);
+            $production = $this->selectProduction($alternatives, $plan);
             $form = [
                 ...array_slice($form, 0, $index),
                 ...$production->symbols,
@@ -290,10 +288,11 @@ final class SqlGenerator
 
     /**
      * @param non-empty-array<int, Production> $alternatives
+     * @param GenerationPlan<bool> $plan
      */
-    private function selectProduction(array $alternatives): Production
+    private function selectProduction(array $alternatives, GenerationPlan $plan): Production
     {
-        if ($this->derivationSteps < $this->targetDepth) {
+        if ($this->derivationSteps < $plan->maxDepth()) {
             $keys = array_keys($alternatives);
 
             return $alternatives[$keys[$this->faker->numberBetween(0, count($keys) - 1)]];

--- a/packages/sql-faker/src/PostgreSqlProvider.php
+++ b/packages/sql-faker/src/PostgreSqlProvider.php
@@ -7,7 +7,6 @@ namespace SqlFaker;
 use Faker\Generator;
 use Faker\Provider\Base;
 use SqlFaker\Grammar\GenerationPlan;
-use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\PostgreSql\Grammar\PgGrammar;
 use SqlFaker\PostgreSql\GenerationPlans;
 use SqlFaker\PostgreSql\SqlGenerator;
@@ -34,7 +33,6 @@ use SqlFaker\PostgreSql\StatementType;
 final class PostgreSqlProvider extends Base
 {
     private SqlGenerator $sql;
-    private RandomStringGenerator $rsg;
 
     /**
      * @param Generator $generator Faker generator
@@ -47,8 +45,7 @@ final class PostgreSqlProvider extends Base
         $generator->addProvider($this);
 
         $resolvedVersion = PgGrammar::resolveVersion($version);
-        $this->rsg = new RandomStringGenerator($generator);
-        $this->sql = new SqlGenerator(PgGrammar::load($resolvedVersion), $generator, $this, $resolvedVersion);
+        $this->sql = new SqlGenerator(PgGrammar::load($resolvedVersion), $generator, $resolvedVersion);
     }
 
     /**
@@ -347,7 +344,7 @@ final class PostgreSqlProvider extends Base
      */
     public function quotedIdentifier(int $minLength = 1, int $maxLength = 63): string
     {
-        return '"' . $this->rsg->rawIdentifier($minLength, $maxLength) . '"';
+        return $this->sql->generate(GenerationPlans::quotedIdentifier($minLength, $maxLength));
     }
 
     /**
@@ -357,7 +354,7 @@ final class PostgreSqlProvider extends Base
      */
     public function stringLiteral(int $minLength = 1, int $maxLength = 255): string
     {
-        return "'" . $this->rsg->mixedAlnumString($minLength, $maxLength) . "'";
+        return $this->sql->generate(GenerationPlans::stringLiteral($minLength, $maxLength));
     }
 
     /**
@@ -367,7 +364,7 @@ final class PostgreSqlProvider extends Base
      */
     public function integerLiteral(int $min = 1, int $max = 2147483647): string
     {
-        return $this->rsg->integerString($min, $max);
+        return $this->sql->generate(GenerationPlans::integerLiteral($min, $max));
     }
 
     /**
@@ -377,7 +374,7 @@ final class PostgreSqlProvider extends Base
      */
     public function decimalLiteral(int $precision = 10, int $scale = 2): string
     {
-        return $this->rsg->decimalString($precision, $scale);
+        return $this->sql->generate(GenerationPlans::decimalLiteral($precision, $scale));
     }
 
     /**
@@ -387,7 +384,9 @@ final class PostgreSqlProvider extends Base
      */
     public function floatLiteral(int $precision = 10, int $scale = 2, int $minExponent = -307, int $maxExponent = 308): string
     {
-        return $this->rsg->floatString($this->decimalLiteral($precision, $scale), $minExponent, $maxExponent);
+        return $this->sql->generate(
+            GenerationPlans::floatLiteral($precision, $scale, $minExponent, $maxExponent),
+        );
     }
 
     /**
@@ -397,7 +396,7 @@ final class PostgreSqlProvider extends Base
      */
     public function hexLiteral(int $minLength = 1, int $maxLength = 16): string
     {
-        return "X'" . $this->rsg->hexString($minLength, $maxLength) . "'";
+        return $this->sql->generate(GenerationPlans::hexLiteral($minLength, $maxLength));
     }
 
     /**
@@ -407,7 +406,7 @@ final class PostgreSqlProvider extends Base
      */
     public function binaryLiteral(int $minLength = 1, int $maxLength = 64): string
     {
-        return "B'" . $this->rsg->binaryString($minLength, $maxLength) . "'";
+        return $this->sql->generate(GenerationPlans::binaryLiteral($minLength, $maxLength));
     }
 
     /**
@@ -417,7 +416,7 @@ final class PostgreSqlProvider extends Base
      */
     public function dollarQuotedString(int $minLength = 1, int $maxLength = 255): string
     {
-        return '$$' . $this->rsg->mixedAlnumString($minLength, $maxLength) . '$$';
+        return $this->sql->generate(GenerationPlans::dollarQuotedString($minLength, $maxLength));
     }
 
     /**
@@ -427,7 +426,7 @@ final class PostgreSqlProvider extends Base
      */
     public function parameterMarker(int $min = 1, int $max = 99): string
     {
-        return '$' . $this->rsg->parameterIndex($min, $max);
+        return $this->sql->generate(GenerationPlans::parameterMarker($min, $max));
     }
 
     /** @return non-empty-string */

--- a/packages/sql-faker/src/Sqlite/GenerationPlans.php
+++ b/packages/sql-faker/src/Sqlite/GenerationPlans.php
@@ -11,6 +11,30 @@ use SqlFaker\Grammar\ProductionPattern;
 final class GenerationPlans
 {
     /** @return GenerationPlan<true> */
+    public static function quotedIdentifier(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('quoted_identifier', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function stringLiteral(int $minLength, int $maxLength): GenerationPlan
+    {
+        return GenerationPlan::lexical('string_literal', compact('minLength', 'maxLength'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function integerLiteral(int $min, int $max): GenerationPlan
+    {
+        return GenerationPlan::lexical('integer_literal', compact('min', 'max'));
+    }
+
+    /** @return GenerationPlan<true> */
+    public static function decimalLiteral(int $precision, int $scale): GenerationPlan
+    {
+        return GenerationPlan::lexical('decimal_literal', compact('precision', 'scale'));
+    }
+
+    /** @return GenerationPlan<true> */
     public static function multiDmlStatement(int $firstChoice, int $secondChoice): GenerationPlan
     {
         $dml = [

--- a/packages/sql-faker/src/Sqlite/LexicalGrammar.php
+++ b/packages/sql-faker/src/Sqlite/LexicalGrammar.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SqlFaker\Sqlite;
 
 use Faker\Generator as FakerGenerator;
+use InvalidArgumentException;
 use RuntimeException;
 use SqlFaker\Grammar\LexicalCatalog;
 use SqlFaker\Grammar\LexicalException;
@@ -112,6 +113,30 @@ final class LexicalGrammar implements LexicalGrammarContract
         }
 
         return $sql;
+    }
+
+    /** @return non-empty-string */
+    public function generateQuotedIdentifier(int $minLength = 1, int $maxLength = 128): string
+    {
+        return '"' . $this->strings->rawIdentifier($minLength, $maxLength) . '"';
+    }
+
+    /** @return non-empty-string */
+    public function generateStringLiteral(int $minLength = 1, int $maxLength = 255): string
+    {
+        return "'" . $this->strings->mixedAlnumString($minLength, $maxLength) . "'";
+    }
+
+    /** @return non-empty-string */
+    public function generateIntegerLiteral(int $min = 1, int $max = PHP_INT_MAX): string
+    {
+        return $this->strings->integerString($min, $max);
+    }
+
+    /** @return non-empty-string */
+    public function generateDecimalLiteral(int $precision = 15, int $scale = 2): string
+    {
+        return $this->strings->decimalString($precision, $scale);
     }
 
     /**
@@ -293,7 +318,7 @@ final class LexicalGrammar implements LexicalGrammarContract
         return match ($this->faker->numberBetween(0, 7)) {
             0 => '"' . str_replace('"', '""', $body . '"quoted') . '"',
             1 => '`' . str_replace('`', '``', $body . '`quoted') . '`',
-            2 => '[' . str_replace(']', '', $body) . ']',
+            2 => '[' . str_replace(']', '', $body . ']quoted') . ']',
             default => $body,
         };
     }
@@ -301,8 +326,7 @@ final class LexicalGrammar implements LexicalGrammarContract
     private function stringLiteral(): string
     {
         $body = match ($this->faker->numberBetween(0, 5)) {
-            0 => 'SELECT FROM WHERE',
-            1 => '/* UPDATE */ -- DELETE',
+            0, 1 => $this->strings->lexicalSequence($this->keywords),
             2 => "a'b",
             3 => 'a\\b',
             default => $this->strings->mixedAlnumString(0, 24),
@@ -478,5 +502,23 @@ final class LexicalGrammar implements LexicalGrammarContract
         }
 
         return $normalized;
+    }
+
+    /**
+     * @param GenerationPlan<bool> $plan
+     * @return non-empty-string
+     */
+    public function generate(GenerationPlan $plan): string
+    {
+        $target = $plan->lexicalTarget();
+        $parameters = $plan->parameters();
+
+        return match ($target) {
+            'quoted_identifier' => $this->generateQuotedIdentifier($parameters['minLength'], $parameters['maxLength']),
+            'string_literal' => $this->generateStringLiteral($parameters['minLength'], $parameters['maxLength']),
+            'integer_literal' => $this->generateIntegerLiteral($parameters['min'], $parameters['max']),
+            'decimal_literal' => $this->generateDecimalLiteral($parameters['precision'], $parameters['scale']),
+            default => throw new InvalidArgumentException("Unknown SQLite lexical generation target: {$target}"),
+        };
     }
 }

--- a/packages/sql-faker/src/Sqlite/SqlGenerator.php
+++ b/packages/sql-faker/src/Sqlite/SqlGenerator.php
@@ -17,7 +17,6 @@ use SqlFaker\Grammar\Terminal;
 use SqlFaker\Grammar\TerminalInventory;
 use SqlFaker\Grammar\TerminationAnalyzer;
 use SqlFaker\Sqlite\Grammar\SqliteGrammar;
-use SqlFaker\SqliteProvider;
 
 /**
  * Grammar-driven SQL generator for SQLite.
@@ -37,16 +36,13 @@ final class SqlGenerator
     private LexicalGrammar $lexicalGrammar;
     private TerminationAnalyzer $terminationAnalyzer;
 
-    private int $targetDepth = PHP_INT_MAX;
     private int $derivationSteps = 0;
 
     public function __construct(
         Grammar $grammar,
         FakerGenerator $faker,
-        SqliteProvider $provider,
         ?string $version = null,
     ) {
-        unset($provider);
         $this->grammar = $this->augmentGrammar($grammar);
         $this->faker = $faker;
         $this->lexicalGrammar = new LexicalGrammar(
@@ -72,7 +68,9 @@ final class SqlGenerator
      */
     public function generate(GenerationPlan $plan): string
     {
-        $this->targetDepth = $plan->maxDepth();
+        if ($plan->lexicalTarget() !== null) {
+            return $this->lexicalGrammar->generate($plan);
+        }
         $start = $plan->startRule() ?? 'cmd';
         $lastException = null;
         for ($attempt = 0; $attempt < self::LEXICAL_ATTEMPT_LIMIT; $attempt++) {
@@ -190,7 +188,7 @@ final class SqlGenerator
                 throw new LogicException('Exceeded derivation limit while generating SQL.');
             }
 
-            if ($this->derivationSteps >= $this->targetDepth) {
+            if ($this->derivationSteps >= $plan->maxDepth()) {
                 $selectedIndex = 0;
                 $bestSteps = PHP_INT_MAX;
                 $bestLength = PHP_INT_MAX;

--- a/packages/sql-faker/src/SqliteProvider.php
+++ b/packages/sql-faker/src/SqliteProvider.php
@@ -7,7 +7,6 @@ namespace SqlFaker;
 use Faker\Generator;
 use Faker\Provider\Base;
 use SqlFaker\Grammar\GenerationPlan;
-use SqlFaker\Grammar\RandomStringGenerator;
 use SqlFaker\Sqlite\Grammar\SqliteGrammar;
 use SqlFaker\Sqlite\GenerationPlans;
 use SqlFaker\Sqlite\SqlGenerator;
@@ -34,7 +33,6 @@ use SqlFaker\Sqlite\StatementType;
 final class SqliteProvider extends Base
 {
     private SqlGenerator $sql;
-    private RandomStringGenerator $rsg;
 
     /**
      * @param Generator $generator Faker generator
@@ -47,8 +45,7 @@ final class SqliteProvider extends Base
         $generator->addProvider($this);
 
         $resolvedVersion = SqliteGrammar::resolveVersion($version);
-        $this->rsg = new RandomStringGenerator($generator);
-        $this->sql = new SqlGenerator(SqliteGrammar::load($resolvedVersion), $generator, $this, $resolvedVersion);
+        $this->sql = new SqlGenerator(SqliteGrammar::load($resolvedVersion), $generator, $resolvedVersion);
     }
 
     /**
@@ -229,7 +226,7 @@ final class SqliteProvider extends Base
      */
     public function quotedIdentifier(int $minLength = 1, int $maxLength = 128): string
     {
-        return '"' . $this->rsg->rawIdentifier($minLength, $maxLength) . '"';
+        return $this->sql->generate(GenerationPlans::quotedIdentifier($minLength, $maxLength));
     }
 
     /**
@@ -237,7 +234,7 @@ final class SqliteProvider extends Base
      */
     public function stringLiteral(int $minLength = 1, int $maxLength = 255): string
     {
-        return "'" . $this->rsg->mixedAlnumString($minLength, $maxLength) . "'";
+        return $this->sql->generate(GenerationPlans::stringLiteral($minLength, $maxLength));
     }
 
     /**
@@ -245,7 +242,7 @@ final class SqliteProvider extends Base
      */
     public function integerLiteral(int $min = 1, int $max = PHP_INT_MAX): string
     {
-        return $this->rsg->integerString($min, $max);
+        return $this->sql->generate(GenerationPlans::integerLiteral($min, $max));
     }
 
     /**
@@ -253,7 +250,7 @@ final class SqliteProvider extends Base
      */
     public function decimalLiteral(int $precision = 15, int $scale = 2): string
     {
-        return $this->rsg->decimalString($precision, $scale);
+        return $this->sql->generate(GenerationPlans::decimalLiteral($precision, $scale));
     }
 
     /** @return non-empty-string */

--- a/packages/sql-faker/tests/Unit/Grammar/GenerationPlanTest.php
+++ b/packages/sql-faker/tests/Unit/Grammar/GenerationPlanTest.php
@@ -134,6 +134,26 @@ final class GenerationPlanTest extends TestCase
         GenerationPlan::all()->withLexemes([]);
     }
 
+    public function testLexicalPlanSelectsOneTargetWithParameters(): void
+    {
+        $plan = GenerationPlan::lexical('quoted_identifier', [
+            'minLength' => 2,
+            'maxLength' => 8,
+        ]);
+
+        self::assertNull($plan->startRule());
+        self::assertSame('quoted_identifier', $plan->lexicalTarget());
+        self::assertSame(['minLength' => 2, 'maxLength' => 8], $plan->parameters());
+    }
+
+    public function testRejectsAnEmptyLexicalTarget(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('target must not be empty');
+
+        GenerationPlan::lexical('', []);
+    }
+
     public function testRejectsAnEmptyStartRule(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/packages/sql-faker/tests/Unit/Grammar/RandomStringGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/Grammar/RandomStringGeneratorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Unit\SqlFaker\Grammar;
 
 use Faker\Factory;
+use InvalidArgumentException;
+use LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\Grammar\RandomStringGenerator;
@@ -429,5 +431,141 @@ final class RandomStringGeneratorTest extends TestCase
         $rsg = new RandomStringGenerator($faker);
         $result = $rsg->hostnameString(2, 2, 3, 3);
         self::assertMatchesRegularExpression('/^[a-z0-9]{3}\.[a-z0-9]{3}$/', $result);
+    }
+
+    public function testHostnameStringRejectsAnEmptyResult(): void
+    {
+        $this->expectException(LogicException::class);
+
+        (new RandomStringGenerator(Factory::create()))->hostnameString(0, 0);
+    }
+
+    public function testLexicalSequenceDerivesTermsFromCatalog(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(42);
+        $sequence = (new RandomStringGenerator($faker))->lexicalSequence(
+            ['SELECT_SYM' => ['SELECT'], 'FROM_SYM' => ['FROM'], 'WHERE_SYM' => ['WHERE']],
+            3,
+            3,
+        );
+
+        self::assertCount(3, explode(' ', $sequence));
+        self::assertMatchesRegularExpression('/^(?:SELECT|FROM|WHERE)(?: (?:SELECT|FROM|WHERE)){2}$/', $sequence);
+    }
+
+    public function testLexicalSequenceUsesDefaultTermBounds(): void
+    {
+        $faker = new class () extends \Faker\Generator {
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if (!is_int($min)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $min;
+            }
+        };
+
+        $sequence = (new RandomStringGenerator($faker))->lexicalSequence(['SELECT_SYM' => ['SELECT']]);
+
+        self::assertSame('SELECT SELECT', $sequence);
+        self::assertSame(
+            [2, 4],
+            array_map(
+                static fn (\ReflectionParameter $parameter): mixed => $parameter->getDefaultValue(),
+                array_slice((new \ReflectionMethod(RandomStringGenerator::class, 'lexicalSequence'))->getParameters(), 1),
+            ),
+        );
+    }
+
+    public function testLexicalSequenceAcceptsOneTerm(): void
+    {
+        self::assertSame(
+            'SELECT',
+            (new RandomStringGenerator(Factory::create()))->lexicalSequence(['SELECT_SYM' => ['SELECT']], 1, 1),
+        );
+    }
+
+    public function testLexicalSequenceIgnoresEmptyTerminalLexemeSets(): void
+    {
+        $faker = new class () extends \Faker\Generator {
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if (!is_int($min)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $min;
+            }
+        };
+
+        self::assertSame(
+            'SELECT',
+            (new RandomStringGenerator($faker))->lexicalSequence(
+                ['EMPTY' => [], 'SELECT_SYM' => ['SELECT']],
+                1,
+                1,
+            ),
+        );
+    }
+
+    public function testLexicalSequenceCanSelectTheLastTerminalLexemeSet(): void
+    {
+        $faker = new class () extends \Faker\Generator {
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if (!is_int($max)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $max;
+            }
+        };
+
+        self::assertSame(
+            'FROM',
+            (new RandomStringGenerator($faker))->lexicalSequence(
+                ['SELECT_SYM' => ['SELECT'], 'FROM_SYM' => ['FROM']],
+                1,
+                1,
+            ),
+        );
+    }
+
+    public function testLexicalSequenceRejectsInvalidBounds(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new RandomStringGenerator(Factory::create()))->lexicalSequence(['SELECT_SYM' => ['SELECT']], 0, 1);
+    }
+
+    public function testLexicalSequenceRejectsEmptyCatalog(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new RandomStringGenerator(Factory::create()))->lexicalSequence([]);
+    }
+
+    public function testLexicalSequenceRejectsEmptyLexemes(): void
+    {
+        $this->expectException(LogicException::class);
+
+        (new RandomStringGenerator(Factory::create()))->lexicalSequence(['EMPTY' => ['']], 1, 1);
     }
 }

--- a/packages/sql-faker/tests/Unit/MySql/LexicalGrammarTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/LexicalGrammarTest.php
@@ -23,6 +23,118 @@ use SqlFaker\MySql\LexicalGrammar;
 #[UsesClass(SqlVersion::class)]
 final class LexicalGrammarTest extends TestCase
 {
+    public function testGeneratesPublicProviderLexemesThroughDialectGrammar(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $lexical = new LexicalGrammar($faker, 'mysql-8.4.7');
+        $sql = implode(' ', [
+            $lexical->generateQuotedIdentifier(3, 3),
+            $lexical->generateStringLiteral(3, 3),
+            $lexical->generateNationalStringLiteral(3, 3),
+            $lexical->generateDollarQuotedString(3, 3),
+            $lexical->generateIntegerLiteral(10, 10),
+            $lexical->generateDecimalLiteral(4, 2),
+            $lexical->generateFloatLiteral(4, 2, 2, 2),
+            $lexical->generateHexLiteral(4, 4),
+            $lexical->generateQuotedHexLiteral(2, 2),
+            $lexical->generateBinaryLiteral(4, 4),
+        ]);
+
+        self::assertSame([
+            'IDENT_QUOTED', 'TEXT_STRING', 'NCHAR_STRING', 'DOLLAR_QUOTED_STRING_SYM', 'NUM',
+            'DECIMAL_NUM', 'FLOAT_NUM', 'HEX_NUM', 'HEX_NUM', 'BIN_NUM',
+        ], $lexical->tokenize($sql));
+        self::assertSame('10', $lexical->generateLongIntegerLiteral(10, 10));
+        self::assertMatchesRegularExpression('/^[0-9]{1,20}$/', $lexical->generateUnsignedBigIntLiteral());
+        self::assertSame(
+            ['@', 'LEX_HOSTNAME'],
+            $lexical->tokenize('@' . $lexical->generateHostname(2, 2, 3)),
+        );
+    }
+
+    /**
+     * @param \Closure(LexicalGrammar): string $generate
+     * @param list<int> $expected
+     */
+    #[DataProvider('providerPublicLexemeDefaults')]
+    public function testPublicLexemeDefaultBounds(\Closure $generate, string $method, array $expected): void
+    {
+        self::assertNotSame('', $generate(new LexicalGrammar(Factory::create(), 'mysql-8.4.7')));
+        self::assertSame(
+            $expected,
+            array_map(
+                static fn (\ReflectionParameter $parameter): mixed => $parameter->getDefaultValue(),
+                (new \ReflectionMethod(LexicalGrammar::class, $method))->getParameters(),
+            ),
+        );
+    }
+
+    /** @return iterable<string, array{\Closure(LexicalGrammar): string, string, list<int>}> */
+    public static function providerPublicLexemeDefaults(): iterable
+    {
+        yield 'quoted identifier' => [static fn (LexicalGrammar $grammar): string => $grammar->generateQuotedIdentifier(), 'generateQuotedIdentifier', [1, 64]];
+        yield 'string' => [static fn (LexicalGrammar $grammar): string => $grammar->generateStringLiteral(), 'generateStringLiteral', [1, 255]];
+        yield 'national string' => [static fn (LexicalGrammar $grammar): string => $grammar->generateNationalStringLiteral(), 'generateNationalStringLiteral', [1, 255]];
+        yield 'dollar quoted string' => [static fn (LexicalGrammar $grammar): string => $grammar->generateDollarQuotedString(), 'generateDollarQuotedString', [1, 255]];
+        yield 'integer' => [static fn (LexicalGrammar $grammar): string => $grammar->generateIntegerLiteral(), 'generateIntegerLiteral', [1, 2147483647]];
+        yield 'long integer' => [static fn (LexicalGrammar $grammar): string => $grammar->generateLongIntegerLiteral(), 'generateLongIntegerLiteral', [0, 2147483647]];
+        yield 'unsigned big integer' => [static fn (LexicalGrammar $grammar): string => $grammar->generateUnsignedBigIntLiteral(), 'generateUnsignedBigIntLiteral', [1, 20]];
+        yield 'decimal' => [static fn (LexicalGrammar $grammar): string => $grammar->generateDecimalLiteral(), 'generateDecimalLiteral', [10, 2]];
+        yield 'float' => [static fn (LexicalGrammar $grammar): string => $grammar->generateFloatLiteral(), 'generateFloatLiteral', [10, 2, -38, 38]];
+        yield 'hex' => [static fn (LexicalGrammar $grammar): string => $grammar->generateHexLiteral(), 'generateHexLiteral', [1, 16]];
+        yield 'quoted hex' => [static fn (LexicalGrammar $grammar): string => $grammar->generateQuotedHexLiteral(), 'generateQuotedHexLiteral', [1, 8]];
+        yield 'binary' => [static fn (LexicalGrammar $grammar): string => $grammar->generateBinaryLiteral(), 'generateBinaryLiteral', [1, 64]];
+        yield 'hostname' => [static fn (LexicalGrammar $grammar): string => $grammar->generateHostname(), 'generateHostname', [1, 4, 63]];
+    }
+
+    #[DataProvider('providerGeneratedStringLiteral')]
+    public function testGeneratesEveryStringLiteralStrategy(int $choice, string $expected): void
+    {
+        $faker = new class ($choice) extends \Faker\Generator {
+            private bool $first = true;
+
+            public function __construct(private readonly int $choice)
+            {
+                parent::__construct();
+            }
+
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if ($this->first) {
+                    $this->first = false;
+
+                    return $this->choice;
+                }
+                if (!is_int($min)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $min;
+            }
+        };
+
+        self::assertSame(
+            $expected,
+            (new LexicalGrammar($faker, 'mysql-8.4.7', true))->realize(['TEXT_STRING']),
+        );
+    }
+
+    /** @return iterable<string, array{int, string}> */
+    public static function providerGeneratedStringLiteral(): iterable
+    {
+        yield 'combined arm value zero' => [0, "'ACCESSIBLE ACCESSIBLE'"];
+        yield 'combined arm value one' => [1, "'ACCESSIBLE ACCESSIBLE'"];
+        yield 'quote escaping' => [2, "'a''b'"];
+        yield 'backslash' => [3, "'a\\b'"];
+        yield 'random body' => [4, "''"];
+    }
+
     public function testTokenizesQuotedValuesHexValuesAndCommentsAsSingleTokens(): void
     {
         $lexical = new LexicalGrammar(Factory::create(), 'mysql-8.4.7');

--- a/packages/sql-faker/tests/Unit/MySql/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/MySql/SqlGeneratorTest.php
@@ -69,7 +69,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -85,7 +85,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('EXPECTED')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
         $plan = GenerationPlan::constrained('stmt', [
             'stmt' => [ProductionPattern::exactly('EXPECTED')],
         ]);
@@ -102,7 +102,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('EXPECTED')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
         $plan = GenerationPlan::fromRule('stmt')->requiringNonEmpty();
 
         self::assertSame('EXPECTED', $generator->generate($plan->withMaxDepth(1)));
@@ -133,7 +133,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('DEFAULT_SYM')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('insert_stmt')->withMaxDepth(1));
 
@@ -170,7 +170,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('DEFAULT_SYM')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlans::withoutEmptyRows('insert_stmt')->withMaxDepth(1));
 
@@ -195,7 +195,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('OTHER_RULE_USED')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::all());
 
@@ -211,7 +211,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('a')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result1 = $generator->generate(GenerationPlan::fromRule('stmt'));
         $result2 = $generator->generate(GenerationPlan::fromRule('stmt'));
@@ -227,7 +227,7 @@ final class SqlGeneratorTest extends TestCase
         $faker->seed(42);
         $provider = new MySqlProvider($faker);
 
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
         $result = $generator->generate(GenerationPlan::fromRule('literal')->withMaxDepth(1));
 
         self::assertNotSame('', $result);
@@ -248,7 +248,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('SHORT')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $resultZero = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(0));
         $resultNegative = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(-10));
@@ -280,7 +280,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('t')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(1));
 
@@ -297,7 +297,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('SECOND')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(1));
 
@@ -318,13 +318,13 @@ final class SqlGeneratorTest extends TestCase
         $faker1 = Factory::create();
         $provider1 = new MySqlProvider($faker1);
         $faker1->seed($seed1);
-        $generator1 = new SqlGenerator($grammar, $faker1, $provider1);
+        $generator1 = new SqlGenerator($grammar, $faker1);
         $result1 = $generator1->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(PHP_INT_MAX));
 
         $faker2 = Factory::create();
         $provider2 = new MySqlProvider($faker2);
         $faker2->seed($seed2);
-        $generator2 = new SqlGenerator($grammar, $faker2, $provider2);
+        $generator2 = new SqlGenerator($grammar, $faker2);
         $result2 = $generator2->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(PHP_INT_MAX));
 
         self::assertNotSame($result1, $result2);
@@ -346,7 +346,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('SHORT')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(3));
 
@@ -371,7 +371,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('2ND')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -398,7 +398,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('42')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -421,7 +421,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -440,7 +440,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Grammar rule has no lexically realizable alternative: infinite');
@@ -455,7 +455,7 @@ final class SqlGeneratorTest extends TestCase
         $grammar = new Grammar('empty', [
             'empty' => new ProductionRule('empty', []),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Production rule has no alternatives.');
@@ -472,7 +472,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('a')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(\LogicException::class);
 
@@ -489,7 +489,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal($terminalName)]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -506,7 +506,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal($terminalName)]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
         $faker->seed(12345);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
@@ -526,7 +526,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -542,7 +542,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('WITH_ROLLUP_SYM')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -558,7 +558,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('SELECT_SYM')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -574,7 +574,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal(',')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -590,7 +590,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('END_OF_INPUT')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -610,7 +610,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -626,7 +626,7 @@ final class SqlGeneratorTest extends TestCase
                 new Production([new Terminal('SINGLE')]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -644,7 +644,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -665,7 +665,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -686,7 +686,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -707,7 +707,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -728,7 +728,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -748,7 +748,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -768,7 +768,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Unterminated MySQL quoted token');
@@ -790,7 +790,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -811,7 +811,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -830,7 +830,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -849,7 +849,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -868,7 +868,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -887,7 +887,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -906,7 +906,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -927,7 +927,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -949,7 +949,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -971,7 +971,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -990,7 +990,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1009,7 +1009,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1031,7 +1031,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1052,7 +1052,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1077,7 +1077,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1098,7 +1098,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1122,7 +1122,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1144,7 +1144,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1164,7 +1164,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1186,7 +1186,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1207,7 +1207,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1227,7 +1227,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1248,7 +1248,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -1267,7 +1267,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $generator = new SqlGenerator($grammar, $faker, new MySqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 

--- a/packages/sql-faker/tests/Unit/PostgreSql/LexicalGrammarTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/LexicalGrammarTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\SqlFaker\PostgreSql;
 
 use Faker\Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\Grammar\LexicalCatalog;
@@ -22,6 +23,137 @@ use SqlFaker\PostgreSql\LexicalGrammar;
 #[UsesClass(SqlVersion::class)]
 final class LexicalGrammarTest extends TestCase
 {
+    public function testGeneratesPublicProviderLexemesThroughDialectGrammar(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $lexical = new LexicalGrammar($faker, 'pg-17.2');
+        $sql = implode(' ', [
+            $lexical->generateQuotedIdentifier(3, 3),
+            $lexical->generateStringLiteral(3, 3),
+            $lexical->generateIntegerLiteral(10, 10),
+            $lexical->generateDecimalLiteral(4, 2),
+            $lexical->generateFloatLiteral(4, 2, 2, 2),
+            $lexical->generateHexLiteral(4, 4),
+            $lexical->generateBinaryLiteral(4, 4),
+            $lexical->generateDollarQuotedString(3, 3),
+            $lexical->generateParameterMarker(2, 2),
+        ]);
+
+        self::assertSame([
+            'IDENT', 'SCONST', 'ICONST', 'FCONST', 'FCONST', 'XCONST', 'BCONST', 'SCONST', 'PARAM',
+        ], $lexical->tokenize($sql));
+    }
+
+    /**
+     * @param \Closure(LexicalGrammar): string $generate
+     * @param list<int> $expected
+     */
+    #[DataProvider('providerPublicLexemeDefaults')]
+    public function testPublicLexemeDefaultBounds(\Closure $generate, string $method, array $expected): void
+    {
+        self::assertNotSame('', $generate(new LexicalGrammar(Factory::create(), 'pg-17.2')));
+        self::assertSame(
+            $expected,
+            array_map(
+                static fn (\ReflectionParameter $parameter): mixed => $parameter->getDefaultValue(),
+                (new \ReflectionMethod(LexicalGrammar::class, $method))->getParameters(),
+            ),
+        );
+    }
+
+    /** @return iterable<string, array{\Closure(LexicalGrammar): string, string, list<int>}> */
+    public static function providerPublicLexemeDefaults(): iterable
+    {
+        yield 'quoted identifier' => [static fn (LexicalGrammar $grammar): string => $grammar->generateQuotedIdentifier(), 'generateQuotedIdentifier', [1, 63]];
+        yield 'string' => [static fn (LexicalGrammar $grammar): string => $grammar->generateStringLiteral(), 'generateStringLiteral', [1, 255]];
+        yield 'integer' => [static fn (LexicalGrammar $grammar): string => $grammar->generateIntegerLiteral(), 'generateIntegerLiteral', [1, 2147483647]];
+        yield 'decimal' => [static fn (LexicalGrammar $grammar): string => $grammar->generateDecimalLiteral(), 'generateDecimalLiteral', [10, 2]];
+        yield 'float' => [static fn (LexicalGrammar $grammar): string => $grammar->generateFloatLiteral(), 'generateFloatLiteral', [10, 2, -307, 308]];
+        yield 'hex' => [static fn (LexicalGrammar $grammar): string => $grammar->generateHexLiteral(), 'generateHexLiteral', [1, 16]];
+        yield 'binary' => [static fn (LexicalGrammar $grammar): string => $grammar->generateBinaryLiteral(), 'generateBinaryLiteral', [1, 64]];
+        yield 'dollar quoted string' => [static fn (LexicalGrammar $grammar): string => $grammar->generateDollarQuotedString(), 'generateDollarQuotedString', [1, 255]];
+        yield 'parameter marker' => [static fn (LexicalGrammar $grammar): string => $grammar->generateParameterMarker(), 'generateParameterMarker', [1, 99]];
+    }
+
+    /** @param list<int> $choices */
+    #[DataProvider('providerGeneratedStringLiteral')]
+    public function testGeneratesEveryStringLiteralStrategy(array $choices, string $expected): void
+    {
+        $faker = new class ($choices) extends \Faker\Generator {
+            private int $call = 0;
+
+            /** @param list<int> $choices */
+            public function __construct(private readonly array $choices)
+            {
+                parent::__construct();
+            }
+
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if (isset($this->choices[$this->call])) {
+                    return $this->choices[$this->call++];
+                }
+                if (!is_int($min)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $min;
+            }
+        };
+
+        self::assertSame(
+            $expected,
+            (new LexicalGrammar($faker, 'pg-17.2', true))->realize(['SCONST']),
+        );
+    }
+
+    /** @return iterable<string, array{list<int>, string}> */
+    public static function providerGeneratedStringLiteral(): iterable
+    {
+        yield 'escape string' => [[0], "E'a\\\\b'"];
+        yield 'dollar quoted string' => [[1], '$$ABORT ABORT ? $$'];
+        yield 'combined arm value zero' => [[2, 0], "'ABORT ABORT'"];
+        yield 'combined arm value one' => [[2, 1], "'ABORT ABORT'"];
+        yield 'quote escaping' => [[2, 2], "'a''b'"];
+        yield 'random body' => [[2, 3], "''"];
+    }
+
+    public function testDollarQuotedStringIncludesTheGeneratedMaximumLengthSuffix(): void
+    {
+        $faker = new class () extends \Faker\Generator {
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if ($min === 0 && $max === 3) {
+                    return 1;
+                }
+                if ($min === 0 && $max === 12) {
+                    return 12;
+                }
+                if (!is_int($min)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $min;
+            }
+        };
+
+        self::assertSame(
+            '$$ABORT ABORT ? aaaaaaaaaaaa$$',
+            (new LexicalGrammar($faker, 'pg-17.2', true))->realize(['SCONST']),
+        );
+    }
+
     public function testTokenizesAllProblematicLiteralAndOperatorFamilies(): void
     {
         $lexical = new LexicalGrammar(Factory::create(), 'pg-17.2');

--- a/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/PostgreSql/SqlGeneratorTest.php
@@ -68,7 +68,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -84,7 +84,7 @@ final class SqlGeneratorTest extends TestCase
             ]),
         ]);
         $faker = Factory::create();
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
         $plan = GenerationPlan::constrained('stmt', [
             'stmt' => [ProductionPattern::exactly('EXPECTED')],
         ]);
@@ -101,7 +101,7 @@ final class SqlGeneratorTest extends TestCase
             ]),
         ]);
         $faker = Factory::create();
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
         $plan = GenerationPlan::fromRule('stmt')->requiringNonEmpty();
 
         self::assertSame('EXPECTED', $generator->generate($plan->withMaxDepth(1)));
@@ -119,7 +119,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::all());
 
@@ -140,7 +140,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $provider = new PostgreSqlProvider($faker, 'pg-17.2');
-        $generator = new SqlGenerator($grammar, $faker, $provider, 'pg-17.2');
+        $generator = new SqlGenerator($grammar, $faker, 'pg-17.2');
         $faker->seed(12345);
 
         self::assertNotEmpty($generator->generate(GenerationPlan::fromRule('stmt')));
@@ -164,7 +164,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result1 = $generator->generate(GenerationPlan::fromRule('stmt'));
         $result2 = $generator->generate(GenerationPlan::fromRule('stmt'));
@@ -194,7 +194,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(1));
 
@@ -210,7 +210,7 @@ final class SqlGeneratorTest extends TestCase
             ]),
         ]);
         $faker = Factory::create();
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('', $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(1)));
     }
@@ -231,7 +231,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Grammar rule has no lexically realizable alternative: infinite');
@@ -246,7 +246,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Production rule has no alternatives.');
@@ -264,7 +264,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -281,7 +281,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $provider = new PostgreSqlProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
         $faker->seed(12345);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
@@ -299,7 +299,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -316,7 +316,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -342,7 +342,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -364,7 +364,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -382,7 +382,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -403,7 +403,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -426,7 +426,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -446,7 +446,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -468,7 +468,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -491,7 +491,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -516,7 +516,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -539,7 +539,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -559,7 +559,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -587,7 +587,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -609,7 +609,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -629,7 +629,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new PostgreSqlProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -708,7 +708,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $result = (new SqlGenerator($grammarFuncParen, $faker, $provider))->generate(GenerationPlan::fromRule('stmt'));
+        $result = (new SqlGenerator($grammarFuncParen, $faker))->generate(GenerationPlan::fromRule('stmt'));
         self::assertSame('COUNT(*)', $result);
 
         $grammarDot = new Grammar('stmt', [
@@ -720,7 +720,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $result = (new SqlGenerator($grammarDot, $faker, $provider))->generate(GenerationPlan::fromRule('stmt'));
+        $result = (new SqlGenerator($grammarDot, $faker))->generate(GenerationPlan::fromRule('stmt'));
         self::assertSame('schema.table', $result);
 
         $grammarTypecast = new Grammar('stmt', [
@@ -732,7 +732,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $result = (new SqlGenerator($grammarTypecast, $faker, $provider))->generate(GenerationPlan::fromRule('stmt'));
+        $result = (new SqlGenerator($grammarTypecast, $faker))->generate(GenerationPlan::fromRule('stmt'));
         self::assertSame('col::INTEGER', $result);
 
         $grammarBracket = new Grammar('stmt', [
@@ -745,7 +745,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $result = (new SqlGenerator($grammarBracket, $faker, $provider))->generate(GenerationPlan::fromRule('stmt'));
+        $result = (new SqlGenerator($grammarBracket, $faker))->generate(GenerationPlan::fromRule('stmt'));
         self::assertSame('arr [1]', $result);
 
         $grammarComma = new Grammar('stmt', [
@@ -757,7 +757,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $result = (new SqlGenerator($grammarComma, $faker, $provider))->generate(GenerationPlan::fromRule('stmt'));
+        $result = (new SqlGenerator($grammarComma, $faker))->generate(GenerationPlan::fromRule('stmt'));
         self::assertSame('a, b', $result);
 
         $grammarSemicolon = new Grammar('stmt', [
@@ -769,7 +769,7 @@ final class SqlGeneratorTest extends TestCase
                 ]),
             ]),
         ]);
-        $result = (new SqlGenerator($grammarSemicolon, $faker, $provider))->generate(GenerationPlan::fromRule('stmt'));
+        $result = (new SqlGenerator($grammarSemicolon, $faker))->generate(GenerationPlan::fromRule('stmt'));
         self::assertSame('SELECT 1;', $result);
     }
 }

--- a/packages/sql-faker/tests/Unit/Sqlite/LexicalGrammarTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/LexicalGrammarTest.php
@@ -23,6 +23,94 @@ use SqlFaker\Sqlite\LexicalGrammar;
 #[UsesClass(SqlVersion::class)]
 final class LexicalGrammarTest extends TestCase
 {
+    public function testGeneratesPublicProviderLexemesThroughDialectGrammar(): void
+    {
+        $faker = Factory::create();
+        $faker->seed(12345);
+        $lexical = new LexicalGrammar($faker, 'sqlite-3.47.2');
+        $sql = implode(' ', [
+            $lexical->generateQuotedIdentifier(3, 3),
+            $lexical->generateStringLiteral(3, 3),
+            $lexical->generateIntegerLiteral(10, 10),
+            $lexical->generateDecimalLiteral(4, 2),
+        ]);
+
+        self::assertSame(['ID', 'STRING', 'INTEGER', 'FLOAT'], $lexical->tokenize($sql));
+    }
+
+    /**
+     * @param \Closure(LexicalGrammar): string $generate
+     * @param list<int> $expected
+     */
+    #[DataProvider('providerPublicLexemeDefaults')]
+    public function testPublicLexemeDefaultBounds(\Closure $generate, string $method, array $expected): void
+    {
+        self::assertNotSame('', $generate(new LexicalGrammar(Factory::create(), 'sqlite-3.47.2')));
+        self::assertSame(
+            $expected,
+            array_map(
+                static fn (\ReflectionParameter $parameter): mixed => $parameter->getDefaultValue(),
+                (new \ReflectionMethod(LexicalGrammar::class, $method))->getParameters(),
+            ),
+        );
+    }
+
+    /** @return iterable<string, array{\Closure(LexicalGrammar): string, string, list<int>}> */
+    public static function providerPublicLexemeDefaults(): iterable
+    {
+        yield 'quoted identifier' => [static fn (LexicalGrammar $grammar): string => $grammar->generateQuotedIdentifier(), 'generateQuotedIdentifier', [1, 128]];
+        yield 'string' => [static fn (LexicalGrammar $grammar): string => $grammar->generateStringLiteral(), 'generateStringLiteral', [1, 255]];
+        yield 'integer' => [static fn (LexicalGrammar $grammar): string => $grammar->generateIntegerLiteral(), 'generateIntegerLiteral', [1, PHP_INT_MAX]];
+        yield 'decimal' => [static fn (LexicalGrammar $grammar): string => $grammar->generateDecimalLiteral(), 'generateDecimalLiteral', [15, 2]];
+    }
+
+    #[DataProvider('providerGeneratedStringLiteral')]
+    public function testGeneratesEveryStringLiteralStrategy(int $choice, string $expected): void
+    {
+        $faker = new class ($choice) extends \Faker\Generator {
+            private bool $first = true;
+
+            public function __construct(private readonly int $choice)
+            {
+                parent::__construct();
+            }
+
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if ($this->first) {
+                    $this->first = false;
+
+                    return $this->choice;
+                }
+                if (!is_int($min)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $min;
+            }
+        };
+
+        self::assertSame(
+            $expected,
+            (new LexicalGrammar($faker, 'sqlite-3.47.2', true))->realize(['STRING']),
+        );
+    }
+
+    /** @return iterable<string, array{int, string}> */
+    public static function providerGeneratedStringLiteral(): iterable
+    {
+        yield 'combined arm value zero' => [0, "'ABORT ABORT'"];
+        yield 'combined arm value one' => [1, "'ABORT ABORT'"];
+        yield 'quote escaping' => [2, "'a''b'"];
+        yield 'backslash' => [3, "'a\\b'"];
+        yield 'random body' => [4, "''"];
+    }
+
     public function testTokenizesQuotedIdentifiersStringsVariablesAndComments(): void
     {
         $lexical = new LexicalGrammar(Factory::create(), 'sqlite-3.47.2');
@@ -165,6 +253,51 @@ SQL;
         $lexical = new LexicalGrammar($faker, 'sqlite-3.47.2', true);
 
         self::assertNotSame($terminal, $lexical->realize([$terminal]));
+    }
+
+    #[DataProvider('providerIdentifierQuoteStrategy')]
+    public function testIdentifierQuoteStrategy(int $choice, string $expected): void
+    {
+        $faker = new class ([0, $choice]) extends \Faker\Generator {
+            private int $call = 0;
+
+            /** @param list<int> $choices */
+            public function __construct(private readonly array $choices)
+            {
+                parent::__construct();
+            }
+
+            /**
+             * @param mixed $min
+             * @param mixed $max
+             */
+            #[\Override]
+            public function numberBetween($min = 0, $max = 2147483647): int
+            {
+                if (isset($this->choices[$this->call])) {
+                    return $this->choices[$this->call++];
+                }
+                if (!is_int($min)) {
+                    throw new \UnexpectedValueException();
+                }
+
+                return $min;
+            }
+        };
+
+        self::assertSame(
+            $expected,
+            (new LexicalGrammar($faker, 'sqlite-3.47.2', true))->realize(['ID']),
+        );
+    }
+
+    /** @return iterable<string, array{int, string}> */
+    public static function providerIdentifierQuoteStrategy(): iterable
+    {
+        yield 'double quote escaping' => [0, '"select""quoted"'];
+        yield 'backtick escaping' => [1, '`select``quoted`'];
+        yield 'closing bracket removal' => [2, '[selectquoted]'];
+        yield 'unquoted identifier' => [3, 'select'];
     }
 
     #[DataProvider('providerStringSyntheticTerminal')]

--- a/packages/sql-faker/tests/Unit/Sqlite/SqlGeneratorTest.php
+++ b/packages/sql-faker/tests/Unit/Sqlite/SqlGeneratorTest.php
@@ -72,7 +72,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -88,7 +88,7 @@ final class SqlGeneratorTest extends TestCase
             ]),
         ]);
         $faker = Factory::create();
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
         $plan = GenerationPlan::constrained('stmt', [
             'stmt' => [ProductionPattern::exactly('EXPECTED')],
         ]);
@@ -105,7 +105,7 @@ final class SqlGeneratorTest extends TestCase
             ]),
         ]);
         $faker = Factory::create();
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
         $plan = GenerationPlan::fromRule('stmt')->requiringNonEmpty();
 
         self::assertSame('EXPECTED', $generator->generate($plan->withMaxDepth(1)));
@@ -120,7 +120,6 @@ final class SqlGeneratorTest extends TestCase
         $generator = new SqlGenerator(
             $grammar,
             $faker,
-            new SqliteProvider($faker),
             'sqlite-3.47.2',
         );
 
@@ -139,7 +138,7 @@ final class SqlGeneratorTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('NOT_A_SQLITE_TERMINAL');
 
-        new SqlGenerator($grammar, $faker, new SqliteProvider($faker), 'sqlite-3.47.2');
+        new SqlGenerator($grammar, $faker, 'sqlite-3.47.2');
     }
 
     public function testGenerateDefaultStartRule(): void
@@ -154,7 +153,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::all());
 
@@ -170,7 +169,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result1 = $generator->generate(GenerationPlan::fromRule('stmt'));
         $result2 = $generator->generate(GenerationPlan::fromRule('stmt'));
@@ -200,7 +199,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(1));
 
@@ -222,7 +221,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $resultZero = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(0));
         $resultNegative = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(-10));
@@ -243,7 +242,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(1));
 
@@ -260,7 +259,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('VALUE', $generator->generate(GenerationPlan::fromRule('value')->withMaxDepth(1)));
     }
@@ -275,7 +274,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('VALUE', $generator->generate(GenerationPlan::fromRule('value')));
     }
@@ -300,7 +299,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $provider = new SqliteProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
         $faker->seed(3);
 
         self::assertStringStartsWith('EXPECTED ', $generator->generate(GenerationPlan::fromRule('start')));
@@ -319,12 +318,12 @@ final class SqlGeneratorTest extends TestCase
 
         $faker1 = Factory::create();
         $faker1->seed($seed1);
-        $generator1 = new SqlGenerator($grammar, $faker1, new SqliteProvider($faker1));
+        $generator1 = new SqlGenerator($grammar, $faker1);
         $result1 = $generator1->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(PHP_INT_MAX));
 
         $faker2 = Factory::create();
         $faker2->seed($seed2);
-        $generator2 = new SqlGenerator($grammar, $faker2, new SqliteProvider($faker2));
+        $generator2 = new SqlGenerator($grammar, $faker2);
         $result2 = $generator2->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(PHP_INT_MAX));
 
         self::assertNotSame($result1, $result2);
@@ -346,7 +345,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt')->withMaxDepth(3));
 
@@ -371,7 +370,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -396,7 +395,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -419,7 +418,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -432,7 +431,7 @@ final class SqlGeneratorTest extends TestCase
         $faker = Factory::create();
         $faker->seed(12345);
         $provider = new SqliteProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('insert')->withMaxDepth(6));
 
@@ -445,7 +444,7 @@ final class SqlGeneratorTest extends TestCase
         $faker = Factory::create();
         $faker->seed(12345);
         $provider = new SqliteProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('delete')->withMaxDepth(6));
 
@@ -458,7 +457,7 @@ final class SqlGeneratorTest extends TestCase
         $faker = Factory::create();
         $faker->seed(12345);
         $provider = new SqliteProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('update')->withMaxDepth(6));
 
@@ -471,7 +470,7 @@ final class SqlGeneratorTest extends TestCase
         $faker = Factory::create();
         $faker->seed(12345);
         $provider = new SqliteProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('drop_table')->withMaxDepth(6));
 
@@ -484,7 +483,7 @@ final class SqlGeneratorTest extends TestCase
         $faker = Factory::create();
         $faker->seed(12345);
         $provider = new SqliteProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('alter_table')->withMaxDepth(6));
 
@@ -503,7 +502,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Grammar rule has no lexically realizable alternative: infinite');
@@ -518,7 +517,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage("Production rule 'empty' has no alternatives.");
@@ -538,7 +537,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -554,7 +553,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -571,7 +570,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -588,7 +587,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -605,7 +604,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $provider = new SqliteProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
         $faker->seed(12345);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
@@ -623,7 +622,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -644,7 +643,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('COUNT(*)', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -662,7 +661,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('a.b', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -680,7 +679,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Unterminated SQLite bracket identifier.');
@@ -701,7 +700,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('a, b', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -719,7 +718,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('SELECT 1;', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -736,7 +735,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('x)', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -753,7 +752,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('(x', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -771,7 +770,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('a->b', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -789,7 +788,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('"func"()', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -808,7 +807,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('+ (x)', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -826,7 +825,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         self::assertSame('A B C', $generator->generate(GenerationPlan::fromRule('stmt')));
     }
@@ -840,7 +839,7 @@ final class SqlGeneratorTest extends TestCase
         ]);
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $result = $generator->generate(GenerationPlan::fromRule('stmt'));
 
@@ -853,7 +852,7 @@ final class SqlGeneratorTest extends TestCase
         $grammar = SqliteGrammar::load();
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $ref = new \ReflectionClass($generator);
         $prop = $ref->getProperty('grammar');
@@ -878,7 +877,7 @@ final class SqlGeneratorTest extends TestCase
         $grammar = SqliteGrammar::load();
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $ref = new \ReflectionClass($generator);
         $prop = $ref->getProperty('grammar');
@@ -903,7 +902,7 @@ final class SqlGeneratorTest extends TestCase
         $grammar = SqliteGrammar::load();
         $faker = Factory::create();
         $faker->seed(12345);
-        $generator = new SqlGenerator($grammar, $faker, new SqliteProvider($faker));
+        $generator = new SqlGenerator($grammar, $faker);
 
         $ref = new \ReflectionClass($generator);
         $prop = $ref->getProperty('grammar');
@@ -946,7 +945,7 @@ final class SqlGeneratorTest extends TestCase
 
         $faker = Factory::create();
         $provider = new SqliteProvider($faker);
-        $generator = new SqlGenerator($grammar, $faker, $provider);
+        $generator = new SqlGenerator($grammar, $faker);
 
         $invalid = array_filter(array_map(static function (int $seed) use ($faker, $generator, $reservedWords): ?string {
             $faker->seed($seed);

--- a/packages/sql-faker/tests/Unit/SqliteProviderTest.php
+++ b/packages/sql-faker/tests/Unit/SqliteProviderTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\SqlFaker;
 use Faker\Factory;
 use Faker\Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\TestCase;
 use SqlFaker\Grammar\GenerationPlan;
 use SqlFaker\Grammar\Grammar;
@@ -49,6 +50,7 @@ use SqlFaker\Grammar\TerminalInventory;
 #[UsesClass(SqlVersion::class)]
 #[UsesClass(TerminalInventory::class)]
 #[UsesClass(GenerationPlans::class)]
+#[Medium]
 final class SqliteProviderTest extends TestCase
 {
     #[DataProvider('providerTargetedGenerationSeed')]


### PR DESCRIPTION
## What

Extend the immutable GenerationPlan to represent one lexical generation target and its typed integer bounds, then route every Provider lexeme API through SqlGenerator::generate(GenerationPlan).

- Providers retain individual public methods for quoted identifiers, literals, parameter markers, and dialect-specific lexical values
- dialect GenerationPlans map each public method to a specific lexical target
- LexicalGrammar and RandomStringGenerator own the algorithms that produce valid lexemes
- SqlGenerator still exposes only generate; no generateQuotedIdentifier-style surface is added
- maxDepth, non-empty output, grammar range, production constraints, and lexeme constraints remain Plan-owned

## Why

Provider-owned lexeme construction bypassed the same generation contract used by grammar-derived SQL. Moving fixed payloads into special SqlGenerator methods would only relocate the responsibility error. A lexical request must be another Plan interpreted by the dialect generator.

## Recurrence prevention

PR #271 adds a PHPStan rule that permits Provider delegation only to SqlGenerator::generate with a GenerationPlan and rejects generation-target parameters, legacy generateRequired calls, special generateX methods, and Provider-owned SQL or lexeme construction.

## Verification

- SQLFaker: 2,022 tests / 6,493 assertions
- format and PHPStan: passed
- Reflection contract tests: MySQL, PostgreSQL, and SQLite SqlGenerator each expose only generate

Stack: agent/issue-zero-57-result-column-types -> agent/issue-zero-58-sqlfaker-lexeme-generation