### PR TITLE
refactor(core): move parameter markers into lexer profiles

### DIFF
--- a/packages/ztd-query-core/src/Sql/SqlLexerProfile.php
+++ b/packages/ztd-query-core/src/Sql/SqlLexerProfile.php
@@ -38,8 +38,14 @@ final class SqlLexerProfile
     /** @var list<non-empty-string> */
     private readonly array $backslashEscapedStringPrefixes;
 
+    /** @var list<non-empty-string> */
+    private readonly array $positionalParameterPatterns;
+
     /** @var array{non-empty-string, non-empty-string}|null */
     private readonly ?array $bracketPair;
+
+    /** @var array{non-empty-string, non-empty-string} */
+    private readonly array $nestingPair;
 
     /**
      * @param list<string> $lineCommentPrefixes
@@ -51,7 +57,9 @@ final class SqlLexerProfile
      * @param array<string, string> $namedParameterSuffixPatterns
      * @param array<string, list<string>> $namedParameterForbiddenPredecessors
      * @param list<string> $backslashEscapedStringPrefixes
+     * @param list<string> $positionalParameterPatterns
      * @param array{string, string}|null $bracketPair
+     * @param array{string, string} $nestingPair
      */
     public function __construct(
         array $lineCommentPrefixes,
@@ -63,15 +71,14 @@ final class SqlLexerProfile
         array $namedParameterSuffixPatterns,
         array $namedParameterForbiddenPredecessors,
         array $backslashEscapedStringPrefixes,
+        array $positionalParameterPatterns,
         private readonly ?string $dollarQuoteDelimiterPattern,
         private readonly string $numericLiteralPattern,
         private readonly string $identifierStartPattern,
         private readonly string $identifierPartPattern,
         ?array $bracketPair,
+        array $nestingPair,
         private readonly bool $nestedBlockComments,
-        private readonly bool $numberedDollarParameters,
-        private readonly bool $questionMarkParameters,
-        private readonly bool $numberedQuestionMarkParameters,
         private readonly bool $backslashEscapedStrings,
     ) {
         $this->lineCommentPrefixes = self::nonEmptyStrings($lineCommentPrefixes);
@@ -87,6 +94,7 @@ final class SqlLexerProfile
             $namedParameterForbiddenPredecessors,
         );
         $this->backslashEscapedStringPrefixes = self::nonEmptyStrings($backslashEscapedStringPrefixes);
+        $this->positionalParameterPatterns = self::patterns($positionalParameterPatterns);
         self::assertPattern($this->dollarQuoteDelimiterPattern);
         self::assertPattern($this->numericLiteralPattern);
         self::assertPattern($this->identifierStartPattern);
@@ -96,6 +104,11 @@ final class SqlLexerProfile
         }
         /** @var array{non-empty-string, non-empty-string}|null $bracketPair */
         $this->bracketPair = $bracketPair;
+        if ($nestingPair[0] === '' || $nestingPair[1] === '') {
+            throw new InvalidArgumentException('Nesting delimiters must not be empty.');
+        }
+        /** @var array{non-empty-string, non-empty-string} $nestingPair */
+        $this->nestingPair = $nestingPair;
     }
 
     public function startsLineComment(string $sql, int $offset): bool
@@ -183,19 +196,16 @@ final class SqlLexerProfile
         return $this->matchAt($this->dollarQuoteDelimiterPattern, $sql, $offset);
     }
 
-    public function supportsNumberedDollarParameters(): bool
+    public function positionalParameterLengthAt(string $sql, int $offset): int
     {
-        return $this->numberedDollarParameters;
-    }
+        foreach ($this->positionalParameterPatterns as $pattern) {
+            $match = $this->matchAt($pattern, $sql, $offset);
+            if ($match !== null) {
+                return strlen($match);
+            }
+        }
 
