### PR TITLE
fix(core): require result column type resolution

### DIFF
--- a/packages/ztd-query-core/src/Connection/StatementInterface.php
+++ b/packages/ztd-query-core/src/Connection/StatementInterface.php
@@ -37,7 +37,7 @@ interface StatementInterface
      *
      * @return list<ResultColumn>
      */
-    public function resultColumns(?ResultColumnTypeResolver $typeResolver = null): array;
+    public function resultColumns(ResultColumnTypeResolver $typeResolver): array;
 
     /**
      * Return the number of affected rows.

--- a/packages/ztd-query-core/src/Platform/MissingResultColumnTypeResolver.php
+++ b/packages/ztd-query-core/src/Platform/MissingResultColumnTypeResolver.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform;
+
+use LogicException;
+use ZtdQuery\Schema\ColumnType;
+
+final class MissingResultColumnTypeResolver implements ResultColumnTypeResolver
+{
+    public function resolve(array $metadata): ColumnType
+    {
+        throw new LogicException('A database platform result column type resolver is required.');
+    }
+}

--- a/packages/ztd-query-core/src/ResultSelectRunner.php
+++ b/packages/ztd-query-core/src/ResultSelectRunner.php
@@ -19,9 +19,12 @@ final class ResultSelectRunner
      * @param callable(string): (StatementInterface|false) $executor
      * @return array<int, array<string, mixed>>
      */
-    public function run(string $sql, callable $executor): array
-    {
-        return $this->runResultSet($sql, $executor)->rows;
+    public function run(
+        string $sql,
+        callable $executor,
+        ResultColumnTypeResolver $typeResolver,
+    ): array {
+        return $this->runResultSet($sql, $executor, $typeResolver)->rows;
     }
 
     /**
@@ -30,7 +33,7 @@ final class ResultSelectRunner
     public function runResultSet(
         string $sql,
         callable $executor,
-        ?ResultColumnTypeResolver $typeResolver = null,
+        ResultColumnTypeResolver $typeResolver,
     ): ResultSet {
         $statement = $executor($sql);
         if ($statement === false) {
@@ -48,8 +51,8 @@ final class ResultSelectRunner
      */
     public function runStatement(
         StatementInterface $statement,
+        ResultColumnTypeResolver $typeResolver,
         ?array $params = null,
-        ?ResultColumnTypeResolver $typeResolver = null,
     ): array {
         $statement->execute($params);
 
@@ -58,7 +61,7 @@ final class ResultSelectRunner
 
     public function readResultSet(
         StatementInterface $statement,
-        ?ResultColumnTypeResolver $typeResolver = null,
+        ResultColumnTypeResolver $typeResolver,
     ): ResultSet {
         $columns = $statement->resultColumns($typeResolver);
         $rows = $statement->fetchAll();

--- a/packages/ztd-query-core/src/Session.php
+++ b/packages/ztd-query-core/src/Session.php
@@ -19,6 +19,7 @@ use ZtdQuery\Platform\CopySupport;
 use ZtdQuery\Platform\CopyTarget;
 use ZtdQuery\Platform\ParameterBindingCompiler;
 use ZtdQuery\Platform\ResultColumnTypeResolver;
+use ZtdQuery\Platform\MissingResultColumnTypeResolver;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
@@ -90,7 +91,7 @@ final class Session
 
     private ?ParameterBindingCompiler $parameterBindingCompiler;
 
-    private ?ResultColumnTypeResolver $resultColumnTypeResolver;
+    private ResultColumnTypeResolver $resultColumnTypeResolver;
 
     private ?string $lastInsertId = null;
 
@@ -111,7 +112,7 @@ final class Session
         ?TableDefinitionRegistry $registry = null,
         ?CopySupport $copySupport = null,
         ?ParameterBindingCompiler $parameterBindingCompiler = null,
-        ?ResultColumnTypeResolver $resultColumnTypeResolver = null,
+        ResultColumnTypeResolver $resultColumnTypeResolver = new MissingResultColumnTypeResolver(),
     ) {
         $this->rewriter = $rewriter;
         $this->shadowStore = $shadowStore;
@@ -233,7 +234,7 @@ final class Session
         return $this->parameterBindingCompiler;
     }
 
-    public function resultColumnTypeResolver(): ?ResultColumnTypeResolver
+    public function resultColumnTypeResolver(): ResultColumnTypeResolver
     {
         return $this->resultColumnTypeResolver;
     }

--- a/packages/ztd-query-core/tests/Fake/FakeStatement.php
+++ b/packages/ztd-query-core/tests/Fake/FakeStatement.php
@@ -45,7 +45,7 @@ final class FakeStatement implements StatementInterface
         return $this->rows;
     }
 
-    public function resultColumns(?ResultColumnTypeResolver $typeResolver = null): array
+    public function resultColumns(ResultColumnTypeResolver $typeResolver): array
     {
         return $this->columns;
     }

--- a/packages/ztd-query-core/tests/Unit/Platform/MissingResultColumnTypeResolverTest.php
+++ b/packages/ztd-query-core/tests/Unit/Platform/MissingResultColumnTypeResolverTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Platform\MissingResultColumnTypeResolver;
+
+#[CoversClass(MissingResultColumnTypeResolver::class)]
+final class MissingResultColumnTypeResolverTest extends TestCase
+{
+    public function testFailsWhenAPlatformResolverWasNotConfigured(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A database platform result column type resolver is required.');
+
+        (new MissingResultColumnTypeResolver())->resolve([]);
+    }
+}

--- a/packages/ztd-query-core/tests/Unit/ResultSelectRunnerTest.php
+++ b/packages/ztd-query-core/tests/Unit/ResultSelectRunnerTest.php
@@ -27,7 +27,8 @@ final class ResultSelectRunnerTest extends TestCase
         $runner = new ResultSelectRunner();
         $rows = [['id' => 1, 'name' => 'Alice']];
 
-        $result = $runner->run('SELECT * FROM users', fn () => new FakeStatement($rows));
+        $resolver = self::createStub(ResultColumnTypeResolver::class);
+        $result = $runner->run('SELECT * FROM users', fn () => new FakeStatement($rows), $resolver);
 
         self::assertSame($rows, $result);
     }
