### PR TITLE
feat(phpstan): guard dialect responsibility boundaries

### DIFF
--- a/packages/phpstan-custom-rules/extension.neon
+++ b/packages/phpstan-custom-rules/extension.neon
@@ -43,6 +43,16 @@ services:
         tags:
             - phpstan.rules.rule
 
+    customRules.rule.sqlFakerProviderDelegation:
+        class: ZtdQuery\PhpStanCustomRules\Rule\SqlFakerProviderDelegationRule
+        tags:
+            - phpstan.rules.rule
+
+    customRules.rule.noDialectLogicInCoreOrPdoAdapter:
+        class: ZtdQuery\PhpStanCustomRules\Rule\NoDialectLogicInCoreOrAdapterRule
+        tags:
+            - phpstan.rules.rule
+
     customRules.rule.noNonOverrideMethodInTestClass:
         class: ZtdQuery\PhpStanCustomRules\Rule\NoNonOverrideMethodInTestClassRule
         tags:

--- a/packages/phpstan-custom-rules/src/Rule/NoDialectLogicInCoreOrAdapterRule.php
+++ b/packages/phpstan-custom-rules/src/Rule/NoDialectLogicInCoreOrAdapterRule.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\PhpStanCustomRules\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\BinaryOp;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\InterpolatedStringPart;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\InterpolatedString;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Node>
+ */
+final class NoDialectLogicInCoreOrAdapterRule implements Rule
+{
+    /** @var list<string> */
+    private const DIALECT_NAMESPACES = [
+        'ZtdQuery\\Platform\\MySql\\',
+        'ZtdQuery\\Platform\\Postgres\\',
+        'ZtdQuery\\Platform\\Sqlite\\',
+    ];
+
+    /** @var list<string> */
+    private const DIALECT_METADATA_LITERALS = [
+        'mysql',
+        'pgsql',
+        'sqlite',
+        'native_type',
+        'sqlite:decl_type',
+        'pdo_type',
+        'flags',
+        'precision',
+        'driver',
+        'charsetnr',
+        'longlong',
+        'newdecimal',
+        'var_string',
+        'bpchar',
+        'int4',
+        'float8',
+        'bytea',
+        'jsonb',
+        'timestamptz',
+        'datetime2',
+    ];
+
+    private const SQL_RENDERING_PATTERN = '~(?:
+        \bROW_NUMBER\s*\(
+        | \bCAST\s*\(
+        | ^\s*(?:WITH|SELECT|FROM|WHERE|JOIN|AS)\s+$
+        | ^\s*NULL\s*$
+        | \bWITH\s+[^\s]+\s+AS\s*\(
+        | \bSELECT\s+.+\s+FROM\b
+        | \bINSERT\s+INTO\b
+        | \bUPDATE\s+[^\s]+\s+SET\b
+        | \bDELETE\s+FROM\b
+        | \b(?:CREATE|ALTER|DROP)\s+(?:TABLE|VIEW|INDEX|DATABASE|SCHEMA)\b
+    )~ix';
+
+    /** @var list<string> */
+    private const NATIVE_TYPE_NAMES = [
+        'TINYINT',
+        'SMALLINT',
+        'INTEGER',
+        'BIGINT',
+        'MEDIUMINT',
+        'YEAR',
+        'BIT',
+        'FLOAT',
+        'DOUBLE',
+        'DECIMAL',
+        'DATE',
+        'TIME',
+        'DATETIME',
+        'TIMESTAMP',
+        'JSON',
+        'BLOB',
+        'TEXT',
+        'VARCHAR',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    /** @return list<IdentifierRuleError> */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $class = $scope->getClassReflection();
+        if ($class === null) {
+            return [];
+        }
+        $className = $class->getName();
+        $pdoAdapter = str_starts_with($className, 'ZtdQuery\\Adapter\\Pdo\\');
+        $mysqliAdapter = str_starts_with($className, 'ZtdQuery\\Adapter\\Mysqli\\');
+        $adapter = $pdoAdapter || $mysqliAdapter;
+        $compositionRoot = strcmp($className, 'ZtdQuery\\Adapter\\Pdo\\ZtdPdo') === 0
+            || strcmp($className, 'ZtdQuery\\Adapter\\Mysqli\\ZtdMysqli') === 0;
+        $core = str_starts_with($className, 'ZtdQuery\\')
+            && !$adapter
+            && !str_starts_with($className, 'ZtdQuery\\PhpStanCustomRules\\')
+            && !$this->isDialectClass($className);
+        if (!$adapter && !$core) {
+            return [];
+        }
+
+        if (!$compositionRoot
+            && $node instanceof Name
+            && ($this->isDialectClass(ltrim($scope->resolveName($node), '\\'))
+                || $this->isDialectClass(ltrim($node->toString(), '\\')))
+        ) {
+            return $this->error($node);
+        }
+        if ($adapter && $node instanceof StaticCall
+            && $node->class instanceof Name
+            && $scope->resolveName($node->class) === 'ZtdQuery\\Sql\\SqlTokenStream'
+        ) {
+            return $this->error($node);
+        }
+        if ($mysqliAdapter && $node instanceof Name
+            && str_starts_with($node->toString(), 'MYSQLI_TYPE_')
+        ) {
+            return $this->error($node);
+        }
+        if ($mysqliAdapter && $this->isNumericMysqliTypeInterpretation($node)) {
+            return $this->error($node);
+        }
+
+        $literal = $this->literalValue($node);
+        if ($literal === null) {
+            return [];
+        }
+        $normalized = strtolower($literal);
+        if ($compositionRoot
+            && (in_array($normalized, ['mysql', 'pgsql', 'sqlite'], true)
+                || $this->isDialectClass(ltrim($literal, '\\')))
+        ) {
+            return [];
+        }
+        if ($this->isDialectClass(ltrim($literal, '\\'))
+            || in_array($normalized, self::DIALECT_METADATA_LITERALS, true)
+            || preg_match(self::SQL_RENDERING_PATTERN, $literal) === 1
+        ) {
+            return $this->error($node);
+        }
+
+        return [];
+    }
+
+    private function isDialectClass(string $className): bool
+    {
+        foreach (self::DIALECT_NAMESPACES as $namespace) {
+            if (str_starts_with($className, $namespace)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isNumericMysqliTypeInterpretation(Node $node): bool
+    {
+        if ($node instanceof Match_) {
+            $nativeMappings = 0;
+            foreach ($node->arms as $arm) {
+                foreach ($arm->conds ?? [] as $condition) {
+                    if ($condition instanceof Int_
+                        && $arm->body instanceof String_
+                        && in_array(strtoupper($arm->body->value), self::NATIVE_TYPE_NAMES, true)
+                    ) {
+                        $nativeMappings++;
+                    }
+                    if ($this->isTypeExpression($node->cond) && $condition instanceof Int_) {
+                        return true;
+                    }
+                }
+            }
+
+            return $nativeMappings >= 2;
+        }
+        if ($node instanceof BinaryOp) {
+            return ($node->left instanceof Int_ && $this->isTypeExpression($node->right))
+                || ($node->right instanceof Int_ && $this->isTypeExpression($node->left));
+        }
+        if (!$node instanceof Array_) {
+            return false;
+        }
+        $nativeMappings = 0;
+        foreach ($node->items as $item) {
+            if (!$item->key instanceof Int_ || !$item->value instanceof String_) {
+                continue;
+            }
+            if (in_array(strtoupper($item->value->value), self::NATIVE_TYPE_NAMES, true)) {
+                $nativeMappings++;
+            }
+        }
+
+        return $nativeMappings >= 2;
+    }
+
+    private function isTypeExpression(Expr $expr): bool
+    {
+        if ($expr instanceof Variable) {
+            return $expr->name === 'type' || $expr->name === 'fieldType';
+        }
+        if ($expr instanceof PropertyFetch && $expr->name instanceof Identifier) {
+            return $expr->name->name === 'type' || $expr->name->name === 'fieldType';
+        }
+        if (!$expr instanceof ArrayDimFetch || !$expr->dim instanceof String_) {
+            return false;
+        }
+
+        return $expr->dim->value === 'type';
+    }
+
+    private function literalValue(Node $node): ?string
+    {
+        if ($node instanceof String_ || $node instanceof InterpolatedStringPart) {
+            return $node->value;
+        }
+        if ($node instanceof InterpolatedString) {
+            return implode('', array_map(
+                static fn (Expr|InterpolatedStringPart $part): string => $part instanceof InterpolatedStringPart
+                    ? $part->value
+                    : '',
+                $node->parts,
+            ));
+        }
+        if (!$node instanceof Concat) {
+            return null;
+        }
+        $left = $this->literalValue($node->left);
+        $right = $this->literalValue($node->right);
+
+        return $left === null || $right === null ? null : $left . $right;
+    }
+
+    /** @return list<IdentifierRuleError> */
+    private function error(Node $node): array
+    {
+        return [RuleErrorBuilder::message(
+            'Core and database adapters must delegate dialect-specific parsing, rendering, and metadata interpretation through platform contracts.'
+        )
+            ->identifier('customRules.noDialectLogicInCoreOrAdapter')
+            ->line($node->getStartLine())
+            ->build()];
+    }
+}

--- a/packages/phpstan-custom-rules/src/Rule/NoFixedSqlStatementRule.php
+++ b/packages/phpstan-custom-rules/src/Rule/NoFixedSqlStatementRule.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace ZtdQuery\PhpStanCustomRules\Rule;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\InterpolatedStringPart;
 use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Scalar\String_;
@@ -18,16 +20,35 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 final class NoFixedSqlStatementRule implements Rule
 {
-    /** @var list<string> */
-    private const PROVIDERS = [
-        'MySqlProvider',
-        'PostgreSqlProvider',
-        'SqliteProvider',
-    ];
-
-    private const GENERATOR_PATTERN = '/^SqlFaker\\\\(?:MySql|PostgreSql|Sqlite)\\\\SqlGenerator$/';
-
-    private const STATEMENT_PATTERN = '/\b(?:WITH|SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|REPLACE|TRUNCATE|LOAD|MERGE|COPY|CALL|DO|EXPLAIN|VACUUM|PRAGMA|ATTACH|DETACH|GRANT|REVOKE)\b(?:\s+|(?=[(;]))/i';
+    private const STATEMENT_PATTERN = '~(?<![A-Za-z0-9_])(?:
+        WITH\s+[A-Za-z_][A-Za-z0-9_]*\s+AS\s*\(
+        | SELECT(?:
+            \s{2,}FROM\b
+            | \s+(?:
+                \*
+                | [0-9]+(?:\.[0-9]+)?
+                | [\'"`(]
+                | \$[0-9]+
+                | :[A-Za-z_][A-Za-z0-9_]*
+                | [A-Za-z_][A-Za-z0-9_.]*\s+(?:FROM|AS|,|\|\||[+*/-])
+            )
+        )
+        | INSERT\s+INTO\b
+        | UPDATE\s+[^\s,;)]+\s+SET\b
+        | DELETE\s+FROM\b
+        | CREATE\s+(?:TABLE|VIEW|INDEX|DATABASE|SCHEMA)\b
+        | ALTER\s+(?:TABLE|VIEW|DATABASE|SCHEMA)\b
+        | DROP\s+(?:TABLE|VIEW|INDEX|DATABASE|SCHEMA)\b
+        | REPLACE\s+INTO\b
+        | TRUNCATE(?:\s+TABLE)?\s+[^\s,;)]+
+        | LOAD\s+DATA\b
+        | MERGE\s+INTO\b
+        | COPY\s+[^\s,;)]+\s+(?:FROM|TO)\b
+        | (?:CALL|EXPLAIN|VACUUM|PRAGMA|ATTACH|DETACH|GRANT|REVOKE)\s+[^\s,;)]+
+        | FROM\s+[^\s,;)]+\s+WHERE\b
+        | JOIN\s+[^\s,;)]+\s+ON\b
+        | WHERE\s+[^\s,;)]+\s*(?:=|<>|!=|<|>)
+    )~ix';
 
     public function getNodeType(): string
     {
@@ -48,33 +69,60 @@ final class NoFixedSqlStatementRule implements Rule
         if (!str_starts_with($className, 'SqlFaker\\')) {
             return [];
         }
-        $separator = strrpos($className, '\\');
-        $shortName = $separator === false ? $className : substr($className, $separator + 1);
-        if (!in_array($shortName, self::PROVIDERS, true)
-            && ($shortName !== 'SqlGenerator' || preg_match(self::GENERATOR_PATTERN, $className) !== 1)
+        if (!$node instanceof String_
+            && !$node instanceof InterpolatedStringPart
+            && !$node instanceof InterpolatedString
+            && !$node instanceof Concat
         ) {
             return [];
         }
 
-        if (!$node instanceof String_ && !$node instanceof InterpolatedStringPart && !$node instanceof InterpolatedString) {
+        $value = $this->literalValue($node);
+        if ($value === null) {
             return [];
         }
-
-        $value = $node instanceof InterpolatedString
-            ? implode('', array_map(
-                static fn (Node\Expr|InterpolatedStringPart $part): string => $part instanceof InterpolatedStringPart ? $part->value : '',
-                $node->parts,
-            ))
-            : $node->value;
-        if (preg_match(self::STATEMENT_PATTERN, $value) !== 1) {
+        if (!$this->containsSqlTemplate($value)) {
             return [];
         }
 
         return [RuleErrorBuilder::message(
-            'SQLFaker Providers and SqlGenerators must not construct SQL statements from fixed templates; derive them from the dialect grammar.'
+            'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.'
         )
             ->identifier('customRules.noFixedSqlStatement')
             ->line($node->getStartLine())
             ->build()];
+    }
+
+    private function containsSqlTemplate(string $value): bool
+    {
+        $withoutBlockComments = preg_replace('~/\*.*?\*/~s', ' ', $value);
+        if ($withoutBlockComments === null) {
+            return false;
+        }
+        $withoutComments = preg_replace('/--[^\r\n]*/', ' ', $withoutBlockComments);
+
+        return $withoutComments !== null && preg_match(self::STATEMENT_PATTERN, $withoutComments) === 1;
+    }
+
+    private function literalValue(Node $node): ?string
+    {
+        if ($node instanceof String_ || $node instanceof InterpolatedStringPart) {
+            return $node->value;
+        }
+        if ($node instanceof InterpolatedString) {
+            return implode('', array_map(
+                static fn (Expr|InterpolatedStringPart $part): string => $part instanceof InterpolatedStringPart
+                    ? $part->value
+                    : '',
+                $node->parts,
+            ));
+        }
+        if (!$node instanceof Concat) {
+            return null;
+        }
+        $left = $this->literalValue($node->left);
+        $right = $this->literalValue($node->right);
+
+        return $left === null || $right === null ? null : $left . $right;
     }
 }

--- a/packages/phpstan-custom-rules/src/Rule/SqlFakerProviderDelegationRule.php
+++ b/packages/phpstan-custom-rules/src/Rule/SqlFakerProviderDelegationRule.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\PhpStanCustomRules\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Node>
+ */
+final class SqlFakerProviderDelegationRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $class = $scope->getClassReflection();
+        if ($class === null) {
+            if ($scope->getNamespace() !== 'SqlFaker') {
+                return [];
+            }
+        } else {
+            $className = $class->getName();
+            if (!str_starts_with($className, 'SqlFaker\\')) {
+                return [];
+            }
+            if (str_contains(substr($className, strlen('SqlFaker\\')), '\\')) {
+                return [];
+            }
+        }
+        if ($node instanceof Property) {
+            foreach ($node->props as $property) {
+                if ($property->name->name === 'sql'
+                    && (!$node->type instanceof \PhpParser\Node\Name
+                        || !str_ends_with($scope->resolveName($node->type), '\\SqlGenerator'))
+                ) {
+                    return [$this->error($node->getStartLine())];
+                }
+            }
+
+            return [];
+        }
+        if (!$node instanceof ClassMethod) {
+            return [];
+        }
+        if ($node->name->name === '__construct') {
+            return [];
+        }
+        foreach ($node->params as $parameter) {
+            if ($parameter->type instanceof Node && $this->containsGenerationTargetType($parameter->type)) {
+                return [$this->error($node->getStartLine())];
+            }
+        }
+        $statements = $node->stmts ?? [];
+        $statement = $statements[count($statements) - 1] ?? null;
+        if ($statement instanceof Return_
+            && $statement->expr !== null
+            && $this->isApprovedDelegation($statement->expr)
+        ) {
+            return [];
+        }
+
+        return [$this->error($statement?->getStartLine() ?? $node->getStartLine())];
+    }
+
+    private function error(int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(
+            'SQLFaker Providers must delegate generation to SqlGenerator::generate() with a GenerationPlan.'
+        )
+            ->identifier('customRules.sqlFakerProviderDelegation')
+            ->line($line)
+            ->build();
+    }
+
+    private function isApprovedDelegation(Expr $expr): bool
+    {
+        if ($expr instanceof Match_) {
+            foreach ($expr->arms as $arm) {
+                if (!$this->isApprovedDelegation($arm->body)) {
+                    return false;
+                }
+            }
+
+            return $expr->arms !== [];
+        }
+        if (!$expr instanceof MethodCall || !$expr->name instanceof Identifier) {
+            return false;
+        }
+        if ($expr->var instanceof Variable && $expr->var->name === 'this') {
+            return $expr->name->name !== 'generateRequired';
+        }
+        if (!$expr->var instanceof PropertyFetch
+            || !$expr->var->var instanceof Variable
+            || !$expr->var->name instanceof Identifier
+        ) {
+            return false;
+        }
+        $arguments = $expr->getArgs();
+
+        return $expr->var->var->name === 'this'
+            && $expr->var->name->name === 'sql'
+            && $expr->name->name === 'generate'
+            && count($arguments) === 1
+            && $this->isGenerationPlan($arguments[0]->value);
+    }
+
+    private function containsGenerationTargetType(Node $node): bool
+    {
+        if (($node instanceof Identifier || $node instanceof \PhpParser\Node\Name)
+            && str_ends_with($node->toString(), 'GenerationTarget')
+        ) {
+            return true;
+        }
+        $subNodes = get_object_vars($node);
+        foreach ($node->getSubNodeNames() as $name) {
+            $child = $subNodes[$name] ?? null;
+            if ($child instanceof Node && $this->containsGenerationTargetType($child)) {
+                return true;
+            }
+            if (!is_array($child)) {
+                continue;
+            }
+            foreach ($child as $item) {
+                if ($item instanceof Node && $this->containsGenerationTargetType($item)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function isGenerationPlan(Expr $expr): bool
+    {
+        if ($expr instanceof Variable) {
+            return true;
+        }
+        if ($expr instanceof MethodCall) {
+            return $this->isGenerationPlan($expr->var);
+        }
+        if (!$expr instanceof StaticCall || !$expr->class instanceof \PhpParser\Node\Name) {
+            return false;
+        }
+        $class = $expr->class->toString();
+
+        return str_ends_with($class, 'GenerationPlan') || str_ends_with($class, 'GenerationPlans');
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/CompositionRootNameCollisionFixture.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/CompositionRootNameCollisionFixture.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Pdo\Nested;
+
+final class ZtdPdo
+{
+    public function driver(): string
+    {
+        return 'mysql';
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/CoreDialectDependencyFixture.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/CoreDialectDependencyFixture.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery;
+
+final class CoreDialectDependencyFixture
+{
+    public function parserClass(): string
+    {
+        return \ZtdQuery\Platform\Postgres\PgSqlParser::class;
+    }
+
+    public function nativeDriverType(): string
+    {
+        return 'LONGLONG';
+    }
+
+    public function renderedCast(string $value): string
+    {
+        return 'CAST(' . $value . ' AS INTEGER)';
+    }
+
+    public function renderedIdentity(int $next): string
+    {
+        return $next . ' + ROW_NUMBER() OVER () - 1';
+    }
+
+    public function renderedInsertSelect(string $name, string $select): string
+    {
+        return 'WITH ' . $name . ' AS (' . $select . ') SELECT value FROM ' . $name;
+    }
+
+    public function splitDialectClass(): string
+    {
+        return 'ZtdQuery\\Platform\\Post' . 'gres\\PgSqlParser';
+    }
+
+    public function splitMetadataKey(): string
+    {
+        return 'nat' . 'ive_type';
+    }
+
+    /** @param array<string, mixed> $metadata */
+    public function metadata(array $metadata): array
+    {
+        return [
+            $metadata['pdo_type'],
+            $metadata['flags'],
+            $metadata['precision'],
+            $metadata['driver'],
+        ];
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/DelegatingProviders.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/DelegatingProviders.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SqlFaker;
+
+final class MySqlProvider
+{
+    private \SqlFaker\MySql\SqlGenerator $sql;
+
+    public function quotedIdentifier(): string
+    {
+        return $this->sql->generate(\SqlFaker\MySql\GenerationPlans::quotedIdentifier(1, 64));
+    }
+
+    public function statement(?string $type): string
+    {
+        return match ($type) {
+            null => $this->sql->generate(\SqlFaker\Grammar\GenerationPlan::all()),
+            default => $this->sql->generate(\SqlFaker\Grammar\GenerationPlan::fromRule('select_stmt')),
+        };
+    }
+
+    public function keyword(): string
+    {
+        return $this->sql->generate('CASCADE');
+    }
+
+    public function byTarget(MySqlGenerationTarget $target): string
+    {
+        return match ($target) {
+            default => $this->sql->generate(\SqlFaker\Grammar\GenerationPlan::fromRule('select_stmt')),
+        };
+    }
+}
+
+final class PostgreSqlProvider
+{
+    private \SqlFaker\PostgreSql\SqlGenerator $sql;
+
+    public function statement(): string
+    {
+        return $this->generateRequired('SelectStmt');
+    }
+
+    public function genericStatement(): string
+    {
+        return $this->sql->generate('SelectStmt');
+    }
+}
+
+final class SqliteProvider
+{
+    private \SqlFaker\Sqlite\SqlGenerator $sql;
+
+    public function statement(): string
+    {
+        $sql = $this->sql->generate('cmd');
+
+        return $sql;
+    }
+}
+
+final class TemplateProvider
+{
+    private \SqlFaker\MySql\TemplateBank $sql;
+
+    public function statement(): string
+    {
+        return $this->sql->generateSelectStatement();
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/MysqliAdapterBoundaryFixture.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/MysqliAdapterBoundaryFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Mysqli;
+
+use ZtdQuery\Platform\MySql\MySqlSessionFactory;
+
+final class ZtdMysqli
+{
+    public function factory(): MySqlSessionFactory
+    {
+        return new MySqlSessionFactory();
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/MysqliDialectLogicFixture.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/MysqliDialectLogicFixture.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Mysqli;
+
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class MysqliDialectLogicFixture
+{
+    public function resolverClass(): string
+    {
+        return \ZtdQuery\Platform\MySql\MySqlMysqliResultColumnTypeResolver::class;
+    }
+
+    public function fieldType(): int
+    {
+        return MYSQLI_TYPE_LONG;
+    }
+
+    public function charsetKey(): string
+    {
+        return 'charsetnr';
+    }
+
+    public function tokens(string $sql): SqlTokenStream
+    {
+        return SqlTokenStream::tokenize($sql);
+    }
+
+    /** @param object{type: int} $field */
+    public function numericType(object $field): string
+    {
+        return match ($field->type) {
+            3 => 'INTEGER',
+            8 => 'BIGINT',
+            default => '',
+        };
+    }
+
+    /** @return array<int, string> */
+    public function numericTypeMap(): array
+    {
+        return [3 => 'INTEGER', 8 => 'BIGINT'];
+    }
+
+    public function comparesNumericType(int $type): bool
+    {
+        return $type === 3;
+    }
+
+    public function numericProtocolType(int $protocolCode): string
+    {
+        return match ($protocolCode) {
+            3 => 'INTEGER',
+            8 => 'BIGINT',
+            default => '',
+        };
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/PdoAdapterBoundaryFixture.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/PdoAdapterBoundaryFixture.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Pdo;
+
+final class ZtdPdo
+{
+    private const DRIVER_MAP = [
+        'mysql' => 'factory',
+        'pgsql' => 'factory',
+        'sqlite' => 'factory',
+    ];
+
+    public function platformClass(): string
+    {
+        return 'ZtdQuery\\Platform\\MySql\\MySqlSessionFactory';
+    }
+}
+
+final class PdoStatement
+{
+    /** @param array<string, mixed> $metadata */
+    public function nativeType(array $metadata): mixed
+    {
+        return $metadata['native_type'];
+    }
+}
+
+final class DynamicDialectReference
+{
+    public function className(): string
+    {
+        return 'ZtdQuery\\Platform\\MySql\\MySqlSessionFactory';
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/PdoDialectLogicFixture.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/PdoDialectLogicFixture.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Pdo;
+
+use ZtdQuery\Sql\SqlTokenStream;
+
+final class PdoDialectLogicFixture
+{
+    public function isPostgreSql(string $driver): bool
+    {
+        return $driver === 'pgsql';
+    }
+
+    /** @param array<string, mixed> $metadata */
+    public function sqliteType(array $metadata): mixed
+    {
+        return $metadata['sqlite:decl_type'];
+    }
+
+    public function tokens(string $sql): SqlTokenStream
+    {
+        return SqlTokenStream::tokenize($sql);
+    }
+
+    public function sqliteCast(string $value): string
+    {
+        return 'CAST(' . $value . ' AS INTEGER)';
+    }
+
+    public function pgType(): string
+    {
+        return 'BPCHAR';
+    }
+
+    public function dynamicDialectClass(): string
+    {
+        return 'ZtdQuery\\Platform\\Sqlite\\SqliteParser';
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/SqlFaker/FutureProvider.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/SqlFaker/FutureProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SqlFaker;
+
+final class FutureSqlFaker
+{
+    public function statement(): string
+    {
+        return 'future implementation';
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/SqlFaker/MySql/StatementTemplateHelper.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/SqlFaker/MySql/StatementTemplateHelper.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SqlFaker\MySql;
+
+final class StatementTemplateHelper
+{
+    public function statement(): string
+    {
+        return 'SELECT id FROM users';
+    }
+
+    public function splitStatement(): string
+    {
+        return 'SEL' . 'ECT id FROM users';
+    }
+
+    public function parenthesizedStatement(): string
+    {
+        return '(SELECT id FROM users)';
+    }
+
+    public function statementAfterComment(): string
+    {
+        return '/* fixture */ SELECT id FROM users';
+    }
+
+    public function embeddedStatement(): string
+    {
+        return 'value = (SELECT id FROM users)';
+    }
+
+    public function clauseFragment(): string
+    {
+        return ' FROM users WHERE id = 1';
+    }
+
+    public function lexicalSequence(): string
+    {
+        return implode(' ', ['SELECT', 'FROM', 'WHERE']);
+    }
+
+    public function diagnostic(): string
+    {
+        return 'Cannot select a lexical profile from the catalog.';
+    }
+
+    public function multiwordTerminal(): string
+    {
+        return 'WITH ROLLUP';
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Unit/Rule/NoDialectLogicInCoreOrAdapterRuleTest.php
+++ b/packages/phpstan-custom-rules/tests/Unit/Rule/NoDialectLogicInCoreOrAdapterRuleTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Medium;
+use ZtdQuery\PhpStanCustomRules\Rule\NoDialectLogicInCoreOrAdapterRule;
+
+/**
+ * @extends RuleTestCase<NoDialectLogicInCoreOrAdapterRule>
+ */
+#[CoversClass(NoDialectLogicInCoreOrAdapterRule::class)]
+#[Medium]
+final class NoDialectLogicInCoreOrAdapterRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoDialectLogicInCoreOrAdapterRule();
+    }
+
+    public function testRejectsDialectLogicInCoreAndAdapters(): void
+    {
+        $message = 'Core and database adapters must delegate dialect-specific parsing, rendering, and metadata interpretation through platform contracts.';
+
+        $this->analyse([
+            __DIR__ . '/../../Fixture/PdoDialectLogicFixture.php',
+            __DIR__ . '/../../Fixture/MysqliDialectLogicFixture.php',
+            __DIR__ . '/../../Fixture/CoreDialectDependencyFixture.php',
+            __DIR__ . '/../../Fixture/PdoAdapterBoundaryFixture.php',
+            __DIR__ . '/../../Fixture/MysqliAdapterBoundaryFixture.php',
+            __DIR__ . '/../../Fixture/CompositionRootNameCollisionFixture.php',
+        ], [
+            [$message, 11],
+            [$message, 11],
+            [$message, 13],
+            [$message, 13],
+            [$message, 16],
+            [$message, 18],
+            [$message, 19],
+            [$message, 21],
+            [$message, 23],
+            [$message, 24],
+            [$message, 26],
+            [$message, 26],
+            [$message, 28],
+            [$message, 29],
+            [$message, 31],
+            [$message, 31],
+            [$message, 34],
+            [$message, 34],
+            [$message, 34],
+            [$message, 36],
+            [$message, 39],
+            [$message, 41],
+            [$message, 44],
+            [$message, 48],
+            [$message, 49],
+            [$message, 49],
+            [$message, 50],
+            [$message, 51],
+            [$message, 54],
+        ]);
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Unit/Rule/NoFixedSqlStatementRuleTest.php
+++ b/packages/phpstan-custom-rules/tests/Unit/Rule/NoFixedSqlStatementRuleTest.php
@@ -24,18 +24,25 @@ final class NoFixedSqlStatementRuleTest extends RuleTestCase
 
     public function testDetectsFixedSqlConstructionInProvidersAndGenerators(): void
     {
-        $message = 'SQLFaker Providers and SqlGenerators must not construct SQL statements from fixed templates; derive them from the dialect grammar.';
+        $message = 'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.';
 
         $this->analyse([
             __DIR__ . '/../../Fixture/MySqlProvider.php',
             __DIR__ . '/../../Fixture/PostgreSqlProvider.php',
             __DIR__ . '/../../Fixture/SqliteProvider.php',
             __DIR__ . '/../../Fixture/MySql/SqlGenerator.php',
+            __DIR__ . '/../../Fixture/SqlFaker/MySql/StatementTemplateHelper.php',
             __DIR__ . '/../../Fixture/Other/MySqlProvider.php',
         ], [
             [$message, 11],
             [$message, 11],
             [$message, 11],
+            [$message, 11],
+            [$message, 16],
+            [$message, 21],
+            [$message, 26],
+            [$message, 31],
+            [$message, 36],
         ]);
     }
 }

--- a/packages/phpstan-custom-rules/tests/Unit/Rule/SqlFakerProviderDelegationRuleTest.php
+++ b/packages/phpstan-custom-rules/tests/Unit/Rule/SqlFakerProviderDelegationRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Medium;
+use ZtdQuery\PhpStanCustomRules\Rule\SqlFakerProviderDelegationRule;
+
+/**
+ * @extends RuleTestCase<SqlFakerProviderDelegationRule>
+ */
+#[CoversClass(SqlFakerProviderDelegationRule::class)]
+#[Medium]
+final class SqlFakerProviderDelegationRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new SqlFakerProviderDelegationRule();
+    }
+
+    public function testRejectsProviderOwnedSqlAndLexemeConstruction(): void
+    {
+        $message = 'SQLFaker Providers must delegate generation to SqlGenerator::generate() with a GenerationPlan.';
+
+        $this->analyse([
+            __DIR__ . '/../../Fixture/MySqlProvider.php',
+            __DIR__ . '/../../Fixture/PostgreSqlProvider.php',
+            __DIR__ . '/../../Fixture/SqliteProvider.php',
+            __DIR__ . '/../../Fixture/Other/MySqlProvider.php',
+            __DIR__ . '/../../Fixture/DelegatingProviders.php',
+            __DIR__ . '/../../Fixture/SqlFaker/FutureProvider.php',
+        ], [
+            [$message, 11],
+            [$message, 11],
+            [$message, 11],
+            [$message, 26],
+            [$message, 29],
+            [$message, 43],
+            [$message, 48],
+            [$message, 60],
+            [$message, 66],
+            [$message, 70],
+            [$message, 11],
+        ]);
+    }
+}

--- a/packages/ztd-query-core/src/Shadow/Mutation/CreateTableAsSelectMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/CreateTableAsSelectMutation.php
@@ -73,7 +73,7 @@ final class CreateTableAsSelectMutation implements ResultSetMutation
             $columns = array_keys($result->rows[0]);
         }
         if ($columns === []) {
-            throw new \RuntimeException("Cannot determine columns for CREATE TABLE AS SELECT.");
+            throw new \RuntimeException("Cannot determine result columns for virtual table '{$this->tableName}'.");
         }
 
         $columnTypes = [];

--- a/packages/ztd-query-core/src/Shadow/Mutation/CreateTableMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/CreateTableMutation.php
@@ -18,23 +18,27 @@ final class CreateTableMutation implements ShadowMutation
     private string $tableName;
     private ?TableDefinition $definition;
     private TableDefinitionRegistry $registry;
+    private string $sourceSql;
     private bool $ifNotExists;
 
     /**
      * @param string $tableName The name of the table to create.
      * @param TableDefinition|null $definition The parsed table definition.
      * @param TableDefinitionRegistry $registry The registry to register the table.
+     * @param string $sourceSql The source statement supplied by the database package.
      * @param bool $ifNotExists Whether to skip if table exists.
      */
     public function __construct(
         string $tableName,
         ?TableDefinition $definition,
         TableDefinitionRegistry $registry,
+        string $sourceSql,
         bool $ifNotExists = false
     ) {
         $this->tableName = $tableName;
         $this->definition = $definition;
         $this->registry = $registry;
+        $this->sourceSql = $sourceSql;
         $this->ifNotExists = $ifNotExists;
     }
 
@@ -47,7 +51,7 @@ final class CreateTableMutation implements ShadowMutation
             if ($this->ifNotExists) {
                 return;
             }
-            throw new TableAlreadyExistsException("CREATE TABLE `{$this->tableName}`", $this->tableName);
+            throw new TableAlreadyExistsException($this->sourceSql, $this->tableName);
         }
 
         if ($this->definition !== null) {

--- a/packages/ztd-query-core/src/Shadow/Mutation/DropTableMutation.php
+++ b/packages/ztd-query-core/src/Shadow/Mutation/DropTableMutation.php
@@ -16,15 +16,18 @@ final class DropTableMutation implements ShadowMutation
 {
     private string $tableName;
     private TableDefinitionRegistry $registry;
+    private string $sourceSql;
     private bool $ifExists;
 
     public function __construct(
         string $tableName,
         TableDefinitionRegistry $registry,
+        string $sourceSql,
         bool $ifExists = false
     ) {
         $this->tableName = $tableName;
         $this->registry = $registry;
+        $this->sourceSql = $sourceSql;
         $this->ifExists = $ifExists;
     }
 
@@ -37,7 +40,7 @@ final class DropTableMutation implements ShadowMutation
             if ($this->ifExists) {
                 return;
             }
-            throw new SchemaNotFoundException("DROP TABLE `{$this->tableName}`", $this->tableName);
+            throw new SchemaNotFoundException($this->sourceSql, $this->tableName);
         }
 
         $this->registry->markRemoved($this->tableName);

--- a/packages/ztd-query-core/tests/Fake/FakeSqlRewriter.php
+++ b/packages/ztd-query-core/tests/Fake/FakeSqlRewriter.php
@@ -229,7 +229,8 @@ final class FakeSqlRewriter implements SqlRewriter
             $mutation = new CreateTableMutation(
                 $tableName,
                 $definition ?? new TableDefinition([], [], [], [], []),
-                $this->registry
+                $this->registry,
+                $sql,
             );
 
             return new RewritePlan('SELECT 1 WHERE FALSE', QueryKind::DDL_SIMULATED, $mutation);
@@ -237,7 +238,7 @@ final class FakeSqlRewriter implements SqlRewriter
 
         if (str_starts_with($upper, 'DROP TABLE')) {
             $tableName = $this->extractTableFromDrop($sql) ?? 'unknown';
-            $mutation = new DropTableMutation($tableName, $this->registry);
+            $mutation = new DropTableMutation($tableName, $this->registry, $sql);
 
             return new RewritePlan('SELECT 1 WHERE FALSE', QueryKind::DDL_SIMULATED, $mutation);
         }

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/CreateTableMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/CreateTableMutationTest.php
@@ -32,7 +32,7 @@ final class CreateTableMutationTest extends TestCase
             ['id'],
             [],
         );
-        $mutation = new CreateTableMutation('users', $definition, $registry);
+        $mutation = new CreateTableMutation('users', $definition, $registry, 'fixture statement');
         $mutation->apply($store, []);
 
         self::assertNotNull($registry->get('users'));
@@ -51,7 +51,7 @@ final class CreateTableMutationTest extends TestCase
             ['id'],
             [],
         );
-        $mutation = new CreateTableMutation('users', $definition, $registry);
+        $mutation = new CreateTableMutation('users', $definition, $registry, 'fixture statement');
         $mutation->apply($store, []);
 
         self::assertSame([], $store->get('users'));
@@ -67,7 +67,7 @@ final class CreateTableMutationTest extends TestCase
             ['id'],
             [],
         );
-        $mutation = new CreateTableMutation('users', $definition, $registry);
+        $mutation = new CreateTableMutation('users', $definition, $registry, 'fixture statement');
 
         self::assertSame('users', $mutation->tableName());
     }
@@ -92,12 +92,15 @@ final class CreateTableMutationTest extends TestCase
             ['id'],
             [],
         );
-        $mutation = new CreateTableMutation('users', $newDefinition, $registry);
+        $mutation = new CreateTableMutation('users', $newDefinition, $registry, 'fixture statement');
 
-        $this->expectException(TableAlreadyExistsException::class);
-        $this->expectExceptionMessage("Table 'users' already exists.");
-
-        $mutation->apply($store, []);
+        try {
+            $mutation->apply($store, []);
+            self::fail('Expected duplicate virtual table creation to fail.');
+        } catch (TableAlreadyExistsException $exception) {
+            self::assertSame("Table 'users' already exists.", $exception->getMessage());
+            self::assertSame('fixture statement', $exception->getSql());
+        }
     }
 
     public function testApplyWithIfNotExistsSkipsWhenTableExists(): void
@@ -120,7 +123,7 @@ final class CreateTableMutationTest extends TestCase
             ['id'],
             [],
         );
-        $mutation = new CreateTableMutation('users', $newDefinition, $registry, true);
+        $mutation = new CreateTableMutation('users', $newDefinition, $registry, 'fixture statement', true);
         $mutation->apply($store, []);
 
         $def = $registry->get('users');
@@ -140,7 +143,7 @@ final class CreateTableMutationTest extends TestCase
             ['id'],
             [],
         );
-        $mutation = new CreateTableMutation('users', $definition, $registry, true);
+        $mutation = new CreateTableMutation('users', $definition, $registry, 'fixture statement', true);
         $mutation->apply($store, []);
 
         self::assertNotNull($registry->get('users'));

--- a/packages/ztd-query-core/tests/Unit/Shadow/Mutation/DropTableMutationTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/Mutation/DropTableMutationTest.php
@@ -34,7 +34,7 @@ final class DropTableMutationTest extends TestCase
         $store = new ShadowStore();
         $store->set('users', [['id' => 1]]);
 
-        $mutation = new DropTableMutation('users', $registry);
+        $mutation = new DropTableMutation('users', $registry, 'fixture statement');
         $mutation->apply($store, []);
 
         self::assertNull($registry->get('users'));
@@ -56,7 +56,7 @@ final class DropTableMutationTest extends TestCase
         $store = new ShadowStore();
         $store->set('users', [['id' => 1], ['id' => 2]]);
 
-        $mutation = new DropTableMutation('users', $registry);
+        $mutation = new DropTableMutation('users', $registry, 'fixture statement');
         $mutation->apply($store, []);
 
         self::assertSame([], $store->get('users'));
@@ -65,7 +65,7 @@ final class DropTableMutationTest extends TestCase
     public function testTableNameReturnsTableName(): void
     {
         $registry = new TableDefinitionRegistry();
-        $mutation = new DropTableMutation('users', $registry);
+        $mutation = new DropTableMutation('users', $registry, 'fixture statement');
 
         self::assertSame('users', $mutation->tableName());
     }
@@ -75,12 +75,15 @@ final class DropTableMutationTest extends TestCase
         $registry = new TableDefinitionRegistry();
         $store = new ShadowStore();
 
-        $mutation = new DropTableMutation('users', $registry);
+        $mutation = new DropTableMutation('users', $registry, 'fixture statement');
 
-        $this->expectException(SchemaNotFoundException::class);
-        $this->expectExceptionMessage("Table 'users' does not exist.");
-
-        $mutation->apply($store, []);
+        try {
+            $mutation->apply($store, []);
+            self::fail('Expected an unknown virtual table to fail.');
+        } catch (SchemaNotFoundException $exception) {
+            self::assertSame("Table 'users' does not exist.", $exception->getMessage());
+            self::assertSame('fixture statement', $exception->getSql());
+        }
     }
 
     public function testApplyWithIfExistsSkipsWhenTableDoesNotExist(): void
@@ -88,7 +91,7 @@ final class DropTableMutationTest extends TestCase
         $registry = new TableDefinitionRegistry();
         $store = new ShadowStore();
 
-        $mutation = new DropTableMutation('users', $registry, true);
+        $mutation = new DropTableMutation('users', $registry, 'fixture statement', true);
 
         $mutation->apply($store, []);
 
@@ -109,7 +112,7 @@ final class DropTableMutationTest extends TestCase
         $store = new ShadowStore();
         $store->set('users', [['id' => 1]]);
 
-        $mutation = new DropTableMutation('users', $registry, true);
+        $mutation = new DropTableMutation('users', $registry, 'fixture statement', true);
         $mutation->apply($store, []);
 
         self::assertNull($registry->get('users'));

--- a/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
+++ b/packages/ztd-query-core/tests/Unit/Shadow/ReferentialIntegrityEnforcerTest.php
@@ -352,7 +352,7 @@ final class ReferentialIntegrityEnforcerTest extends TestCase
         (new ReferentialIntegrityEnforcer($registry))->synchronize(
             $store->snapshot(),
             $store,
-            new CreateTableMutation('archive', null, $registry),
+            new CreateTableMutation('archive', null, $registry, 'fixture statement'),
             [],
             'CREATE TABLE archive',
         );

--- a/packages/ztd-query-mysql/src/MySqlMutationResolver.php
+++ b/packages/ztd-query-mysql/src/MySqlMutationResolver.php
@@ -322,7 +322,7 @@ final class MySqlMutationResolver
         }
 
         $definition = $this->schemaParser->parse($sql);
-        return new CreateTableMutation($tableName, $definition, $this->registry, $ifNotExists);
+        return new CreateTableMutation($tableName, $definition, $this->registry, $sql, $ifNotExists);
     }
 
     /**
@@ -347,7 +347,7 @@ final class MySqlMutationResolver
             throw new UnknownSchemaException($sql, $tableName, 'table');
         }
 
-        return new DropTableMutation($tableName, $this->registry, $ifExists);
+        return new DropTableMutation($tableName, $this->registry, $sql, $ifExists);
     }
 
     private function resolveAlterTable(AlterStatement $statement, string $sql): ShadowMutation

--- a/packages/ztd-query-mysqli-adapter/phpstan.neon
+++ b/packages/ztd-query-mysqli-adapter/phpstan.neon
@@ -36,7 +36,7 @@ parameters:
         # Related issue: https://github.com/phpstan/phpstan/issues/2553
         #
         # TODO: Remove this excludePath once PHPStan fixes the functionMap for bind_param.
-        - src/ZtdMysqliStatement.php
+        - src/MysqliStatementBindingBridge.php
     ignoreErrors:
         -
             message: '#Line comments using // are prohibited#'

--- a/packages/ztd-query-mysqli-adapter/src/MysqliResultStatement.php
+++ b/packages/ztd-query-mysqli-adapter/src/MysqliResultStatement.php
@@ -20,10 +20,11 @@ final class MysqliResultStatement implements StatementInterface
 
     private int $affectedRows;
 
-    public function __construct(?mysqli_result $result, int $affectedRows)
+    public function __construct(?mysqli_result $result, int|string $affectedRows)
     {
         $this->result = $result;
-        $this->affectedRows = $affectedRows;
+        $normalizedAffectedRows = filter_var($affectedRows, FILTER_VALIDATE_INT);
+        $this->affectedRows = $normalizedAffectedRows === false ? PHP_INT_MAX : $normalizedAffectedRows;
     }
 
     /**

--- a/packages/ztd-query-mysqli-adapter/src/MysqliStatementBindingBridge.php
+++ b/packages/ztd-query-mysqli-adapter/src/MysqliStatementBindingBridge.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Mysqli;
+
+use mysqli_stmt;
+
+/**
+ * Isolates native mysqli by-reference signatures that PHPStan models incorrectly.
+ */
+abstract class MysqliStatementBindingBridge extends mysqli_stmt
+{
+    private mysqli_stmt $bindingDelegate;
+
+    public function __construct(mysqli_stmt $bindingDelegate)
+    {
+        $this->bindingDelegate = $bindingDelegate;
+    }
+
+    /** @param mixed ...$vars */
+    final public function bind_param(string $types, mixed &...$vars): bool
+    {
+        return $this->bindingDelegate->bind_param($types, ...$vars);
+    }
+
+    final public function bind_result(mixed &...$vars): bool
+    {
+        return $this->bindingDelegate->bind_result(...$vars);
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/src/ZtdMysqliStatement.php
+++ b/packages/ztd-query-mysqli-adapter/src/ZtdMysqliStatement.php
@@ -23,7 +23,7 @@ use ZtdQuery\Session;
  *
  * Properties are delegated via __get/__isset to the delegate instance.
  */
-final class ZtdMysqliStatement extends mysqli_stmt
+final class ZtdMysqliStatement extends MysqliStatementBindingBridge
 {
     /**
      * Inner mysqli_stmt to delegate operations to.
@@ -53,13 +53,11 @@ final class ZtdMysqliStatement extends mysqli_stmt
 
     public function __construct(mysqli_stmt $delegate, Session $session, ?RewritePlan $plan)
     {
-        // Do not call parent constructor
+        parent::__construct($delegate);
         $this->delegate = $delegate;
         $this->session = $session;
         $this->plan = $plan;
     }
-
-    // === Property delegation via __get/__isset ===
 
     /**
      * Delegate property access to the delegate instance.
@@ -84,7 +82,19 @@ final class ZtdMysqliStatement extends mysqli_stmt
             }
         }
 
-        return $this->delegate->{$name};
+        return match ($name) {
+            'affected_rows' => $this->delegate->affected_rows,
+            'insert_id' => $this->delegate->insert_id,
+            'num_rows' => $this->delegate->num_rows,
+            'param_count' => $this->delegate->param_count,
+            'field_count' => $this->delegate->field_count,
+            'errno' => $this->delegate->errno,
+            'error' => $this->delegate->error,
+            'error_list' => $this->delegate->error_list,
+            'sqlstate' => $this->delegate->sqlstate,
+            'id' => $this->delegate->id,
+            default => null,
+        };
     }
 
     /**
@@ -92,7 +102,18 @@ final class ZtdMysqliStatement extends mysqli_stmt
      */
     public function __isset(string $name): bool
     {
-        return isset($this->delegate->{$name});
+        return in_array($name, [
+            'affected_rows',
+            'insert_id',
+            'num_rows',
+            'param_count',
+            'field_count',
+            'errno',
+            'error',
+            'error_list',
+            'sqlstate',
+            'id',
+        ], true);
     }
 
     /**
@@ -114,37 +135,15 @@ final class ZtdMysqliStatement extends mysqli_stmt
         return (int) $this->delegate->affected_rows;
     }
 
-    // === mysqli_stmt methods - all explicitly overridden for delegation ===
-
-    /**
-     * Bind parameters to the statement.
-     *
-     * @param string $types Type specification string (i=int, d=double, s=string, b=blob)
-     * @param mixed ...$vars Variables to bind (by reference)
-     */
-    public function bind_param(string $types, mixed &...$vars): bool
-    {
-        return $this->delegate->bind_param($types, ...$vars);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function bind_result(mixed &...$vars): bool
-    {
-        return $this->delegate->bind_result(...$vars);
-    }
-
     /**
      * Execute the statement, applying ZTD simulation as needed.
      *
-     * @param array<int, mixed>|null $params Optional parameters to bind (PHP 8.1+).
+     * @param array<mixed, mixed>|null $params Optional parameters to bind (PHP 8.1+).
      */
     public function execute(?array $params = null): bool
     {
         $this->result = null;
 
-        // No plan means ZTD was disabled at prepare time (shouldn't happen with new design)
         if ($this->plan === null) {
             if ($params !== null) {
                 return $this->delegate->execute($params);
@@ -152,12 +151,10 @@ final class ZtdMysqliStatement extends mysqli_stmt
             return $this->delegate->execute();
         }
 
-        // SKIPPED: do not execute, return false
         if (!$this->session->shouldExecute($this->plan)) {
             return false;
         }
 
-        // READ: execute directly (includes passthrough cases)
         if (!$this->session->needsPostProcessing($this->plan)) {
             if ($params !== null) {
                 return $this->delegate->execute($params);
@@ -165,7 +162,6 @@ final class ZtdMysqliStatement extends mysqli_stmt
             return $this->delegate->execute();
         }
 
-        // WRITE_SIMULATED/DDL_SIMULATED: execute and process result
         if ($params !== null) {
             if (!$this->delegate->execute($params)) {
                 return false;
@@ -176,7 +172,6 @@ final class ZtdMysqliStatement extends mysqli_stmt
             }
         }
 
-        // Get the result set and cache it for later get_result() calls
         $this->cachedMysqliResult = $this->delegate->get_result();
 
         if ($this->cachedMysqliResult !== false) {
@@ -189,7 +184,6 @@ final class ZtdMysqliStatement extends mysqli_stmt
                 throw new ZtdMysqliException($e->getMessage(), 0, $e);
             }
         } else {
-            // No result set (e.g., for WRITE operations that don't return rows)
             $this->result = $this->session->createEmptyWriteResult();
         }
 
@@ -201,16 +195,13 @@ final class ZtdMysqliStatement extends mysqli_stmt
      */
     public function get_result(): mysqli_result|false
     {
-        // If we have a cached result from ZTD execution, return it
         if ($this->cachedMysqliResult !== null) {
             $result = $this->cachedMysqliResult;
-            // Clear the cache so subsequent calls go to delegate
             $this->cachedMysqliResult = null;
 
             return $result;
         }
 
-        // For ZTD results without cached mysqli_result (WRITE/DDL operations)
         if ($this->result !== null && !$this->result->isPassthrough()) {
             if (!$this->result->hasResultSet()) {
                 return false;
@@ -226,13 +217,11 @@ final class ZtdMysqliStatement extends mysqli_stmt
     public function fetch(): ?bool
     {
         if ($this->result !== null && !$this->result->isPassthrough()) {
-            // WRITE/DDL operations don't return result sets in standard mysqli
             if (!$this->result->hasResultSet()) {
                 return null;
             }
         }
 
-        // For READ queries: delegate to statement (prepared with rewritten SQL)
         return $this->delegate->fetch();
     }
 
@@ -293,7 +282,12 @@ final class ZtdMysqliStatement extends mysqli_stmt
      */
     public function attr_get(int $attribute): int
     {
-        return $this->delegate->attr_get($attribute);
+        $value = $this->delegate->attr_get($attribute);
+        if ($value === false) {
+            throw new ZtdMysqliException('Unable to read the mysqli statement attribute.');
+        }
+
+        return $value;
     }
 
     /**
@@ -355,4 +349,5 @@ final class ZtdMysqliStatement extends mysqli_stmt
     {
         return $this->delegate->send_long_data($param_num, $data);
     }
+
 }

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultStatementTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultStatementTest.php
@@ -70,6 +70,13 @@ final class MysqliResultStatementTest extends TestCase
         self::assertSame(0, $stmt->rowCount());
     }
 
+    public function testSaturatesAffectedRowsOutsideThePlatformIntegerRange(): void
+    {
+        $stmt = new MysqliResultStatement(null, '999999999999999999999999999999999999');
+
+        self::assertSame(PHP_INT_MAX, $stmt->rowCount());
+    }
+
     public function testResultColumnsReturnsEmptyArrayWithoutResult(): void
     {
         $stmt = new MysqliResultStatement(null, 0);

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliStatementBindingBridgeTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliStatementBindingBridgeTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ZtdQuery\Adapter\Mysqli\MysqliStatementBindingBridge;
+use ZtdQuery\Adapter\Mysqli\ZtdMysqliStatement;
+
+#[CoversClass(MysqliStatementBindingBridge::class)]
+final class MysqliStatementBindingBridgeTest extends TestCase
+{
+    public function testLimitsThePhpStanExcludedBridgeToNativeBindingMethods(): void
+    {
+        $bridge = new ReflectionClass(MysqliStatementBindingBridge::class);
+        $statement = new ReflectionClass(ZtdMysqliStatement::class);
+        $declaredMethods = array_map(
+            static fn (\ReflectionMethod $method): string => $method->getName(),
+            array_filter(
+                $bridge->getMethods(),
+                static fn (\ReflectionMethod $method): bool => $method->getDeclaringClass()->getName() === MysqliStatementBindingBridge::class,
+            ),
+        );
+        sort($declaredMethods);
+        $parent = $statement->getParentClass();
+
+        self::assertSame(['__construct', 'bind_param', 'bind_result'], $declaredMethods);
+        self::assertInstanceOf(ReflectionClass::class, $parent);
+        self::assertSame(MysqliStatementBindingBridge::class, $parent->getName());
+        self::assertTrue($bridge->getMethod('bind_param')->isFinal());
+        self::assertTrue($bridge->getMethod('bind_result')->isFinal());
+        self::assertTrue($bridge->getMethod('bind_param')->getParameters()[1]->isPassedByReference());
+        self::assertTrue($bridge->getMethod('bind_result')->getParameters()[0]->isPassedByReference());
+    }
+
+    public function testExcludedBridgeContainsOnlyTheReviewedDelegationBodies(): void
+    {
+        $bridge = new ReflectionClass(MysqliStatementBindingBridge::class);
+        $fileName = $bridge->getFileName();
+        self::assertIsString($fileName);
+        $source = file_get_contents($fileName);
+
+        self::assertSame(<<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Adapter\Mysqli;
+
+use mysqli_stmt;
+
+/**
+ * Isolates native mysqli by-reference signatures that PHPStan models incorrectly.
+ */
+abstract class MysqliStatementBindingBridge extends mysqli_stmt
+{
+    private mysqli_stmt $bindingDelegate;
+
+    public function __construct(mysqli_stmt $bindingDelegate)
+    {
+        $this->bindingDelegate = $bindingDelegate;
+    }
+
+    /** @param mixed ...$vars */
+    final public function bind_param(string $types, mixed &...$vars): bool
+    {
+        return $this->bindingDelegate->bind_param($types, ...$vars);
+    }
+
+    final public function bind_result(mixed &...$vars): bool
+    {
+        return $this->bindingDelegate->bind_result(...$vars);
+    }
+}
+
+PHP, $source);
+    }
+}

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/ZtdMysqliStatementTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/ZtdMysqliStatementTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Tests\Fixtures\StubMysqliStmt;
+use ZtdQuery\Adapter\Mysqli\MysqliStatementBindingBridge;
 use ZtdQuery\Adapter\Mysqli\ZtdMysqliStatement;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
@@ -19,8 +21,25 @@ use ZtdQuery\Shadow\Mutation\ShadowMutation;
 use ZtdQuery\Shadow\ShadowStore;
 
 #[CoversClass(ZtdMysqliStatement::class)]
+#[UsesClass(MysqliStatementBindingBridge::class)]
 final class ZtdMysqliStatementTest extends TestCase
 {
+    public function testBindingBridgeUsesTheStatementDelegateInitializedByTheConstructor(): void
+    {
+        $delegate = StubMysqliStmt::create();
+        $session = new Session(
+            static::createStub(SqlRewriter::class),
+            new ShadowStore(),
+            new ResultSelectRunner(),
+            ZtdConfig::default(),
+            static::createStub(ConnectionInterface::class)
+        );
+        $stmt = new ZtdMysqliStatement($delegate, $session, null);
+        $value = null;
+
+        self::assertTrue($stmt->bind_result($value));
+    }
+
     public function testExecuteWithNullPlanDelegatesToDelegate(): void
     {
         $delegate = StubMysqliStmt::create();

--- a/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
+++ b/packages/ztd-query-postgres/src/PgSqlMutationResolver.php
@@ -250,7 +250,7 @@ final class PgSqlMutationResolver
                 $definition = $definition->withPartitionKey($childKey);
             }
 
-            return new CreateTableMutation($tableName, $definition, $this->registry, $ifNotExists);
+            return new CreateTableMutation($tableName, $definition, $this->registry, $sql, $ifNotExists);
         }
 
         if ($this->parser->hasCreateTableLike($sql)) {
@@ -277,7 +277,7 @@ final class PgSqlMutationResolver
 
         $definition = $this->schemaParser->parse($sql);
 
-        return new CreateTableMutation($tableName, $definition, $this->registry, $ifNotExists);
+        return new CreateTableMutation($tableName, $definition, $this->registry, $sql, $ifNotExists);
     }
 
     private function storageTable(string $tableName): string
@@ -308,7 +308,7 @@ final class PgSqlMutationResolver
             throw new UnknownSchemaException($sql, $tableName, 'table');
         }
 
-        return new DropTableMutation($tableName, $this->registry, $ifExists);
+        return new DropTableMutation($tableName, $this->registry, $sql, $ifExists);
     }
 
     private function resolveAlterTable(string $sql): ?ShadowMutation

--- a/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
+++ b/packages/ztd-query-sqlite/src/SqliteMutationResolver.php
@@ -208,7 +208,7 @@ final class SqliteMutationResolver
 
         $definition = $this->schemaParser->parse($sql);
 
-        return new CreateTableMutation($tableName, $definition, $this->registry, $ifNotExists);
+        return new CreateTableMutation($tableName, $definition, $this->registry, $sql, $ifNotExists);
     }
 
     private function resolveDropTable(string $sql): ShadowMutation
@@ -222,7 +222,7 @@ final class SqliteMutationResolver
 
         if ($this->registry->isRemoved($tableName)) {
             if ($ifExists) {
-                return new DropTableMutation($tableName, $this->registry, true);
+                return new DropTableMutation($tableName, $this->registry, $sql, true);
             }
             throw new UnsupportedSqlException($sql, 'Table was removed from the virtual schema');
         }
@@ -231,7 +231,7 @@ final class SqliteMutationResolver
             throw new UnknownSchemaException($sql, $tableName, 'table');
         }
 
-        return new DropTableMutation($tableName, $this->registry, $ifExists);
+        return new DropTableMutation($tableName, $this->registry, $sql, $ifExists);
     }
 
     /**


### PR DESCRIPTION
## What

Add PHPStan rules for dialect responsibility boundaries, fixed or joined SQL templates, and SQLFaker Provider delegation; remove residual core SQL rendering and adapter metadata interpretation detected by those rules.

The SQLFaker rule now enforces the Plan contract mechanically:

- the Provider sql property must be the matching dialect SqlGenerator
- Provider methods may delegate only to SqlGenerator::generate with a GenerationPlan
- Provider APIs taking a GenerationTarget are rejected
- generateRequired, special generateX methods, direct SQL strings, joined templates, and Provider-owned lexeme construction are rejected

## Why

Responsibility regressions in core, adapters, and SQLFaker were not mechanically prevented. In particular, a review fix could move fixed SQL from a Provider into a special SqlGenerator method while preserving the underlying design error.

## Verification

- custom rules: 25 tests / 44 assertions; lint and PHPStan
- SQLFaker: 2,022 tests / 6,493 assertions with the rule enabled
- core, MySQL, PostgreSQL, SQLite, PDO, and MySQLi lint/PHPStan: passed
- final verified unit total: 7,557 tests / 17,147 assertions

Stack: agent/issue-zero-59-neutral-sql-lexer-profile -> agent/issue-zero-60-responsibility-guards