-    public function supportsQuestionMarkParameters(): bool
-    {
-        return $this->questionMarkParameters;
-    }
-
-    public function supportsNumberedQuestionMarkParameters(): bool
-    {
-        return $this->numberedQuestionMarkParameters;
+        return 0;
     }
 
     public function namedParameterPrefixAt(string $sql, int $offset): ?string
@@ -286,6 +296,16 @@ final class SqlLexerProfile
         return $this->bracketPair !== null && $character === $this->bracketPair[1];
     }
 
+    public function isNestingOpening(string $character): bool
+    {
+        return $character === $this->nestingPair[0];
+    }
+
+    public function isNestingClosing(string $character): bool
+    {
+        return $character === $this->nestingPair[1];
+    }
+
     private function matchesCharacter(string $pattern, string $character): bool
     {
         return $character !== '' && preg_match($pattern, $character) === 1;
@@ -356,6 +376,20 @@ final class SqlLexerProfile
             if ($prefix === '' || $pattern === '') {
                 throw new InvalidArgumentException('Parameter suffix patterns and prefixes must not be empty.');
             }
+            self::assertPattern($pattern);
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * @param list<string> $patterns
+     * @return list<non-empty-string>
+     */
+    private static function patterns(array $patterns): array
+    {
+        $patterns = self::nonEmptyStrings($patterns);
+        foreach ($patterns as $pattern) {
             self::assertPattern($pattern);
         }
 

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -361,19 +361,9 @@ final class SqlTokenStream
                 continue;
             }
 
-            $next = $sql[$offset + 1] ?? '';
-            if ($char === '$' && $profile->supportsNumberedDollarParameters() && ctype_digit($next)) {
-                $offset++;
-                $offset += strspn($sql, '0123456789', $offset);
-                $tokens[] = self::token($sql, SqlTokenKind::Parameter, $start, $offset, $depth, $bracketDepth);
-                continue;
-            }
-
-            if ($char === '?' && $profile->supportsQuestionMarkParameters()) {
-                $offset++;
-                if ($profile->supportsNumberedQuestionMarkParameters()) {
-                    $offset += strspn($sql, '0123456789', $offset);
-                }
+            $positionalParameterLength = $profile->positionalParameterLengthAt($sql, $offset);
+            if ($positionalParameterLength > 0) {
+                $offset += $positionalParameterLength;
                 $tokens[] = self::token($sql, SqlTokenKind::Parameter, $start, $offset, $depth, $bracketDepth);
                 continue;
             }
@@ -417,14 +407,14 @@ final class SqlTokenStream
                 continue;
             }
 
-            if ($char === ')') {
+            if ($profile->isNestingClosing($char)) {
                 $depth = max(0, $depth - 1);
             } elseif ($profile->isBracketClosing($char)) {
                 $bracketDepth = max(0, $bracketDepth - 1);
             }
             $offset++;
             $tokens[] = self::token($sql, SqlTokenKind::Symbol, $start, $offset, $depth, $bracketDepth);
-            if ($char === '(') {
+            if ($profile->isNestingOpening($char)) {
                 $depth++;
             } elseif ($profile->isBracketOpening($char)) {
                 $bracketDepth++;

--- a/packages/ztd-query-core/tests/Fake/FakeSqlLexerProfiles.php
+++ b/packages/ztd-query-core/tests/Fake/FakeSqlLexerProfiles.php
@@ -18,7 +18,9 @@ final class FakeSqlLexerProfiles
      * @param array<string, string> $namedParameterSuffixPatterns
      * @param array<string, list<string>> $namedParameterForbiddenPredecessors
      * @param list<string> $backslashEscapedStringPrefixes
+     * @param list<string> $positionalParameterPatterns
      * @param array{string, string}|null $bracketPair
+     * @param array{string, string} $nestingPair
      */
     public static function custom(
         array $lineCommentPrefixes = ['--'],
@@ -30,15 +32,14 @@ final class FakeSqlLexerProfiles
         array $namedParameterSuffixPatterns = [],
         array $namedParameterForbiddenPredecessors = [],
         array $backslashEscapedStringPrefixes = [],
+        array $positionalParameterPatterns = [],
         ?string $dollarQuoteDelimiterPattern = null,
         string $numericLiteralPattern = '/^[0-9]+/',
         string $identifierStartPattern = '/^[_A-Za-z]$/',
         string $identifierPartPattern = '/^[_A-Za-z0-9]$/',
         ?array $bracketPair = null,
+        array $nestingPair = ['(', ')'],
         bool $nestedBlockComments = false,
-        bool $numberedDollarParameters = false,
-        bool $questionMarkParameters = false,
-        bool $numberedQuestionMarkParameters = false,
         bool $backslashEscapedStrings = false,
     ): SqlLexerProfile {
         return new SqlLexerProfile(
@@ -51,15 +52,14 @@ final class FakeSqlLexerProfiles
             namedParameterSuffixPatterns: $namedParameterSuffixPatterns,
             namedParameterForbiddenPredecessors: $namedParameterForbiddenPredecessors,
             backslashEscapedStringPrefixes: $backslashEscapedStringPrefixes,
+            positionalParameterPatterns: $positionalParameterPatterns,
             dollarQuoteDelimiterPattern: $dollarQuoteDelimiterPattern,
             numericLiteralPattern: $numericLiteralPattern,
             identifierStartPattern: $identifierStartPattern,
             identifierPartPattern: $identifierPartPattern,
             bracketPair: $bracketPair,
+            nestingPair: $nestingPair,
             nestedBlockComments: $nestedBlockComments,
-            numberedDollarParameters: $numberedDollarParameters,
-            questionMarkParameters: $questionMarkParameters,
-            numberedQuestionMarkParameters: $numberedQuestionMarkParameters,
             backslashEscapedStrings: $backslashEscapedStrings,
         );
     }
@@ -76,15 +76,14 @@ final class FakeSqlLexerProfiles
             namedParameterSuffixPatterns: [],
             namedParameterForbiddenPredecessors: [],
             backslashEscapedStringPrefixes: [],
+            positionalParameterPatterns: [],
             dollarQuoteDelimiterPattern: null,
             numericLiteralPattern: '/^(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?/',
             identifierStartPattern: '/^[_A-Za-z\x80-\xFF]$/',
             identifierPartPattern: '/^[_A-Za-z0-9\x80-\xFF]$/',
             bracketPair: ['[', ']'],
+            nestingPair: ['(', ')'],
             nestedBlockComments: true,
-            numberedDollarParameters: false,
-            questionMarkParameters: false,
-            numberedQuestionMarkParameters: false,
             backslashEscapedStrings: false,
         );
     }
@@ -101,15 +100,14 @@ final class FakeSqlLexerProfiles
             namedParameterSuffixPatterns: [':' => '/^\([^ \t\n\r\0\x0B)]*\)/'],
             namedParameterForbiddenPredecessors: [':' => [':']],
             backslashEscapedStringPrefixes: ['E', 'e'],
+            positionalParameterPatterns: ['/^\$[0-9]+/', '/^\?[0-9]*/'],
             dollarQuoteDelimiterPattern: '/^\$(?:[_A-Za-z][_A-Za-z0-9]*)?\$/',
             numericLiteralPattern: '/^(?:0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*|(?:[0-9](?:_?[0-9])*)(?:\.(?:[0-9](?:_?[0-9])*)?)?(?:[eE][+-]?[0-9](?:_?[0-9])*)?)/',
             identifierStartPattern: '/^[_A-Za-z\x80-\xFF]$/',
             identifierPartPattern: '/^[_A-Za-z0-9$\x80-\xFF]$/',
             bracketPair: ['[', ']'],
+            nestingPair: ['(', ')'],
             nestedBlockComments: true,
-            numberedDollarParameters: true,
-            questionMarkParameters: true,
-            numberedQuestionMarkParameters: true,
             backslashEscapedStrings: true,
         );
     }

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlLexerProfileTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlLexerProfileTest.php
@@ -25,15 +25,14 @@ final class SqlLexerProfileTest extends TestCase
             namedParameterSuffixPatterns: [':' => '/^<[^ ]*>/', '$' => '/^\([^ ]*\)/'],
             namedParameterForbiddenPredecessors: [':' => [':'], '$' => []],
             backslashEscapedStringPrefixes: ['E'],
