### PR TITLE
refactor(dialects): align insert-select renderer APIs

### DIFF
--- a/packages/ztd-query-mysql/src/Transformer/InsertSelectRenderer.php
+++ b/packages/ztd-query-mysql/src/Transformer/InsertSelectRenderer.php
@@ -51,7 +51,7 @@ final class InsertSelectRenderer
             if ($sourceIndex !== null) {
                 $expression = $this->quoter->quote('__ztd_insert_' . $sourceIndex);
             } elseif ($generatedIdentityStart !== null) {
-                $expression = $generatedIdentityStart . ' + ROW_NUMBER() OVER () - 1';
+                $expression = $this->renderGeneratedIdentity($generatedIdentityStart);
             } else {
                 $expression = $projection->defaultExpressionValue() ?? 'NULL';
             }
@@ -62,5 +62,14 @@ final class InsertSelectRenderer
 
         return 'WITH ' . $sourceName . ' (' . implode(', ', $sourceColumns) . ') AS ('
             . $selectSql . ') SELECT ' . implode(', ', $selects) . ' FROM ' . $sourceName;
+    }
+
+    public function renderGeneratedIdentity(int $start): string
+    {
+        if ($start < 1) {
+            throw new \InvalidArgumentException('Generated identity start must be positive.');
+        }
+
+        return $start . ' + ROW_NUMBER() OVER () - 1';
     }
 }

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertSelectRendererTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertSelectRendererTest.php
@@ -55,4 +55,28 @@ final class InsertSelectRendererTest extends TestCase
 
         self::assertStringContainsString('SELECT source.* FROM source', $result);
     }
+
+    public function testRendersGeneratedIdentityWithMySqlDialectSyntax(): void
+    {
+        self::assertSame(
+            '8 + ROW_NUMBER() OVER () - 1',
+            (new InsertSelectRenderer())->renderGeneratedIdentity(8),
+        );
+    }
+
+    public function testAcceptsMinimumGeneratedIdentityStart(): void
+    {
+        self::assertSame(
+            '1 + ROW_NUMBER() OVER () - 1',
+            (new InsertSelectRenderer())->renderGeneratedIdentity(1),
+        );
+    }
+
+    public function testRejectsNonPositiveGeneratedIdentityStart(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Generated identity start must be positive.');
+
+        (new InsertSelectRenderer())->renderGeneratedIdentity(0);
+    }
 }

--- a/packages/ztd-query-sqlite/src/Transformer/InsertSelectRenderer.php
+++ b/packages/ztd-query-sqlite/src/Transformer/InsertSelectRenderer.php
@@ -43,7 +43,7 @@ final class InsertSelectRenderer
             if ($sourceIndex !== null) {
                 $expression = $this->quoter->quote('__ztd_insert_' . $sourceIndex);
             } elseif ($generatedIdentityStart !== null) {
-                $expression = $generatedIdentityStart . ' + ROW_NUMBER() OVER () - 1';
+                $expression = $this->renderGeneratedIdentity($generatedIdentityStart);
             } else {
                 $expression = $projection->defaultExpressionValue() ?? 'NULL';
             }
@@ -54,5 +54,14 @@ final class InsertSelectRenderer
 
         return 'WITH ' . $sourceName . ' (' . implode(', ', $sourceColumns) . ') AS ('
             . $selectSql . ') SELECT ' . implode(', ', $selects) . ' FROM ' . $sourceName;
+    }
+
+    public function renderGeneratedIdentity(int $start): string
+    {
+        if ($start < 1) {
+            throw new \InvalidArgumentException('Generated identity start must be positive.');
+        }
+
+        return $start . ' + ROW_NUMBER() OVER () - 1';
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertSelectRendererTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertSelectRendererTest.php
@@ -32,4 +32,28 @@ final class InsertSelectRendererTest extends TestCase
             $sql,
         );
     }
+
+    public function testRendersGeneratedIdentityWithSqliteDialectSyntax(): void
+    {
+        self::assertSame(
+            '8 + ROW_NUMBER() OVER () - 1',
+            (new InsertSelectRenderer())->renderGeneratedIdentity(8),
+        );
+    }
+
+    public function testAcceptsMinimumGeneratedIdentityStart(): void
+    {
+        self::assertSame(
+            '1 + ROW_NUMBER() OVER () - 1',
+            (new InsertSelectRenderer())->renderGeneratedIdentity(1),
+        );
+    }
+
+    public function testRejectsNonPositiveGeneratedIdentityStart(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Generated identity start must be positive.');
+
+        (new InsertSelectRenderer())->renderGeneratedIdentity(0);
+    }
 }


### PR DESCRIPTION
## What

Expose and use renderGeneratedIdentity consistently in all three dialect renderers, with positive-start validation.

## Why

Generated-identity SQL rendering was exposed only by the PostgreSQL renderer while MySQL and SQLite assembled it inline.

## Verification

- MySQL, PostgreSQL, and SQLite renderer unit tests and lint.
- Final stack: 7,188 unit tests and 16,469 assertions passed.

Stack: agent/issue-zero-60-responsibility-guards -> agent/issue-zero-61-insert-select-renderer-api