@@ -36,7 +37,8 @@ final class ResultSelectRunnerTest extends TestCase
     {
         $runner = new ResultSelectRunner();
 
-        $result = $runner->run('SELECT * FROM users', fn () => false);
+        $resolver = self::createStub(ResultColumnTypeResolver::class);
+        $result = $runner->run('SELECT * FROM users', fn () => false, $resolver);
 
         self::assertSame([], $result);
     }
@@ -47,7 +49,8 @@ final class ResultSelectRunnerTest extends TestCase
         $rows = [['id' => 1]];
         $statement = new FakeStatement($rows);
 
-        $result = $runner->runStatement($statement);
+        $resolver = self::createStub(ResultColumnTypeResolver::class);
+        $result = $runner->runStatement($statement, $resolver);
 
         self::assertSame($rows, $result);
         self::assertTrue($statement->isExecuted());
@@ -58,7 +61,12 @@ final class ResultSelectRunnerTest extends TestCase
         $runner = new ResultSelectRunner();
         $column = new ResultColumn('id', new ColumnType(ColumnTypeFamily::INTEGER, 'int4'));
 
-        $result = $runner->runResultSet('SELECT id FROM users WHERE FALSE', fn () => new FakeStatement([], [$column]));
+        $resolver = self::createStub(ResultColumnTypeResolver::class);
+        $result = $runner->runResultSet(
+            'SELECT id FROM users WHERE FALSE',
+            fn () => new FakeStatement([], [$column]),
+            $resolver,
+        );
 
         self::assertInstanceOf(ResultSet::class, $result);
         self::assertSame([], $result->rows);
@@ -71,7 +79,8 @@ final class ResultSelectRunnerTest extends TestCase
         $column = new ResultColumn('id', new ColumnType(ColumnTypeFamily::INTEGER, 'int4'));
         $statement = new FakeStatement([['id' => 1]], [$column]);
 