+            positionalParameterPatterns: ['/^\$[0-9]+/', '/^\?[0-9]*/'],
             dollarQuoteDelimiterPattern: '/^\$(?:[_A-Za-z][_A-Za-z0-9]*)?\$/',
             numericLiteralPattern: '/^(?:0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*|[0-9]+(?:_[0-9]+)*)/',
             identifierStartPattern: '/^[_A-Za-z]$/',
             identifierPartPattern: '/^[_A-Za-z0-9$]$/',
             bracketPair: ['[', ']'],
+            nestingPair: ['(', ')'],
             nestedBlockComments: true,
-            numberedDollarParameters: true,
-            questionMarkParameters: true,
-            numberedQuestionMarkParameters: true,
             backslashEscapedStrings: false,
         );
 
@@ -55,9 +54,9 @@ final class SqlLexerProfileTest extends TestCase
         self::assertNull($profile->quotedIdentifierValue('plain'));
         self::assertTrue($profile->supportsNestedBlockComments());
         self::assertSame('$tag$', $profile->dollarQuoteDelimiterAt('$tag$body$tag$', 0));
-        self::assertTrue($profile->supportsNumberedDollarParameters());
-        self::assertTrue($profile->supportsQuestionMarkParameters());
-        self::assertTrue($profile->supportsNumberedQuestionMarkParameters());
+        self::assertSame(3, $profile->positionalParameterLengthAt('$12 tail', 0));
+        self::assertSame(3, $profile->positionalParameterLengthAt('?34 tail', 0));
+        self::assertSame(0, $profile->positionalParameterLengthAt('value', 0));
         self::assertSame(':', $profile->namedParameterPrefixAt(':name', 0));
         self::assertSame(':', $profile->namedParameterPrefixAt('x:name', 1));
         self::assertSame('$', $profile->namedParameterPrefixAt('$name', 0));
