### PR TITLE
fix(mysql): reflect session SQL mode in lexing

### DIFF
--- a/packages/ztd-query-mysql/src/MySqlLexerProfile.php
+++ b/packages/ztd-query-mysql/src/MySqlLexerProfile.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Platform\MySql;
 
+use PhpMyAdmin\SqlParser\Context;
 use ZtdQuery\Sql\SqlLexerProfile;
 
 final class MySqlLexerProfile
 {
-    public static function create(bool $ansiQuotes = false): SqlLexerProfile
+    public static function create(?bool $ansiQuotes = null): SqlLexerProfile
     {
+        $ansiQuotes ??= Context::hasMode(Context::SQL_MODE_ANSI_QUOTES);
+
         return new SqlLexerProfile(
             lineCommentPrefixes: ['#'],
             whitespaceDelimitedLineCommentPrefixes: ['--'],

--- a/packages/ztd-query-mysql/src/MySqlSessionFactory.php
+++ b/packages/ztd-query-mysql/src/MySqlSessionFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ZtdQuery\Platform\MySql;
 
+use PhpMyAdmin\SqlParser\Context;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\MySql\Transformer\DeleteTransformer;
@@ -30,6 +31,8 @@ final class MySqlSessionFactory implements SessionFactory
      */
     public function create(ConnectionInterface $connection, ZtdConfig $config): Session
     {
+        Context::setMode((new MySqlSessionSqlModeReflector($connection))->reflect());
+
         $shadowStore = new ShadowStore();
         $parser = new MySqlParser();
         $schemaParser = new MySqlSchemaParser($parser);

--- a/packages/ztd-query-mysql/src/MySqlSessionSqlModeReflector.php
+++ b/packages/ztd-query-mysql/src/MySqlSessionSqlModeReflector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZtdQuery\Platform\MySql;
+
+use ZtdQuery\Connection\ConnectionInterface;
+
+final class MySqlSessionSqlModeReflector
+{
+    public function __construct(private readonly ConnectionInterface $connection)
+    {
+    }
+
+    public function reflect(): string
+    {
+        $statement = $this->connection->query('SELECT @@SESSION.sql_mode AS ztd_sql_mode');
+        if ($statement === false) {
+            return '';
+        }
+        $row = $statement->fetchAll()[0] ?? [];
+        $sqlMode = $row['ztd_sql_mode'] ?? '';
+
+        return is_string($sqlMode) ? $sqlMode : '';
+    }
+}

--- a/packages/ztd-query-mysql/tests/Unit/MySqlLexerProfileTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlLexerProfileTest.php
@@ -15,7 +15,7 @@ final class MySqlLexerProfileTest extends TestCase
 {
     public function testAddsMySqlHashLineComments(): void
     {
-        $profile = MySqlLexerProfile::create();
+        $profile = MySqlLexerProfile::create(false);
 
         self::assertTrue($profile->startsLineComment('# comment', 0));
         self::assertTrue($profile->startsLineComment('-- comment', 0));
@@ -40,7 +40,7 @@ final class MySqlLexerProfileTest extends TestCase
 
     public function testUsesDefaultAndAnsiQuotesModesExplicitly(): void
     {
-        $default = SqlTokenStream::tokenize('"value" `column`', MySqlLexerProfile::create())->significantTokens();
+        $default = SqlTokenStream::tokenize('"value" `column`', MySqlLexerProfile::create(false))->significantTokens();
         $ansi = SqlTokenStream::tokenize('"column" `other`', MySqlLexerProfile::create(true))->significantTokens();
 
         self::assertSame(SqlTokenKind::String, $default[0]->kind);

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use PhpMyAdmin\SqlParser\Context;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Connection\StatementInterface;
+use ZtdQuery\Platform\MySql\MySqlLexerProfile;
 use ZtdQuery\Platform\MySql\MySqlMutationResolver;
 use ZtdQuery\Platform\MySql\MySqlCastRenderer;
 use ZtdQuery\Platform\MySql\MySqlIdentifierQuoter;
@@ -20,6 +22,7 @@ use ZtdQuery\Platform\MySql\MySqlRewriter;
 use ZtdQuery\Platform\MySql\MySqlSchemaParser;
 use ZtdQuery\Platform\MySql\MySqlSchemaReflector;
 use ZtdQuery\Platform\MySql\MySqlSessionFactory;
+use ZtdQuery\Platform\MySql\MySqlSessionSqlModeReflector;
 use ZtdQuery\Platform\MySql\Transformer\DeleteTransformer;
 use ZtdQuery\Platform\MySql\Transformer\InsertTransformer;
 use ZtdQuery\Platform\MySql\Transformer\MySqlTransformer;
@@ -27,8 +30,11 @@ use ZtdQuery\Platform\MySql\Transformer\ReplaceTransformer;
 use ZtdQuery\Platform\MySql\Transformer\SelectTransformer;
 use ZtdQuery\Platform\MySql\Transformer\UpdateTransformer;
 use ZtdQuery\Session;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(MySqlSessionFactory::class)]
+#[UsesClass(MySqlLexerProfile::class)]
 #[UsesClass(MySqlMutationResolver::class)]
 #[UsesClass(MySqlCastRenderer::class)]
 #[UsesClass(MySqlIdentifierQuoter::class)]
@@ -38,6 +44,7 @@ use ZtdQuery\Session;
 #[UsesClass(MySqlRewriter::class)]
 #[UsesClass(MySqlSchemaParser::class)]
 #[UsesClass(MySqlSchemaReflector::class)]
+#[UsesClass(MySqlSessionSqlModeReflector::class)]
 #[UsesClass(DeleteTransformer::class)]
 #[UsesClass(InsertTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\Transformer\InsertRowRenderer::class)]
@@ -52,6 +59,7 @@ use ZtdQuery\Session;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlTypeSemantics::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlCteShadowComposer::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlNativeUpsertProjector::class)]
+#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlReadOnlyDiagnosticStatement::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewDefinitionParser::class)]
@@ -102,5 +110,29 @@ final class MySqlSessionFactoryTest extends TestCase
 
         self::assertInstanceOf(Session::class, $session);
         self::assertInstanceOf(MySqlResultColumnTypeResolver::class, $session->resultColumnTypeResolver());
+    }
+
+    public function testCreateAppliesReflectedAnsiQuotesModeToProductionLexing(): void
+    {
+        $empty = self::createStub(StatementInterface::class);
+        $empty->method('fetchAll')->willReturn([]);
+        $sqlMode = self::createStub(StatementInterface::class);
+        $sqlMode->method('fetchAll')->willReturn([['ztd_sql_mode' => 'STRICT_TRANS_TABLES,ANSI_QUOTES']]);
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            static fn (string $sql): StatementInterface => $sql === 'SELECT @@SESSION.sql_mode AS ztd_sql_mode'
+                ? $sqlMode
+                : $empty,
+        );
+        $previousMode = Context::getMode();
+
+        try {
+            (new MySqlSessionFactory())->create($connection, ZtdConfig::default());
+            $tokens = SqlTokenStream::tokenize('"column"', MySqlLexerProfile::create())->significantTokens();
+
+            self::assertSame(SqlTokenKind::QuotedIdentifier, $tokens[0]->kind);
+        } finally {
+            Context::setMode($previousMode);
+        }
     }
 }

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionFactoryTest.php
@@ -64,8 +64,6 @@ use ZtdQuery\Sql\SqlTokenStream;
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlSelectRelationParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewDefinitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\MySql\MySqlViewShadowRenderer::class)]
-#[UsesClass(\ZtdQuery\Platform\MySql\MySqlGeneratedColumnProjector::class)]
-#[UsesClass(\ZtdQuery\Platform\MySql\MySqlLexerProfile::class)]
 final class MySqlSessionFactoryTest extends TestCase
 {
     public function testCreateRegistersReflectedViews(): void

--- a/packages/ztd-query-mysql/tests/Unit/MySqlSessionSqlModeReflectorTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlSessionSqlModeReflectorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZtdQuery\Connection\ConnectionInterface;
+use ZtdQuery\Connection\StatementInterface;
+use ZtdQuery\Platform\MySql\MySqlSessionSqlModeReflector;
+
+#[CoversClass(MySqlSessionSqlModeReflector::class)]
+final class MySqlSessionSqlModeReflectorTest extends TestCase
+{
+    public function testReflectsTheCurrentSessionSqlMode(): void
+    {
+        $statement = self::createStub(StatementInterface::class);
+        $statement->method('fetchAll')->willReturn([['ztd_sql_mode' => 'STRICT_TRANS_TABLES,ANSI_QUOTES']]);
+        $connection = self::createMock(ConnectionInterface::class);
+        $connection->expects(self::once())
+            ->method('query')
+            ->with('SELECT @@SESSION.sql_mode AS ztd_sql_mode')
+            ->willReturn($statement);
+
+        self::assertSame(
+            'STRICT_TRANS_TABLES,ANSI_QUOTES',
+            (new MySqlSessionSqlModeReflector($connection))->reflect(),
+        );
+    }
+
+    public function testUsesTheDefaultModeWhenReflectionFails(): void
+    {
+        $connection = self::createStub(ConnectionInterface::class);
+        $connection->method('query')->willReturn(false);
+
+        self::assertSame('', (new MySqlSessionSqlModeReflector($connection))->reflect());
+    }
+}


### PR DESCRIPTION
## What

Reflect the live MySQL session sql_mode before parser construction and let production lexer profiles follow that parser context.

## Why

ANSI_QUOTES lexer support existed only as an unreachable test flag.

## Verification

- MySQL full unit suite, production-path ANSI_QUOTES regression test, and lint.
- Final stack: 7,188 unit tests and 16,469 assertions passed.

Stack: agent/issue-zero-65-require-column-type-resolver -> agent/issue-zero-66-mysql-session-sql-mode