### PR TITLE
test(phpstan): analyze excluded mysqli bridge boundary

### DIFF
--- a/packages/phpstan-custom-rules/tests/Unit/Rule/NoDialectLogicInCoreOrAdapterRuleTest.php
+++ b/packages/phpstan-custom-rules/tests/Unit/Rule/NoDialectLogicInCoreOrAdapterRuleTest.php
@@ -33,6 +33,7 @@ final class NoDialectLogicInCoreOrAdapterRuleTest extends RuleTestCase
             __DIR__ . '/../../Fixture/PdoAdapterBoundaryFixture.php',
             __DIR__ . '/../../Fixture/MysqliAdapterBoundaryFixture.php',
             __DIR__ . '/../../Fixture/CompositionRootNameCollisionFixture.php',
+            __DIR__ . '/../../../../ztd-query-mysqli-adapter/src/MysqliStatementBindingBridge.php',
         ], [
             [$message, 11],
             [$message, 11],


### PR DESCRIPTION
## What

Feed the exact excluded mysqli bridge source into the dialect-responsibility rule test in addition to its complete-source adapter test.

## Why

A PHPStan compatibility exclusion could otherwise become an unchecked adapter responsibility boundary.

## Verification

- Custom-rule full unit suite and lint.
- Final stack: 7,188 unit tests and 16,469 assertions passed.

Stack: agent/issue-zero-63-profile-parameter-markers -> agent/issue-zero-64-bridge-boundary-analysis