@@ -82,6 +81,8 @@ final class SqlLexerProfileTest extends TestCase
         self::assertFalse($profile->isBracketOpening('('));
         self::assertTrue($profile->isBracketClosing(']'));
         self::assertFalse($profile->isBracketClosing(')'));
+        self::assertTrue($profile->isNestingOpening('('));
+        self::assertTrue($profile->isNestingClosing(')'));
     }
 
     public function testRejectsEmptyLexicalDelimiter(): void
@@ -134,6 +135,20 @@ final class SqlLexerProfileTest extends TestCase
         FakeSqlLexerProfiles::custom(bracketPair: ['[', '']);
     }
 
+    public function testRejectsEmptyOpeningNestingDelimiter(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        FakeSqlLexerProfiles::custom(nestingPair: ['', ')']);
+    }
+
+    public function testRejectsEmptyClosingNestingDelimiter(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        FakeSqlLexerProfiles::custom(nestingPair: ['(', '']);
+    }
+
     public function testRejectsEmptyParameterPrefix(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -167,6 +182,13 @@ final class SqlLexerProfileTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         FakeSqlLexerProfiles::custom(namedParameterSuffixPatterns: [':' => '/[/']);
+    }
+
+    public function testRejectsInvalidPositionalParameterPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        FakeSqlLexerProfiles::custom(positionalParameterPatterns: ['/[/']);
     }
 
     public function testRestoresTheErrorHandlerAfterInvalidPattern(): void

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -456,8 +456,7 @@ final class SqlTokenStreamTest extends TestCase
     public function testQuestionMarkProfileCanRejectNumericSuffixes(): void
     {
         $profile = FakeSqlLexerProfiles::custom(
-            questionMarkParameters: true,
-            numberedQuestionMarkParameters: false,
+            positionalParameterPatterns: ['/^\?/'],
         );
 
         self::assertSame(

--- a/packages/ztd-query-mysql/src/MySqlLexerProfile.php
+++ b/packages/ztd-query-mysql/src/MySqlLexerProfile.php
@@ -20,15 +20,14 @@ final class MySqlLexerProfile
             namedParameterSuffixPatterns: [],
             namedParameterForbiddenPredecessors: [':' => [':']],
             backslashEscapedStringPrefixes: [],
+            positionalParameterPatterns: ['/^\?/'],
             dollarQuoteDelimiterPattern: null,
             numericLiteralPattern: '/^(?:0[xX][0-9A-Fa-f]+|(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)/',
             identifierStartPattern: '/^[_A-Za-z$\x80-\xFF]$/',
             identifierPartPattern: '/^[_A-Za-z0-9$\x80-\xFF]$/',
             bracketPair: ['[', ']'],
+            nestingPair: ['(', ')'],
             nestedBlockComments: false,
-            numberedDollarParameters: false,
-            questionMarkParameters: true,
-            numberedQuestionMarkParameters: false,
             backslashEscapedStrings: true,
         );
     }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlLexerProfileTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlLexerProfileTest.php
