### PR TITLE
fix(phpstan): reject joined fixed SQL templates

### DIFF
--- a/packages/phpstan-custom-rules/src/Rule/NoDialectLogicInCoreOrAdapterRule.php
+++ b/packages/phpstan-custom-rules/src/Rule/NoDialectLogicInCoreOrAdapterRule.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
@@ -68,6 +69,7 @@ final class NoDialectLogicInCoreOrAdapterRule implements Rule
         | ^\s*NULL\s*$
         | \bWITH\s+[^\s]+\s+AS\s*\(
         | \bSELECT\s+.+\s+FROM\b
+        | \bSELECT\s{2,}FROM\b
         | \bINSERT\s+INTO\b
         | \bUPDATE\s+[^\s]+\s+SET\b
         | \bDELETE\s+FROM\b
@@ -243,6 +245,29 @@ final class NoDialectLogicInCoreOrAdapterRule implements Rule
                     : '',
                 $node->parts,
             ));
+        }
+        if ($node instanceof FuncCall
+            && $node->name instanceof Name
+            && in_array(strtolower($node->name->toString()), ['implode', 'join'], true)
+        ) {
+            $arguments = $node->getArgs();
+            $separatorNode = count($arguments) === 1 ? null : ($arguments[0]->value ?? null);
+            $valuesNode = count($arguments) === 1
+                ? ($arguments[0]->value ?? null)
+                : ($arguments[1]->value ?? null);
+            if (!$valuesNode instanceof Array_) {
+                return null;
+            }
+            $separator = $separatorNode === null ? '' : $this->literalValue($separatorNode);
+            if ($separator === null) {
+                return null;
+            }
+            $values = [];
+            foreach ($valuesNode->items as $item) {
+                $values[] = $this->literalValue($item->value) ?? '';
+            }
+
+            return implode($separator, $values);
         }
         if (!$node instanceof Concat) {
             return null;

--- a/packages/phpstan-custom-rules/src/Rule/NoFixedSqlStatementRule.php
+++ b/packages/phpstan-custom-rules/src/Rule/NoFixedSqlStatementRule.php
@@ -6,10 +6,23 @@ namespace ZtdQuery\PhpStanCustomRules\Rule;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\AssignOp\Concat as AssignConcat;
 use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\InterpolatedStringPart;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
@@ -20,36 +33,6 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 final class NoFixedSqlStatementRule implements Rule
 {
-    private const STATEMENT_PATTERN = '~(?<![A-Za-z0-9_])(?:
-        WITH\s+[A-Za-z_][A-Za-z0-9_]*\s+AS\s*\(
-        | SELECT(?:
-            \s{2,}FROM\b
-            | \s+(?:
-                \*
-                | [0-9]+(?:\.[0-9]+)?
-                | [\'"`(]
-                | \$[0-9]+
-                | :[A-Za-z_][A-Za-z0-9_]*
-                | [A-Za-z_][A-Za-z0-9_.]*\s+(?:FROM|AS|,|\|\||[+*/-])
-            )
-        )
-        | INSERT\s+INTO\b
-        | UPDATE\s+[^\s,;)]+\s+SET\b
-        | DELETE\s+FROM\b
-        | CREATE\s+(?:TABLE|VIEW|INDEX|DATABASE|SCHEMA)\b
-        | ALTER\s+(?:TABLE|VIEW|DATABASE|SCHEMA)\b
-        | DROP\s+(?:TABLE|VIEW|INDEX|DATABASE|SCHEMA)\b
-        | REPLACE\s+INTO\b
-        | TRUNCATE(?:\s+TABLE)?\s+[^\s,;)]+
-        | LOAD\s+DATA\b
-        | MERGE\s+INTO\b
-        | COPY\s+[^\s,;)]+\s+(?:FROM|TO)\b
-        | (?:CALL|EXPLAIN|VACUUM|PRAGMA|ATTACH|DETACH|GRANT|REVOKE)\s+[^\s,;)]+
-        | FROM\s+[^\s,;)]+\s+WHERE\b
-        | JOIN\s+[^\s,;)]+\s+ON\b
-        | WHERE\s+[^\s,;)]+\s*(?:=|<>|!=|<|>)
-    )~ix';
-
     public function getNodeType(): string
     {
         return Node::class;
@@ -60,21 +43,48 @@ final class NoFixedSqlStatementRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $class = $scope->getClassReflection();
-        if ($class === null) {
+        $namespace = $scope->getNamespace() ?? '';
+        if ($namespace !== 'SqlFaker' && !str_starts_with($namespace, 'SqlFaker\\')) {
             return [];
         }
+        if ($node instanceof ClassMethod
+            && str_starts_with($node->name->name, 'generate')
+            && $this->isDialectGeneratorClass($scope)
+        ) {
+            return $this->invalidGeneratorReturnErrors($node, $scope);
+        }
+        if ($node instanceof Return_ && $node->expr !== null) {
+            if ($this->isDialectGeneratorMethod($scope)) {
+                return [];
+            }
+            foreach ($scope->getType($node->expr)->getConstantStrings() as $constantString) {
+                $value = $constantString->getValue();
+                if (SqlStatementTemplateDetector::contains($value, true)
+                    && !SqlStatementTemplateDetector::contains($value)
+                ) {
+                    return [$this->error($node->getStartLine())];
+                }
+            }
 
-        $className = $class->getName();
-        if (!str_starts_with($className, 'SqlFaker\\')) {
             return [];
         }
         if (!$node instanceof String_
             && !$node instanceof InterpolatedStringPart
             && !$node instanceof InterpolatedString
             && !$node instanceof Concat
+            && !$node instanceof Assign
+            && !$node instanceof AssignConcat
+            && !$node instanceof FuncCall
         ) {
             return [];
+        }
+
+        if ($node instanceof FuncCall) {
+            foreach ($scope->getType($node)->getConstantStrings() as $constantString) {
+                if ($this->containsSqlTemplate($constantString->getValue())) {
+                    return [$this->error($node->getStartLine())];
+                }
+            }
         }
 
         $value = $this->literalValue($node);
@@ -85,23 +95,236 @@ final class NoFixedSqlStatementRule implements Rule
             return [];
         }
 
-        return [RuleErrorBuilder::message(
+        return [$this->error($node->getStartLine())];
+    }
+
+    private function isDialectGeneratorMethod(Scope $scope): bool
+    {
+        $function = $scope->getFunctionName();
+
+        return $function !== null
+            && str_starts_with($function, 'generate')
+            && $this->isDialectGeneratorClass($scope);
+    }
+
+    private function isDialectGeneratorClass(Scope $scope): bool
+    {
+        $class = $scope->getClassReflection();
+        if ($class === null) {
+            return false;
+        }
+        $className = $class->getName();
+
+        return strcmp($className, 'SqlFaker\\MySql\\SqlGenerator') === 0
+            || strcmp($className, 'SqlFaker\\PostgreSql\\SqlGenerator') === 0
+            || strcmp($className, 'SqlFaker\\Sqlite\\SqlGenerator') === 0;
+    }
+
+    /**
+     * @param array<string, list<Expr>> $assignments
+     * @param list<string> $visited
+     */
+    private function isApprovedGeneratorReturn(
+        Expr $expr,
+        Scope $scope,
+        array $assignments,
+        array $visited,
+    ): bool {
+        if ($expr instanceof Match_) {
+            foreach ($expr->arms as $arm) {
+                if (!$this->isApprovedGeneratorReturn($arm->body, $scope, $assignments, $visited)) {
+                    return false;
+                }
+            }
+
+            return $expr->arms !== [];
+        }
+        if ($expr instanceof Variable && is_string($expr->name)) {
+            return $this->isGrammarDerivedVariable($expr->name, $assignments, $scope, $visited);
+        }
+        if (!$expr instanceof MethodCall || !$expr->name instanceof Identifier) {
+            return false;
+        }
+        if ($expr->var instanceof Variable && $expr->var->name === 'this') {
+            return str_starts_with($expr->name->name, 'generate');
+        }
+        if (!$expr->var instanceof PropertyFetch
+            || !$expr->var->var instanceof Variable
+            || $expr->var->var->name !== 'this'
+            || !$expr->var->name instanceof Identifier
+            || $expr->var->name->name !== 'lexicalGrammar'
+        ) {
+            return false;
+        }
+
+        if (str_starts_with($expr->name->name, 'generate')) {
+            return true;
+        }
+        $argument = $expr->getArgs()[0]->value ?? null;
+
+        return $expr->name->name === 'realize'
+            && $argument instanceof Expr
+            && $this->isDerivedTerminalExpression($argument, $assignments, $scope, []);
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function invalidGeneratorReturnErrors(ClassMethod $method, Scope $scope): array
+    {
+        $returns = [];
+        $assignments = [];
+        foreach ($method->stmts ?? [] as $statement) {
+            $this->collectVariableFlow($statement, $returns, $assignments);
+        }
+        $errors = [];
+        foreach ($returns as [$expression, $line]) {
+            if ($this->isApprovedGeneratorReturn($expression, $scope, $assignments, [])) {
+                continue;
+            }
+            $errors[] = $this->error($line);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string, list<Expr>> $assignments
+     * @param list<string> $visited
+     */
+    private function isGrammarDerivedVariable(
+        string $name,
+        array $assignments,
+        Scope $scope,
+        array $visited,
+    ): bool {
+        if (in_array($name, $visited, true)) {
+            return false;
+        }
+        $sources = $assignments[$name] ?? [];
+        if ($sources === []) {
+            return false;
+        }
+        $visited[] = $name;
+        foreach ($sources as $source) {
+            if ($source instanceof Variable && is_string($source->name)) {
+                if (!$this->isGrammarDerivedVariable($source->name, $assignments, $scope, $visited)) {
+                    return false;
+                }
+                continue;
+            }
+            if (!$this->isApprovedGeneratorReturn($source, $scope, $assignments, $visited)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, list<Expr>> $assignments
+     * @param list<string> $visited
+     */
+    private function isDerivedTerminalExpression(
+        Expr $expr,
+        array $assignments,
+        Scope $scope,
+        array $visited,
+    ): bool {
+        if ($expr instanceof Variable && is_string($expr->name)) {
+            if (in_array($expr->name, $visited, true)) {
+                return false;
+            }
+            $sources = $assignments[$expr->name] ?? [];
+            if ($sources === []) {
+                return false;
+            }
+            $visited[] = $expr->name;
+            foreach ($sources as $source) {
+                if (!$this->isDerivedTerminalExpression($source, $assignments, $scope, $visited)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        if ($expr instanceof FuncCall
+            && $expr->name instanceof Name
+            && strtolower($expr->name->toString()) === 'array_map'
+        ) {
+            $argument = $expr->getArgs()[1]->value ?? null;
+
+            return $argument instanceof Expr
+                && $this->isDerivedTerminalExpression($argument, $assignments, $scope, $visited);
+        }
+        if (!$expr instanceof MethodCall
+            || !$expr->var instanceof Variable
+            || $expr->var->name !== 'this'
+            || !$expr->name instanceof Identifier
+        ) {
+            return false;
+        }
+        if ($expr->name->name === 'derive') {
+            return true;
+        }
+        if ($expr->name->name !== 'normalizeParserSemantics') {
+            return false;
+        }
+        $argument = $expr->getArgs()[0]->value ?? null;
+
+        return $argument instanceof Expr
+            && $this->isDerivedTerminalExpression($argument, $assignments, $scope, $visited);
+    }
+
+    /**
+     * @param list<array{Expr, int}> $returns
+     * @param array<string, list<Expr>> $assignments
+     */
+    private function collectVariableFlow(Node $node, array &$returns, array &$assignments): void
+    {
+        if ($node instanceof \PhpParser\Node\FunctionLike && !$node instanceof ClassMethod) {
+            return;
+        }
+        if ($node instanceof Return_ && $node->expr !== null) {
+            $returns[] = [$node->expr, $node->getStartLine()];
+        }
+        if (($node instanceof Assign || $node instanceof AssignOp)
+            && $node->var instanceof Variable
+            && is_string($node->var->name)
+        ) {
+            $assignments[$node->var->name][] = $node->expr;
+        }
+        $subNodes = get_object_vars($node);
+        foreach ($node->getSubNodeNames() as $name) {
+            $child = $subNodes[$name] ?? null;
+            if ($child instanceof Node) {
+                $this->collectVariableFlow($child, $returns, $assignments);
+                continue;
+            }
+            if (!is_array($child)) {
+                continue;
+            }
+            foreach ($child as $item) {
+                if ($item instanceof Node) {
+                    $this->collectVariableFlow($item, $returns, $assignments);
+                }
+            }
+        }
+    }
+
+    private function error(int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(
             'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.'
         )
             ->identifier('customRules.noFixedSqlStatement')
-            ->line($node->getStartLine())
-            ->build()];
+            ->line($line)
+            ->build();
     }
 
     private function containsSqlTemplate(string $value): bool
     {
-        $withoutBlockComments = preg_replace('~/\*.*?\*/~s', ' ', $value);
-        if ($withoutBlockComments === null) {
-            return false;
-        }
-        $withoutComments = preg_replace('/--[^\r\n]*/', ' ', $withoutBlockComments);
-
-        return $withoutComments !== null && preg_match(self::STATEMENT_PATTERN, $withoutComments) === 1;
+        return SqlStatementTemplateDetector::contains($value);
     }
 
     private function literalValue(Node $node): ?string
@@ -113,16 +336,105 @@ final class NoFixedSqlStatementRule implements Rule
             return implode('', array_map(
                 static fn (Expr|InterpolatedStringPart $part): string => $part instanceof InterpolatedStringPart
                     ? $part->value
-                    : '',
+                    : '__ztd_dynamic__',
                 $node->parts,
             ));
+        }
+        if ($node instanceof FuncCall && $node->name instanceof Name) {
+            $function = strtolower($node->name->toString());
+            if (in_array($function, ['sprintf', 'vsprintf'], true)) {
+                return $this->formattedValue($node, $function === 'vsprintf');
+            }
+            if ($function === 'str_replace') {
+                $arguments = $node->getArgs();
+                $search = isset($arguments[0]) ? $this->literalValue($arguments[0]->value) : null;
+                $replace = isset($arguments[1]) ? $this->literalValue($arguments[1]->value) : null;
+                $subject = isset($arguments[2]) ? $this->literalValue($arguments[2]->value) : null;
+
+                return $search === null || $replace === null || $subject === null
+                    ? null
+                    : str_replace($search, $replace, $subject);
+            }
+            if (!in_array($function, ['implode', 'join'], true)) {
+                return null;
+            }
+            $arguments = $node->getArgs();
+            $separatorNode = count($arguments) === 1 ? null : ($arguments[0]->value ?? null);
+            $valuesNode = count($arguments) === 1
+                ? ($arguments[0]->value ?? null)
+                : ($arguments[1]->value ?? null);
+            if (!$valuesNode instanceof Array_) {
+                return null;
+            }
+            $separator = $separatorNode === null ? '' : ($this->literalValue($separatorNode) ?? ' ');
+            $values = [];
+            foreach ($valuesNode->items as $item) {
+                $values[] = $this->literalValue($item->value) ?? '__ztd_dynamic__';
+            }
+
+            return implode($separator, $values);
+        }
+        if ($node instanceof AssignConcat) {
+            $suffix = $this->literalValue($node->expr);
+
+            return $suffix === null ? null : 'SELECT __ztd_dynamic__ ' . $suffix;
+        }
+        if ($node instanceof Assign
+            && $node->var instanceof Variable
+            && is_string($node->var->name)
+            && $node->expr instanceof Concat
+            && $node->expr->left instanceof Variable
+            && $node->expr->left->name === $node->var->name
+        ) {
+            $suffix = $this->literalValue($node->expr->right);
+
+            return $suffix === null ? null : 'SELECT __ztd_dynamic__ ' . $suffix;
         }
         if (!$node instanceof Concat) {
             return null;
         }
-        $left = $this->literalValue($node->left);
-        $right = $this->literalValue($node->right);
+        $left = $this->literalValue($node->left) ?? '__ztd_dynamic__';
+        $right = $this->literalValue($node->right) ?? '__ztd_dynamic__';
 
-        return $left === null || $right === null ? null : $left . $right;
+        return $left . $right;
+    }
+
+    private function formattedValue(FuncCall $call, bool $argumentsInArray): ?string
+    {
+        $arguments = $call->getArgs();
+        $formatNode = $arguments[0]->value ?? null;
+        if (!$formatNode instanceof Node) {
+            return null;
+        }
+        $format = $this->literalValue($formatNode);
+        if ($format === null) {
+            return null;
+        }
+        if ($this->containsSqlTemplate($format)) {
+            return null;
+        }
+        if ($argumentsInArray) {
+            $valuesNode = $arguments[1]->value ?? null;
+            if (!$valuesNode instanceof Array_) {
+                return null;
+            }
+            $valueNodes = array_map(static fn ($item): Node => $item->value, $valuesNode->items);
+        } else {
+            $valueNodes = array_map(static fn ($argument): Node => $argument->value, array_slice($arguments, 1));
+        }
+        $values = array_map(
+            fn (Node $value): string => $this->literalValue($value) ?? '__ztd_dynamic__',
+            $valueNodes,
+        );
+        $index = 0;
+        $formatted = preg_replace_callback(
+            '~%(?:[0-9]+\\$)?[-+0\x20\x27]*(?:[0-9]+|\*)?(?:\.(?:[0-9]+|\*))?[bcdeEfFgGosuxX]~',
+            static function () use (&$index, $values): string {
+                return $values[$index++] ?? '';
+            },
+            $format,
+        );
+
+        return $formatted;
     }
 }

--- a/packages/phpstan-custom-rules/src/Rule/SqlFakerProviderDelegationRule.php
+++ b/packages/phpstan-custom-rules/src/Rule/SqlFakerProviderDelegationRule.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Return_;
@@ -35,25 +36,21 @@ final class SqlFakerProviderDelegationRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $class = $scope->getClassReflection();
-        if ($class === null) {
-            if ($scope->getNamespace() !== 'SqlFaker') {
-                return [];
-            }
-        } else {
-            $className = $class->getName();
-            if (!str_starts_with($className, 'SqlFaker\\')) {
-                return [];
-            }
-            if (str_contains(substr($className, strlen('SqlFaker\\')), '\\')) {
-                return [];
-            }
+        if ($scope->getNamespace() !== 'SqlFaker') {
+            return [];
+        }
+        if ($node instanceof Param
+            && $node->flags !== 0
+            && $node->var instanceof Variable
+            && $node->var->name === 'sql'
+            && !$this->isDialectSqlGeneratorType($node->type, $scope)
+        ) {
+            return [$this->error($node->getStartLine())];
         }
         if ($node instanceof Property) {
             foreach ($node->props as $property) {
                 if ($property->name->name === 'sql'
-                    && (!$node->type instanceof \PhpParser\Node\Name
-                        || !str_ends_with($scope->resolveName($node->type), '\\SqlGenerator'))
+                    && !$this->isDialectSqlGeneratorType($node->type, $scope)
                 ) {
                     return [$this->error($node->getStartLine())];
                 }
@@ -82,6 +79,16 @@ final class SqlFakerProviderDelegationRule implements Rule
         }
 
         return [$this->error($statement?->getStartLine() ?? $node->getStartLine())];
+    }
+
+    private function isDialectSqlGeneratorType(Node|null $type, Scope $scope): bool
+    {
+        return $type instanceof \PhpParser\Node\Name
+            && in_array($scope->resolveName($type), [
+                'SqlFaker\\MySql\\SqlGenerator',
+                'SqlFaker\\PostgreSql\\SqlGenerator',
+                'SqlFaker\\Sqlite\\SqlGenerator',
+            ], true);
     }
 
     private function error(int $line): IdentifierRuleError

--- a/packages/phpstan-custom-rules/src/Rule/SqlStatementTemplateDetector.php
+++ b/packages/phpstan-custom-rules/src/Rule/SqlStatementTemplateDetector.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\PhpStanCustomRules\Rule;
+
+final class SqlStatementTemplateDetector
+{
+    public static function contains(string $value, bool $completeStatementContext = false): bool
+    {
+        $tokens = self::tokenize($value);
+        foreach ($tokens as $index => $token) {
+            if (!self::isBoundary($tokens, $index)) {
+                continue;
+            }
+            if ($token === 'WITH' && self::isCommonTableExpression($tokens, $index)) {
+                return true;
+            }
+            if ($token === 'SELECT' && self::isSelect($tokens, $index, $completeStatementContext)) {
+                return true;
+            }
+            if (in_array($token, ['INSERT', 'REPLACE', 'MERGE'], true)
+                && self::containsAfter($tokens, $index, 'INTO')
+            ) {
+                return true;
+            }
+            if ($token === 'UPDATE' && self::containsAfter($tokens, $index, 'SET')) {
+                return true;
+            }
+            if ($token === 'DELETE' && self::containsAfter($tokens, $index, 'FROM')) {
+                return true;
+            }
+            if ($token === 'CREATE' && self::containsObjectType($tokens, $index)) {
+                return true;
+            }
+            if (in_array($token, ['ALTER', 'DROP'], true)
+                && self::containsObjectType($tokens, $index)
+            ) {
+                return true;
+            }
+            if ($token === 'TRUNCATE' && self::hasValueAfter($tokens, $index)) {
+                return true;
+            }
+            if ($token === 'LOAD' && ($tokens[$index + 1] ?? null) === 'DATA') {
+                return true;
+            }
+            if ($token === 'COPY'
+                && (self::containsAfter($tokens, $index, 'FROM') || self::containsAfter($tokens, $index, 'TO'))
+            ) {
+                return true;
+            }
+            if (in_array($token, ['CALL', 'EXPLAIN', 'VACUUM', 'PRAGMA', 'ATTACH', 'DETACH', 'GRANT', 'REVOKE'], true)
+                && self::hasValueAfter($tokens, $index)
+            ) {
+                return true;
+            }
+            if ($token === 'START' && ($tokens[$index + 1] ?? null) === 'TRANSACTION') {
+                return true;
+            }
+            if ($token === 'SAVEPOINT' && self::hasValueAfter($tokens, $index)) {
+                return true;
+            }
+            if ($token === 'RELEASE' && ($tokens[$index + 1] ?? null) === 'SAVEPOINT') {
+                return true;
+            }
+            if ($token === 'SET'
+                && (self::containsAfter($tokens, $index, '=')
+                    || in_array($tokens[$index + 1] ?? null, ['TRANSACTION', 'SESSION', 'LOCAL', 'NAMES'], true))
+            ) {
+                return true;
+            }
+            if (in_array($token, ['BEGIN', 'COMMIT', 'ROLLBACK'], true)
+                && self::isTransactionControl($tokens, $index, $completeStatementContext)
+            ) {
+                return true;
+            }
+            if ($token === 'FROM'
+                && self::hasValueAfter($tokens, $index)
+                && self::containsAfter($tokens, $index, 'WHERE')
+            ) {
+                return true;
+            }
+            if ($token === 'JOIN'
+                && self::hasValueAfter($tokens, $index)
+                && self::containsAfter($tokens, $index, 'ON')
+            ) {
+                return true;
+            }
+            if ($token === 'WHERE' && self::containsComparisonAfter($tokens, $index)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function tokenize(string $value): array
+    {
+        $tokens = [];
+        $length = strlen($value);
+        for ($index = 0; $index < $length;) {
+            $character = $value[$index];
+            $next = $value[$index + 1] ?? '';
+            if (ctype_space($character)) {
+                $index++;
+                continue;
+            }
+            if ($character === '/' && $next === '*') {
+                $index += 2;
+                while ($index < $length && !($value[$index] === '*' && ($value[$index + 1] ?? '') === '/')) {
+                    $index++;
+                }
+                $index = min($length, $index + 2);
+                continue;
+            }
+            if (($character === '-' && $next === '-') || $character === '#') {
+                while ($index < $length && !in_array($value[$index], ["\r", "\n"], true)) {
+                    $index++;
+                }
+                continue;
+            }
+            if (in_array($character, ["'", '"', '`'], true)) {
+                $quote = $character;
+                $index++;
+                while ($index < $length) {
+                    if ($value[$index] === '\\') {
+                        $index += 2;
+                        continue;
+                    }
+                    if ($value[$index] !== $quote) {
+                        $index++;
+                        continue;
+                    }
+                    if (($value[$index + 1] ?? '') === $quote) {
+                        $index += 2;
+                        continue;
+                    }
+                    $index++;
+                    break;
+                }
+                $tokens[] = '__ZTD_VALUE__';
+                continue;
+            }
+            if ($character === '[') {
+                $index++;
+                while ($index < $length && $value[$index] !== ']') {
+                    $index++;
+                }
+                $index = min($length, $index + 1);
+                $tokens[] = '__ZTD_VALUE__';
+                continue;
+            }
+            if (ctype_alnum($character) || in_array($character, ['_', '$', ':', '%', '{'], true)) {
+                $start = $index;
+                do {
+                    $index++;
+                    $current = $value[$index] ?? '';
+                } while ($index < $length
+                    && (ctype_alnum($current) || in_array($current, ['_', '$', ':', '%', '.', '}'], true))
+                );
+                $tokens[] = strtoupper(substr($value, $start, $index - $start));
+                continue;
+            }
+            if (in_array($character . $next, ['<>', '!=', '<=', '>='], true)) {
+                $tokens[] = $character . $next;
+                $index += 2;
+                continue;
+            }
+            $tokens[] = $character;
+            $index++;
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private static function isBoundary(array $tokens, int $index): bool
+    {
+        if ($index === 0) {
+            return true;
+        }
+
+        return isset($tokens[$index - 1]) && in_array($tokens[$index - 1], ['(', '=', ';'], true);
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private static function isCommonTableExpression(array $tokens, int $index): bool
+    {
+        $nameIndex = $index + (($tokens[$index + 1] ?? null) === 'RECURSIVE' ? 2 : 1);
+        if (!self::isValue($tokens[$nameIndex] ?? null)) {
+            return false;
+        }
+
+        return self::containsAfter($tokens, $nameIndex, 'AS')
+            && self::containsAfter($tokens, $nameIndex, '(');
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private static function isSelect(array $tokens, int $index, bool $completeStatementContext): bool
+    {
+        $projectionIndex = $index + 1;
+        if (in_array($tokens[$projectionIndex] ?? null, ['DISTINCT', 'ALL'], true)) {
+            $projectionIndex++;
+        }
+        $projection = $tokens[$projectionIndex] ?? null;
+        if (!self::isValue($projection) && $projection !== '*' && $projection !== '(') {
+            return false;
+        }
+
+        return $completeStatementContext || self::containsAfter($tokens, $projectionIndex, 'FROM');
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private static function containsObjectType(array $tokens, int $index): bool
+    {
+        foreach (array_slice($tokens, $index + 1, 8) as $token) {
+            if (in_array($token, ['TABLE', 'VIEW', 'INDEX', 'DATABASE', 'SCHEMA', 'DOMAIN', 'TYPE', 'SEQUENCE'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private static function isTransactionControl(array $tokens, int $index, bool $completeStatementContext): bool
+    {
+        $next = $tokens[$index + 1] ?? null;
+        if ($next === null || $next === ';') {
+            return $completeStatementContext;
+        }
+
+        return in_array($next, ['WORK', 'TRANSACTION', 'TO', 'PREPARED', 'AND'], true);
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private static function hasValueAfter(array $tokens, int $index): bool
+    {
+        return self::isValue($tokens[$index + 1] ?? null);
+    }
+
+    private static function isValue(?string $token): bool
+    {
+        return $token !== null && !in_array($token, [')', '(', ',', ';', '='], true);
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private static function containsAfter(array $tokens, int $index, string $expected): bool
+    {
+        return in_array($expected, array_slice($tokens, $index + 1), true);
+    }
+
+    /**
+     * @param list<string> $tokens
+     */
+    private static function containsComparisonAfter(array $tokens, int $index): bool
+    {
+        foreach (array_slice($tokens, $index + 1) as $token) {
+            if (in_array($token, ['=', '<>', '!=', '<', '>', '<=', '>='], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/CoreDialectDependencyFixture.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/CoreDialectDependencyFixture.php
@@ -41,6 +41,11 @@ final class CoreDialectDependencyFixture
         return 'nat' . 'ive_type';
     }
 
+    public function joinedInsertSelect(string $columns, string $source): string
+    {
+        return implode(' ', ['SELECT', $columns, 'FROM', $source]);
+    }
+
     /** @param array<string, mixed> $metadata */
     public function metadata(array $metadata): array
     {

--- a/packages/phpstan-custom-rules/tests/Fixture/DelegatingProviders.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/DelegatingProviders.php
@@ -70,3 +70,38 @@ final class TemplateProvider
         return $this->sql->generateSelectStatement();
     }
 }
+
+final class AnonymousProviderFactory
+{
+    public function __construct()
+    {
+        new class () {
+            public function statement(): string
+            {
+                return 'SELECT id FROM users';
+            }
+        };
+    }
+}
+
+final class PromotedTemplateProvider
+{
+    public function __construct(private \SqlFaker\MySql\TemplateBank $sql)
+    {
+    }
+
+    public function statement(): string
+    {
+        return $this->sql->generateSelectStatement();
+    }
+}
+
+final class SuffixOnlyProvider
+{
+    private \SqlFaker\Fixed\SqlGenerator $sql;
+
+    public function statement(): string
+    {
+        return $this->sql->generateStatement();
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Fixture/MySql/SqlGenerator.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/MySql/SqlGenerator.php
@@ -10,4 +10,61 @@ final class SqlGenerator
     {
         return 'SELECT id FROM users';
     }
+
+    public function generateUnknownStatement(): string
+    {
+        return 'SHOW TABLES';
+    }
+
+    public function generateDynamicUnknownStatement(string $table): string
+    {
+        return 'SHOW ' . $table;
+    }
+
+    public function generateDelegatedStatement(): string
+    {
+        return $this->generateDerivedStatement();
+    }
+
+    public function generateLexicalStatement(): string
+    {
+        $terminals = $this->derive();
+
+        return $this->lexicalGrammar->realize($terminals);
+    }
+
+    public function generateMatchedStatement(bool $select): string
+    {
+        return match ($select) {
+            true => $this->generateDelegatedStatement(),
+            false => $this->generateDerivedStatement(),
+        };
+    }
+
+    public function generateForeignKeyConstraint(): string
+    {
+        $constraint = $this->generateDerivedStatement();
+
+        return $constraint;
+    }
+
+    public function generateLiteralRealization(): string
+    {
+        return $this->lexicalGrammar->realize(['COMMIT_SYM']);
+    }
+
+    public function generateTargetedStatement(int $targetDepth): string
+    {
+        return $this->generateRequiredWithPlan(
+            'SelectStmt',
+            $targetDepth,
+            new \SqlFaker\Grammar\DerivationPlan([]),
+            new \SqlFaker\Grammar\LexemePlan(['Op' => ['@@']]),
+        );
+    }
+
+    public function generateLexicalIdentifier(): string
+    {
+        return $this->lexicalGrammar->generateQuotedIdentifier(1, 64);
+    }
 }

--- a/packages/phpstan-custom-rules/tests/Fixture/SqlFaker/MySql/StatementTemplateHelper.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/SqlFaker/MySql/StatementTemplateHelper.php
@@ -36,9 +36,74 @@ final class StatementTemplateHelper
         return ' FROM users WHERE id = 1';
     }
 
-    public function lexicalSequence(): string
+    public function joinedStatement(string $columns, string $table): string
     {
-        return implode(' ', ['SELECT', 'FROM', 'WHERE']);
+        return implode(' ', ['SELECT', $columns, 'FROM', $table]);
+    }
+
+    public function partialStatement(string $columns): string
+    {
+        return 'SELECT ' . $columns . ' FROM users';
+    }
+
+    public function formattedStatement(string $columns, string $table): string
+    {
+        return sprintf('SELECT %s FROM %s', $columns, $table);
+    }
+
+    public function accumulatedStatement(): string
+    {
+        $sql = 'SELECT id';
+        $sql .= ' FROM users';
+
+        return $sql;
+    }
+
+    public function assignedConcatStatement(): string
+    {
+        $sql = 'SELECT id';
+        $sql = $sql . ' FROM users';
+
+        return $sql;
+    }
+
+    public function splitFormattedStatement(string $columns, string $table): string
+    {
+        return sprintf('%s %s FROM %s', 'SELECT', $columns, $table);
+    }
+
+    public function splitFormattedArrayStatement(string $columns, string $table): string
+    {
+        return vsprintf('%s %s FROM %s', ['SELECT', $columns, $table]);
+    }
+
+    public function dynamicallyJoinedStatement(string $columns, string $table): string
+    {
+        $separator = ' ';
+
+        return implode($separator, ['SELECT', $columns, 'FROM', $table]);
+    }
+
+    public function hoistedTokenStatement(): string
+    {
+        $tokens = ['INSERT', 'INTO', 'users', '(', 'id', ')', 'VALUES', '(', '1', ')'];
+
+        return implode(' ', $tokens);
+    }
+
+    public function replacedTokenStatement(): string
+    {
+        return str_replace('_', ' ', 'SELECT_id_FROM_users');
+    }
+
+    public function anonymousStatementFactory(): object
+    {
+        return new class () {
+            public function statement(): string
+            {
+                return 'SELECT id FROM users';
+            }
+        };
     }
 
     public function diagnostic(): string
@@ -49,5 +114,31 @@ final class StatementTemplateHelper
     public function multiwordTerminal(): string
     {
         return 'WITH ROLLUP';
+    }
+
+    /** @return list<string> */
+    public function lexicalCatalog(): array
+    {
+        return ['SELECT', 'FROM', 'WHERE'];
+    }
+
+    public function plainSelectList(): string
+    {
+        return 'SELECT id, name FROM users';
+    }
+
+    public function recursiveCommonTableExpression(): string
+    {
+        return 'WITH RECURSIVE t(n) AS (SELECT n FROM q) SELECT n FROM t';
+    }
+
+    public function statementAfterLineComment(): string
+    {
+        return "-- fixture\nSELECT id FROM users";
+    }
+
+    public function transactionStatement(): string
+    {
+        return 'COMMIT';
     }
 }

--- a/packages/phpstan-custom-rules/tests/Fixture/SqlFaker/NamespaceTemplate.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/SqlFaker/NamespaceTemplate.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SqlFaker;
+
+const FIXED_STATEMENT = 'SELECT id FROM users';

--- a/packages/phpstan-custom-rules/tests/Fixture/Sqlite/SqlGenerator.php
+++ b/packages/phpstan-custom-rules/tests/Fixture/Sqlite/SqlGenerator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SqlFaker\Sqlite;
+
+final class SqlGenerator
+{
+    public function generateForeignKeyConstraint(): string
+    {
+        $head = 'SELECT 1';
+        $fixed = $head . ' FROM sqlite_master';
+        $constraint = $fixed;
+
+        return $constraint;
+    }
+
+    public function generateAccumulatedStatement(): string
+    {
+        $sql = $this->generateDerivedStatement();
+        $sql .= ' SHOW';
+
+        return $sql;
+    }
+
+    public function generateMixedBranchStatement(bool $derived): string
+    {
+        if ($derived) {
+            $sql = $this->generateDerivedStatement();
+        } else {
+            $sql = 'SHOW TABLES';
+        }
+
+        return $sql;
+    }
+
+    public function generateCyclicStatement(): string
+    {
+        $first = $second;
+        $second = $first;
+
+        return $first;
+    }
+}

--- a/packages/phpstan-custom-rules/tests/Unit/Rule/NoDialectLogicInCoreOrAdapterRuleTest.php
+++ b/packages/phpstan-custom-rules/tests/Unit/Rule/NoDialectLogicInCoreOrAdapterRuleTest.php
@@ -57,12 +57,13 @@ final class NoDialectLogicInCoreOrAdapterRuleTest extends RuleTestCase
             [$message, 39],
             [$message, 41],
             [$message, 44],
-            [$message, 48],
+            [$message, 46],
             [$message, 49],
-            [$message, 49],
-            [$message, 50],
-            [$message, 51],
+            [$message, 53],
             [$message, 54],
+            [$message, 54],
+            [$message, 55],
+            [$message, 56],
         ]);
     }
 }

--- a/packages/phpstan-custom-rules/tests/Unit/Rule/NoFixedSqlStatementRuleTest.php
+++ b/packages/phpstan-custom-rules/tests/Unit/Rule/NoFixedSqlStatementRuleTest.php
@@ -22,27 +22,83 @@ final class NoFixedSqlStatementRuleTest extends RuleTestCase
         return new NoFixedSqlStatementRule();
     }
 
-    public function testDetectsFixedSqlConstructionInProvidersAndGenerators(): void
+    public function testDetectsFixedSqlConstructionInMySqlProvider(): void
     {
         $message = 'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.';
 
-        $this->analyse([
-            __DIR__ . '/../../Fixture/MySqlProvider.php',
-            __DIR__ . '/../../Fixture/PostgreSqlProvider.php',
-            __DIR__ . '/../../Fixture/SqliteProvider.php',
-            __DIR__ . '/../../Fixture/MySql/SqlGenerator.php',
-            __DIR__ . '/../../Fixture/SqlFaker/MySql/StatementTemplateHelper.php',
-            __DIR__ . '/../../Fixture/Other/MySqlProvider.php',
-        ], [
+        $this->analyse([__DIR__ . '/../../Fixture/MySqlProvider.php'], [[$message, 11]]);
+    }
+
+    public function testDetectsFixedSqlConstructionInPostgreSqlProvider(): void
+    {
+        $message = 'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.';
+
+        $this->analyse([__DIR__ . '/../../Fixture/PostgreSqlProvider.php'], [[$message, 11]]);
+    }
+
+    public function testAllowsProviderGrammarRulesAndClassesOutsideSqlFaker(): void
+    {
+        $this->analyse([__DIR__ . '/../../Fixture/SqliteProvider.php'], []);
+        $this->analyse([__DIR__ . '/../../Fixture/Other/MySqlProvider.php'], []);
+    }
+
+    public function testDetectsFixedSqlConstructionInMySqlGenerator(): void
+    {
+        $message = 'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.';
+
+        $this->analyse([__DIR__ . '/../../Fixture/MySql/SqlGenerator.php'], [
             [$message, 11],
-            [$message, 11],
-            [$message, 11],
+            [$message, 16],
+            [$message, 21],
+            [$message, 53],
+        ]);
+    }
+
+    public function testDetectsFixedSqlConstructionInSqliteGenerator(): void
+    {
+        $message = 'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.';
+
+        $this->analyse([__DIR__ . '/../../Fixture/Sqlite/SqlGenerator.php'], [
+            [$message, 15],
+            [$message, 23],
+            [$message, 34],
+            [$message, 42],
+        ]);
+    }
+
+    public function testDetectsEverySupportedStatementTemplateShape(): void
+    {
+        $message = 'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.';
+
+        $this->analyse([__DIR__ . '/../../Fixture/SqlFaker/MySql/StatementTemplateHelper.php'], [
             [$message, 11],
             [$message, 16],
             [$message, 21],
             [$message, 26],
             [$message, 31],
             [$message, 36],
+            [$message, 41],
+            [$message, 46],
+            [$message, 51],
+            [$message, 57],
+            [$message, 65],
+            [$message, 72],
+            [$message, 77],
+            [$message, 84],
+            [$message, 91],
+            [$message, 96],
+            [$message, 104],
+            [$message, 127],
+            [$message, 132],
+            [$message, 137],
+            [$message, 142],
         ]);
+    }
+
+    public function testDetectsFixedSqlConstructionInSqlFakerNamespace(): void
+    {
+        $message = 'SQLFaker must not construct SQL statements from fixed templates; derive them from the dialect grammar.';
+
+        $this->analyse([__DIR__ . '/../../Fixture/SqlFaker/NamespaceTemplate.php'], [[$message, 7]]);
     }
 }

--- a/packages/phpstan-custom-rules/tests/Unit/Rule/SqlFakerProviderDelegationRuleTest.php
+++ b/packages/phpstan-custom-rules/tests/Unit/Rule/SqlFakerProviderDelegationRuleTest.php
@@ -44,6 +44,11 @@ final class SqlFakerProviderDelegationRuleTest extends RuleTestCase
             [$message, 60],
             [$message, 66],
             [$message, 70],
+            [$message, 81],
+            [$message, 89],
+            [$message, 95],
+            [$message, 101],
+            [$message, 105],
             [$message, 11],
         ]);
     }

--- a/packages/phpstan-custom-rules/tests/Unit/Rule/SqlStatementTemplateDetectorTest.php
+++ b/packages/phpstan-custom-rules/tests/Unit/Rule/SqlStatementTemplateDetectorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Medium;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\PhpStanCustomRules\Rule\SqlStatementTemplateDetector;
+
+#[CoversClass(SqlStatementTemplateDetector::class)]
+#[Medium]
+final class SqlStatementTemplateDetectorTest extends TestCase
+{
+    public function testDetectsStatementsAndExecutableFragments(): void
+    {
+        self::assertTrue(SqlStatementTemplateDetector::contains('SELECT id, name FROM users'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('SELECT DISTINCT COUNT(*) FROM users'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('WITH RECURSIVE t(n) AS (SELECT n FROM q) SELECT n FROM t'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('INSERT INTO users (id) VALUES (1)'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('UPDATE users SET name = 1'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('DELETE FROM users'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('CREATE TABLE users (id INT)'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('START TRANSACTION'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('SET autocommit = 0'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('/* fixture */ SELECT id FROM users'));
+        self::assertTrue(SqlStatementTemplateDetector::contains("-- fixture\nSELECT id FROM users"));
+        self::assertTrue(SqlStatementTemplateDetector::contains('value = (SELECT id FROM users)'));
+        self::assertTrue(SqlStatementTemplateDetector::contains(' FROM users WHERE id = 1'));
+        self::assertTrue(SqlStatementTemplateDetector::contains('COMMIT', true));
+    }
+
+    public function testAllowsGrammarSymbolsAndDiagnostics(): void
+    {
+        self::assertFalse(SqlStatementTemplateDetector::contains('SELECT'));
+        self::assertFalse(SqlStatementTemplateDetector::contains('FROM'));
+        self::assertFalse(SqlStatementTemplateDetector::contains('WHERE'));
+        self::assertFalse(SqlStatementTemplateDetector::contains('COMMIT'));
+        self::assertFalse(SqlStatementTemplateDetector::contains('WITH ROLLUP'));
+        self::assertFalse(SqlStatementTemplateDetector::contains('Cannot select a lexical profile from the catalog.'));
+        self::assertFalse(SqlStatementTemplateDetector::contains('select_stmt'));
+    }
+}


### PR DESCRIPTION
## What

Fold joined literal arrays in both SQLFaker and core responsibility rules while preserving unjoined grammar terminal catalogs.

## Why

Fixed SQL could evade recurrence guards through implode or join with dynamic pieces.

## Verification

- Custom-rule full unit suite and lint.
- Final stack: 7,188 unit tests and 16,469 assertions passed.

Stack: agent/issue-zero-61-insert-select-renderer-api -> agent/issue-zero-62-guard-joined-sql