-        $result = $runner->readResultSet($statement);
+        $resolver = self::createStub(ResultColumnTypeResolver::class);
+        $result = $runner->readResultSet($statement, $resolver);
 
         self::assertSame([['id' => 1]], $result->rows);
         self::assertSame([$column], $result->columns);

--- a/packages/ztd-query-core/tests/Unit/SessionTest.php
+++ b/packages/ztd-query-core/tests/Unit/SessionTest.php
@@ -18,6 +18,7 @@ use ZtdQuery\Exception\ForeignKeyViolationException;
 use ZtdQuery\Platform\CopySupport;
 use ZtdQuery\Platform\CopyTarget;
 use ZtdQuery\Platform\ParameterBindingCompiler;
+use ZtdQuery\Platform\MissingResultColumnTypeResolver;
 use ZtdQuery\Platform\ResultColumnTypeResolver;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
@@ -53,6 +54,7 @@ use ZtdQuery\Shadow\ShadowTransactionManager;
 #[UsesClass(ReferentialIntegrityEnforcer::class)]
 #[UsesClass(MissingPrimaryKeyException::class)]
 #[UsesClass(CopyTarget::class)]
+#[UsesClass(MissingResultColumnTypeResolver::class)]
 final class SessionTest extends TestCase
 {
     public function testEnableAndDisable(): void
@@ -74,7 +76,7 @@ final class SessionTest extends TestCase
         self::assertNull($session->copySupport());
         self::assertNull($session->copyTarget('users', null));
         self::assertNull($session->parameterBindingCompiler());
-        self::assertNull($session->resultColumnTypeResolver());
+        self::assertInstanceOf(MissingResultColumnTypeResolver::class, $session->resultColumnTypeResolver());
 
         $session->disable();
         self::assertFalse($session->isEnabled());

--- a/packages/ztd-query-mysqli-adapter/src/MysqliResultColumnExtractor.php
+++ b/packages/ztd-query-mysqli-adapter/src/MysqliResultColumnExtractor.php
@@ -7,20 +7,17 @@ namespace ZtdQuery\Adapter\Mysqli;
 use mysqli_result;
 use ZtdQuery\Connection\ResultColumn;
 use ZtdQuery\Platform\ResultColumnTypeResolver;
-use ZtdQuery\Schema\ColumnType;
-use ZtdQuery\Schema\ColumnTypeFamily;
 
 final class MysqliResultColumnExtractor
 {
     /** @return list<ResultColumn> */
-    public static function extract(mysqli_result $result, ?ResultColumnTypeResolver $typeResolver = null): array
+    public static function extract(mysqli_result $result, ResultColumnTypeResolver $typeResolver): array
     {
         $columns = [];
         foreach ($result->fetch_fields() as $field) {
             /** @var array<string, mixed> $metadata */
             $metadata = get_object_vars($field);
-            $type = $typeResolver?->resolve($metadata)
-                ?? new ColumnType(ColumnTypeFamily::UNKNOWN, '');
+            $type = $typeResolver->resolve($metadata);
             $columns[] = new ResultColumn($field->name, $type);
         }
 

--- a/packages/ztd-query-mysqli-adapter/src/MysqliResultStatement.php
+++ b/packages/ztd-query-mysqli-adapter/src/MysqliResultStatement.php
@@ -55,7 +55,7 @@ final class MysqliResultStatement implements StatementInterface
     /**
      * {@inheritDoc}
      */
-    public function resultColumns(?ResultColumnTypeResolver $typeResolver = null): array
+    public function resultColumns(ResultColumnTypeResolver $typeResolver): array
     {
         if ($this->result === null) {
             return [];

--- a/packages/ztd-query-mysqli-adapter/src/MysqliStatement.php
+++ b/packages/ztd-query-mysqli-adapter/src/MysqliStatement.php
@@ -97,7 +97,7 @@ final class MysqliStatement implements StatementInterface
     /**
      * {@inheritDoc}
      */
-    public function resultColumns(?ResultColumnTypeResolver $typeResolver = null): array
+    public function resultColumns(ResultColumnTypeResolver $typeResolver): array
     {
         $result = $this->loadResult();
         if ($result === false) {

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultColumnExtractorTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultColumnExtractorTest.php
@@ -10,24 +10,24 @@ use Tests\Fixtures\StubMysqliField;
 use Tests\Fixtures\StubMysqliResult;
 use ZtdQuery\Adapter\Mysqli\MysqliResultColumnExtractor;
 use ZtdQuery\Platform\ResultColumnTypeResolver;
+use ZtdQuery\Platform\MissingResultColumnTypeResolver;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
 #[CoversClass(MysqliResultColumnExtractor::class)]
 final class MysqliResultColumnExtractorTest extends TestCase
 {
-    public function testExtractPreservesEveryResultColumn(): void
+    public function testExtractFailsWithoutDialectResolver(): void
     {
         $result = StubMysqliResult::create([], [
             new StubMysqliField('id', MYSQLI_TYPE_LONG, 63),
             new StubMysqliField('name', MYSQLI_TYPE_VAR_STRING, 255),
         ]);
 
-        $columns = MysqliResultColumnExtractor::extract($result);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A database platform result column type resolver is required.');
 
-        self::assertSame(['id', 'name'], array_map(static fn ($column) => $column->name, $columns));
-        self::assertSame(ColumnTypeFamily::UNKNOWN, $columns[0]->type->family);
-        self::assertSame(ColumnTypeFamily::UNKNOWN, $columns[1]->type->family);
+        MysqliResultColumnExtractor::extract($result, new MissingResultColumnTypeResolver());
     }
 
     public function testExtractDelegatesRawFieldMetadataToResolver(): void

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultStatementTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultStatementTest.php
@@ -80,8 +80,9 @@ final class MysqliResultStatementTest extends TestCase
     public function testResultColumnsReturnsEmptyArrayWithoutResult(): void
     {
         $stmt = new MysqliResultStatement(null, 0);
+        $resolver = self::createStub(ResultColumnTypeResolver::class);
 
-        self::assertSame([], $stmt->resultColumns());
+        self::assertSame([], $stmt->resultColumns($resolver));
     }
 
     public function testResultColumnsMapMysqliFieldMetadata(): void

--- a/packages/ztd-query-pdo-adapter/src/PdoStatement.php
+++ b/packages/ztd-query-pdo-adapter/src/PdoStatement.php
@@ -11,8 +11,6 @@ use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Connection\ResultColumn;
 use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\ResultColumnTypeResolver;
-use ZtdQuery\Schema\ColumnType;
-use ZtdQuery\Schema\ColumnTypeFamily;
 
 /**
  * PDO statement implementing StatementInterface for ZTD layer.
@@ -62,7 +60,7 @@ final class PdoStatement implements StatementInterface
     /**
      * {@inheritDoc}
      */
-    public function resultColumns(?ResultColumnTypeResolver $typeResolver = null): array
+    public function resultColumns(ResultColumnTypeResolver $typeResolver): array
     {
         $columns = [];
         for ($index = 0; $index < $this->statement->columnCount(); $index++) {
@@ -73,25 +71,11 @@ final class PdoStatement implements StatementInterface
 
             $columns[] = new ResultColumn(
                 $metadata['name'],
-                $this->resolveType($metadata, $typeResolver),
+                $typeResolver->resolve($metadata),
             );
         }
 
         return $columns;
-    }
-
-    /**
-     * @param array<string, mixed> $metadata
-     */
-    private function resolveType(
-        array $metadata,
-        ?ResultColumnTypeResolver $typeResolver,
-    ): ColumnType {
-        if ($typeResolver !== null) {
-            return $typeResolver->resolve($metadata);
-        }
-
-        return new ColumnType(ColumnTypeFamily::UNKNOWN, '');
     }
 
     /**

--- a/packages/ztd-query-pdo-adapter/tests/Unit/PdoStatementTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/PdoStatementTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use ZtdQuery\Adapter\Pdo\PdoStatement;
 use ZtdQuery\Connection\StatementInterface;
 use ZtdQuery\Platform\ResultColumnTypeResolver;
+use ZtdQuery\Platform\MissingResultColumnTypeResolver;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
 
@@ -96,16 +97,15 @@ final class PdoStatementTest extends TestCase
         self::assertSame(ColumnTypeFamily::FLOAT, $columns[2]->type->family);
     }
 
-    public function testResultColumnsDoNotInterpretMetadataWithoutDialectResolver(): void
+    public function testResultColumnsFailWithoutDialectResolver(): void
     {
         $pdo = new PDO('sqlite::memory:');
         $nativeStmt = $pdo->query('SELECT 1 AS id');
         self::assertNotFalse($nativeStmt);
 
-        $columns = (new PdoStatement($nativeStmt))->resultColumns();
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A database platform result column type resolver is required.');
 
-        self::assertCount(1, $columns);
-        self::assertSame(ColumnTypeFamily::UNKNOWN, $columns[0]->type->family);
-        self::assertSame('', $columns[0]->type->nativeType);
+        (new PdoStatement($nativeStmt))->resultColumns(new MissingResultColumnTypeResolver());
     }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoStatementTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoStatementTest.php
@@ -18,11 +18,14 @@ use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\Exception\DatabaseException;
 use ZtdQuery\Exception\MissingPrimaryKeyException;
+use ZtdQuery\Platform\ResultColumnTypeResolver;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Session;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Shadow\Mutation\UpdateMutation;
 use ZtdQuery\Shadow\ShadowStore;
 
@@ -132,12 +135,15 @@ final class ZtdPdoStatementTest extends TestCase
 
         $shadowStore = new ShadowStore();
         $shadowStore->set('users', [['id' => 1, 'name' => 'Alice']]);
+        $typeResolver = static::createStub(ResultColumnTypeResolver::class);
+        $typeResolver->method('resolve')->willReturn(new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'));
         $session = new Session(
             static::createStub(SqlRewriter::class),
             $shadowStore,
             new ResultSelectRunner(),
             ZtdConfig::default(),
             static::createStub(ConnectionInterface::class),
+            resultColumnTypeResolver: $typeResolver,
         );
         $plan = new RewritePlan(
             "SELECT 1 AS id, 'Bob' AS name",

--- a/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoTest.php
@@ -16,11 +16,14 @@ use ZtdQuery\Adapter\Pdo\ZtdPdo;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\SessionFactory;
+use ZtdQuery\Platform\ResultColumnTypeResolver;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
 use ZtdQuery\Rewrite\RewritePlan;
 use ZtdQuery\Rewrite\SqlRewriter;
 use ZtdQuery\Session;
+use ZtdQuery\Schema\ColumnType;
+use ZtdQuery\Schema\ColumnTypeFamily;
 use ZtdQuery\Shadow\Mutation\InsertMutation;
 use ZtdQuery\Shadow\ShadowStore;
 
@@ -288,6 +291,8 @@ final class ZtdPdoTest extends TestCase
                 default => throw new RuntimeException("Unexpected SQL: $sql"),
             });
         $factory = static::createMock(SessionFactory::class);
+        $typeResolver = static::createStub(ResultColumnTypeResolver::class);
+        $typeResolver->method('resolve')->willReturn(new ColumnType(ColumnTypeFamily::INTEGER, 'INTEGER'));
         $factory->expects(self::once())
             ->method('create')
             ->willReturnCallback(static fn (ConnectionInterface $connection, ZtdConfig $config): Session => new Session(
@@ -296,6 +301,7 @@ final class ZtdPdoTest extends TestCase
                 new ResultSelectRunner(),
                 $config,
                 $connection,
+                resultColumnTypeResolver: $typeResolver,
             ));
         $ztdPdo = ZtdPdo::fromPdo(new PDO('sqlite::memory:'), null, $factory);
 


### PR DESCRIPTION
## What

Make resolver APIs non-null, remove adapter fallbacks, and fail explicitly through MissingResultColumnTypeResolver when a platform was not configured.

## Why

Missing dialect metadata resolution silently degraded to UNKNOWN with an empty native type.

## Verification

- Core and both adapter full unit suites; PHPStan and formatting.
- Final stack: 7,188 unit tests and 16,469 assertions passed.

Stack: agent/issue-zero-64-bridge-boundary-analysis -> agent/issue-zero-65-require-column-type-resolver