@@ -27,10 +27,10 @@ final class MySqlLexerProfileTest extends TestCase
         self::assertNull($profile->namedParameterPrefixAt('value::type', 6));
         self::assertTrue($profile->isBracketOpening('['));
         self::assertTrue($profile->isBracketClosing(']'));
+        self::assertTrue($profile->isNestingOpening('('));
+        self::assertTrue($profile->isNestingClosing(')'));
         self::assertFalse($profile->supportsNestedBlockComments());
-        self::assertFalse($profile->supportsNumberedDollarParameters());
-        self::assertTrue($profile->supportsQuestionMarkParameters());
-        self::assertFalse($profile->supportsNumberedQuestionMarkParameters());
+        self::assertSame(1, $profile->positionalParameterLengthAt('?1', 0));
         self::assertSame(4, $profile->numberLengthAt('0xCA tail', 0));
         self::assertTrue($profile->isIdentifierStart('$'));
         self::assertTrue($profile->isIdentifierPart('$'));

--- a/packages/ztd-query-postgres/src/PgSqlLexerProfile.php
+++ b/packages/ztd-query-postgres/src/PgSqlLexerProfile.php
@@ -20,15 +20,14 @@ final class PgSqlLexerProfile
             namedParameterSuffixPatterns: [],
             namedParameterForbiddenPredecessors: [':' => [':']],
             backslashEscapedStringPrefixes: ['E', 'e'],
+            positionalParameterPatterns: ['/^\$[0-9]+/', '/^\?/'],
             dollarQuoteDelimiterPattern: '/^\$(?:[_A-Za-z\x80-\xFF][_A-Za-z0-9\x80-\xFF]*)?\$/',
             numericLiteralPattern: '/^(?:0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO]_?[0-7](?:_?[0-7])*|0[bB]_?[01](?:_?[01])*|(?:(?:[0-9](?:_?[0-9])*)(?:\.(?:[0-9](?:_?[0-9])*)?)?|\.(?:[0-9](?:_?[0-9])*))(?:[eE][+-]?[0-9](?:_?[0-9])*)?)/',
             identifierStartPattern: '/^[_A-Za-z\x80-\xFF]$/',
             identifierPartPattern: '/^[_A-Za-z0-9$\x80-\xFF]$/',
             bracketPair: ['[', ']'],
+            nestingPair: ['(', ')'],
             nestedBlockComments: true,
-            numberedDollarParameters: true,
-            questionMarkParameters: true,
-            numberedQuestionMarkParameters: false,
             backslashEscapedStrings: false,
         );
     }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlLexerProfileTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlLexerProfileTest.php
@@ -55,9 +55,11 @@ final class PgSqlLexerProfileTest extends TestCase
         self::assertSame(['/*', '*/'], $profile->blockCommentAt('/* comment */', 0));
         self::assertTrue($profile->isBracketOpening('['));
         self::assertTrue($profile->isBracketClosing(']'));
+        self::assertTrue($profile->isNestingOpening('('));
+        self::assertTrue($profile->isNestingClosing(')'));
         self::assertTrue($profile->supportsNestedBlockComments());
-        self::assertTrue($profile->supportsQuestionMarkParameters());
-        self::assertFalse($profile->supportsNumberedQuestionMarkParameters());
+        self::assertSame(2, $profile->positionalParameterLengthAt('$1', 0));
+        self::assertSame(1, $profile->positionalParameterLengthAt('?1', 0));
     }
 
     public function testRecognizesRadixNumbersAndDoesNotMisclassifyCastOperator(): void

--- a/packages/ztd-query-sqlite/src/SqliteLexerProfile.php
+++ b/packages/ztd-query-sqlite/src/SqliteLexerProfile.php
@@ -20,15 +20,14 @@ final class SqliteLexerProfile
             namedParameterSuffixPatterns: ['$' => '/^\([^ \t\n\r\0\x0B)]*\)/'],
             namedParameterForbiddenPredecessors: [':' => [':'], '@' => [], '$' => []],
             backslashEscapedStringPrefixes: [],
+            positionalParameterPatterns: ['/^\?[0-9]*/'],
             dollarQuoteDelimiterPattern: null,
             numericLiteralPattern: '/^(?:0[xX]_?[0-9A-Fa-f](?:_?[0-9A-Fa-f])*|(?:(?:[0-9](?:_?[0-9])*)(?:\.(?:[0-9](?:_?[0-9])*)?)?|\.(?:[0-9](?:_?[0-9])*))(?:[eE][+-]?[0-9](?:_?[0-9])*)?)/',
             identifierStartPattern: '/^[_A-Za-z$\x80-\xFF]$/',
             identifierPartPattern: '/^[_A-Za-z0-9$\x80-\xFF]$/',
             bracketPair: ['[', ']'],
+            nestingPair: ['(', ')'],
             nestedBlockComments: false,
-            numberedDollarParameters: false,
-            questionMarkParameters: true,
-            numberedQuestionMarkParameters: true,
             backslashEscapedStrings: false,
         );
     }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteLexerProfileTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteLexerProfileTest.php
@@ -41,8 +41,10 @@ final class SqliteLexerProfileTest extends TestCase
         self::assertNull(SqliteLexerProfile::create()->namedParameterPrefixAt('value::type', 6));
         self::assertTrue(SqliteLexerProfile::create()->isBracketOpening('['));
         self::assertTrue(SqliteLexerProfile::create()->isBracketClosing(']'));
+        self::assertTrue(SqliteLexerProfile::create()->isNestingOpening('('));
+        self::assertTrue(SqliteLexerProfile::create()->isNestingClosing(')'));
         self::assertFalse(SqliteLexerProfile::create()->supportsNestedBlockComments());
-        self::assertFalse(SqliteLexerProfile::create()->supportsNumberedDollarParameters());
+        self::assertSame(0, SqliteLexerProfile::create()->positionalParameterLengthAt('$1', 0));
         self::assertFalse(SqliteLexerProfile::create()->stringUsesBackslashEscapes("'value'", 0));
     }
 }


### PR DESCRIPTION
## What

Replace marker booleans with dialect-supplied positional parameter regexes and move nesting delimiters into profiles.

## Why

Core scanner still knew PostgreSQL and SQLite positional marker spellings and digit alphabets.

## Verification

- Core full unit suite; all dialect lexer tests and lints.
- Final stack: 7,188 unit tests and 16,469 assertions passed.

Stack: agent/issue-zero-62-guard-joined-sql -> agent/issue-zero-63-profile-parameter-markers