### PR TITLE
refactor(core): move SQL punctuation into lexer profiles

### DIFF
--- a/packages/ztd-query-core/src/Sql/SqlLexerProfile.php
+++ b/packages/ztd-query-core/src/Sql/SqlLexerProfile.php
@@ -78,6 +78,8 @@ final class SqlLexerProfile
         private readonly string $identifierPartPattern,
         ?array $bracketPair,
         array $nestingPair,
+        private readonly string $statementDelimiter,
+        private readonly string $listDelimiter,
         private readonly bool $nestedBlockComments,
         private readonly bool $backslashEscapedStrings,
     ) {
@@ -109,6 +111,9 @@ final class SqlLexerProfile
         }
         /** @var array{non-empty-string, non-empty-string} $nestingPair */
         $this->nestingPair = $nestingPair;
+        if (strlen($this->statementDelimiter) !== 1 || strlen($this->listDelimiter) !== 1) {
+            throw new InvalidArgumentException('Statement and list delimiters must be single characters.');
+        }
     }
 
     public function startsLineComment(string $sql, int $offset): bool
@@ -304,6 +309,16 @@ final class SqlLexerProfile
     public function isNestingClosing(string $character): bool
     {
         return $character === $this->nestingPair[1];
+    }
+
+    public function isStatementDelimiter(string $symbol): bool
+    {
+        return $symbol === $this->statementDelimiter;
+    }
+
+    public function listDelimiter(): string
+    {
+        return $this->listDelimiter;
     }
 
     private function matchesCharacter(string $pattern, string $character): bool

--- a/packages/ztd-query-core/src/Sql/SqlTokenStream.php
+++ b/packages/ztd-query-core/src/Sql/SqlTokenStream.php
@@ -69,9 +69,9 @@ final class SqlTokenStream
         return null;
     }
 
-    public function matchingClosingParenthesis(SqlToken $opening): ?SqlToken
+    public function matchingClosingNestingToken(SqlToken $opening): ?SqlToken
     {
-        if ($opening->kind !== SqlTokenKind::Symbol || $opening->text !== '(') {
+        if ($opening->kind !== SqlTokenKind::Symbol || !$this->profile->isNestingOpening($opening->text)) {
             return null;
         }
 
@@ -84,7 +84,7 @@ final class SqlTokenStream
             if ($token->kind !== SqlTokenKind::Symbol) {
                 continue;
             }
-            if ($token->text !== ')') {
+            if (!$this->profile->isNestingClosing($token->text)) {
                 continue;
             }
             if ($token->depth !== $opening->depth) {
@@ -117,7 +117,10 @@ final class SqlTokenStream
         $statements = [];
         $start = 0;
         foreach ($this->significantTokens() as $token) {
-            if ($token->kind !== SqlTokenKind::Symbol || $token->text !== ';' || !$token->isTopLevel()) {
+            if ($token->kind !== SqlTokenKind::Symbol
+                || !$this->profile->isStatementDelimiter($token->text)
+                || !$token->isTopLevel()
+            ) {
                 continue;
             }
             $statement = trim(substr($this->sql, $start, $token->offset - $start));
@@ -194,8 +197,9 @@ final class SqlTokenStream
     /**
      * @return list<string>
      */
-    public function splitTopLevel(string $delimiter = ','): array
+    public function splitTopLevel(?string $delimiter = null): array
     {
+        $delimiter ??= $this->profile->listDelimiter();
         $parts = [];
         $start = 0;
         foreach ($this->significantTokens() as $token) {

--- a/packages/ztd-query-core/tests/Fake/FakeSqlLexerProfiles.php
+++ b/packages/ztd-query-core/tests/Fake/FakeSqlLexerProfiles.php
@@ -39,6 +39,8 @@ final class FakeSqlLexerProfiles
         string $identifierPartPattern = '/^[_A-Za-z0-9]$/',
         ?array $bracketPair = null,
         array $nestingPair = ['(', ')'],
+        string $statementDelimiter = ';',
+        string $listDelimiter = ',',
         bool $nestedBlockComments = false,
         bool $backslashEscapedStrings = false,
     ): SqlLexerProfile {
@@ -59,6 +61,8 @@ final class FakeSqlLexerProfiles
             identifierPartPattern: $identifierPartPattern,
             bracketPair: $bracketPair,
             nestingPair: $nestingPair,
+            statementDelimiter: $statementDelimiter,
+            listDelimiter: $listDelimiter,
             nestedBlockComments: $nestedBlockComments,
             backslashEscapedStrings: $backslashEscapedStrings,
         );
@@ -83,6 +87,8 @@ final class FakeSqlLexerProfiles
             identifierPartPattern: '/^[_A-Za-z0-9\x80-\xFF]$/',
             bracketPair: ['[', ']'],
             nestingPair: ['(', ')'],
+            statementDelimiter: ';',
+            listDelimiter: ',',
             nestedBlockComments: true,
             backslashEscapedStrings: false,
         );
@@ -107,6 +113,8 @@ final class FakeSqlLexerProfiles
             identifierPartPattern: '/^[_A-Za-z0-9$\x80-\xFF]$/',
             bracketPair: ['[', ']'],
             nestingPair: ['(', ')'],
+            statementDelimiter: ';',
+            listDelimiter: ',',
             nestedBlockComments: true,
             backslashEscapedStrings: true,
         );

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlLexerProfileTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlLexerProfileTest.php
@@ -32,6 +32,8 @@ final class SqlLexerProfileTest extends TestCase
             identifierPartPattern: '/^[_A-Za-z0-9$]$/',
             bracketPair: ['[', ']'],
             nestingPair: ['(', ')'],
+            statementDelimiter: ';',
+            listDelimiter: ',',
             nestedBlockComments: true,
             backslashEscapedStrings: false,
         );
@@ -83,6 +85,8 @@ final class SqlLexerProfileTest extends TestCase
         self::assertFalse($profile->isBracketClosing(')'));
         self::assertTrue($profile->isNestingOpening('('));
         self::assertTrue($profile->isNestingClosing(')'));
+        self::assertTrue($profile->isStatementDelimiter(';'));
+        self::assertSame(',', $profile->listDelimiter());
     }
 
     public function testRejectsEmptyLexicalDelimiter(): void
@@ -147,6 +151,20 @@ final class SqlLexerProfileTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         FakeSqlLexerProfiles::custom(nestingPair: ['(', '']);
+    }
+
+    public function testRejectsInvalidStatementDelimiterLength(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        FakeSqlLexerProfiles::custom(statementDelimiter: ';;');
+    }
+
+    public function testRejectsInvalidListDelimiterLength(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        FakeSqlLexerProfiles::custom(listDelimiter: '::');
     }
 
     public function testRejectsEmptyParameterPrefix(): void

--- a/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
+++ b/packages/ztd-query-core/tests/Unit/Sql/SqlTokenStreamTest.php
@@ -43,8 +43,8 @@ final class SqlTokenStreamTest extends TestCase
     {
         $stream = SqlTokenStream::tokenize('MATCH((title), body) AGAINST (?)', FakeSqlLexerProfiles::standard());
         $tokens = $stream->significantTokens();
-        $columnsClosing = $stream->matchingClosingParenthesis($tokens[1]);
-        $queryClosing = $stream->matchingClosingParenthesis($tokens[9]);
+        $columnsClosing = $stream->matchingClosingNestingToken($tokens[1]);
+        $queryClosing = $stream->matchingClosingNestingToken($tokens[9]);
 
         self::assertNotNull($columnsClosing);
         self::assertNotNull($queryClosing);
@@ -63,11 +63,11 @@ final class SqlTokenStreamTest extends TestCase
         $closingSymbols = SqlTokenStream::tokenize(') )', FakeSqlLexerProfiles::standard());
         $closingTokens = $closingSymbols->significantTokens();
 
-        self::assertNull($stream->matchingClosingParenthesis($tokens[0]));
-        self::assertNull($stream->matchingClosingParenthesis($tokens[1]));
-        self::assertNull($stream->matchingClosingParenthesis($foreign));
-        self::assertNull($closed->matchingClosingParenthesis($closedTokens[0]));
-        self::assertNull($closingSymbols->matchingClosingParenthesis($closingTokens[0]));
+        self::assertNull($stream->matchingClosingNestingToken($tokens[0]));
+        self::assertNull($stream->matchingClosingNestingToken($tokens[1]));
+        self::assertNull($stream->matchingClosingNestingToken($foreign));
+        self::assertNull($closed->matchingClosingNestingToken($closedTokens[0]));
+        self::assertNull($closingSymbols->matchingClosingNestingToken($closingTokens[0]));
     }
 
     public function testReadsWordAndQuotedIdentifiersAtSignificantTokenOffsets(): void
@@ -116,6 +116,27 @@ final class SqlTokenStreamTest extends TestCase
     public function testReturnsNoStatementsForEmptyInputAndTerminators(): void
     {
         self::assertSame([], SqlTokenStream::tokenize(' ; ; ', FakeSqlLexerProfiles::standard())->splitStatements());
+    }
+
+    public function testUsesProfileSuppliedNestingAndPunctuation(): void
+    {
+        $profile = FakeSqlLexerProfiles::custom(
+            nestingPair: ['{', '}'],
+            statementDelimiter: '!',
+            listDelimiter: '|',
+        );
+        $nested = SqlTokenStream::tokenize('outer{inner{value}}', $profile);
+        $tokens = $nested->significantTokens();
+
+        self::assertSame('}', $nested->matchingClosingNestingToken($tokens[1])?->text);
+        self::assertSame(
+            ['alpha{nested!value}', 'beta'],
+            SqlTokenStream::tokenize('alpha{nested!value}!beta', $profile)->splitStatements(),
+        );
+        self::assertSame(
+            ['first', 'nested{second|third}', 'last'],
+            SqlTokenStream::tokenize('first|nested{second|third}|last', $profile)->splitTopLevel(),
+        );
     }
 
     public function testClauseIgnoresNestedKeywords(): void

--- a/packages/ztd-query-mysql/src/MySqlFullTextSearchRewriter.php
+++ b/packages/ztd-query-mysql/src/MySqlFullTextSearchRewriter.php
@@ -45,7 +45,7 @@ final class MySqlFullTextSearchRewriter
         if ($columnsOpen === null) {
             return null;
         }
-        $columnsClose = $stream->matchingClosingParenthesis($columnsOpen);
+        $columnsClose = $stream->matchingClosingNestingToken($columnsOpen);
         if ($columnsClose === null) {
             return null;
         }
@@ -57,7 +57,7 @@ final class MySqlFullTextSearchRewriter
         if ($queryOpen === null) {
             return null;
         }
-        $queryClose = $stream->matchingClosingParenthesis($queryOpen);
+        $queryClose = $stream->matchingClosingNestingToken($queryOpen);
         if ($queryClose === null) {
             return null;
         }

--- a/packages/ztd-query-mysql/src/MySqlLexerProfile.php
+++ b/packages/ztd-query-mysql/src/MySqlLexerProfile.php
@@ -30,6 +30,8 @@ final class MySqlLexerProfile
             identifierPartPattern: '/^[_A-Za-z0-9$\x80-\xFF]$/',
             bracketPair: ['[', ']'],
             nestingPair: ['(', ')'],
+            statementDelimiter: ';',
+            listDelimiter: ',',
             nestedBlockComments: false,
             backslashEscapedStrings: true,
         );

--- a/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/MySqlCteShadowComposerTest.php
@@ -168,6 +168,16 @@ final class MySqlCteShadowComposerTest extends TestCase
             $declared,
             $composer->compose($declared, ['Users' => 'Users AS (SELECT 2 AS id)']),
         );
+        self::assertStringContainsString(
+            'orders AS (SELECT 2 AS id)',
+            $composer->compose(
+                'WITH users AS (SELECT 1 AS id) SELECT * FROM users JOIN orders ON TRUE',
+                [
+                    'orders' => 'orders AS (SELECT 2 AS id)',
+                    'Users' => 'Users AS (SELECT 3 AS id)',
+                ],
+            ),
+        );
     }
 
     public function testHandlesAWithTokenWithoutFollowingHeaderTokens(): void

--- a/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-mysql/tests/Unit/Transformer/InsertTransformerTest.php
@@ -975,6 +975,7 @@ final class InsertTransformerTest extends TestCase
         ]];
 
         $transformer->transform("INSERT INTO users (id, name) VALUES (42, 'explicit')", $tables);
+        $transformer->commitRewriteState();
         $generated = $transformer->transform("INSERT INTO users (name) VALUES ('generated')", $tables);
 
         self::assertStringContainsString('1 AS `id`', $generated);
@@ -991,6 +992,7 @@ final class InsertTransformerTest extends TestCase
         ]];
 
         $transformer->transform("INSERT INTO users SET id = 42, name = 'explicit'", $tables);
+        $transformer->commitRewriteState();
         $generated = $transformer->transform("INSERT INTO users SET name = 'generated'", $tables);
 
         self::assertStringContainsString('1 AS `id`', $generated);

--- a/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultColumnExtractorTest.php
+++ b/packages/ztd-query-mysqli-adapter/tests/Unit/MysqliResultColumnExtractorTest.php
@@ -46,4 +46,18 @@ final class MysqliResultColumnExtractorTest extends TestCase
         self::assertSame('value', $columns[0]->name);
         self::assertSame(ColumnTypeFamily::INTEGER, $columns[0]->type->family);
     }
+
+    public function testExtractReturnsEveryResultColumn(): void
+    {
+        $result = StubMysqliResult::create([], [
+            new StubMysqliField('id', MYSQLI_TYPE_LONG, 63),
+            new StubMysqliField('name', MYSQLI_TYPE_VAR_STRING, 255),
+        ]);
+        $resolver = self::createStub(ResultColumnTypeResolver::class);
+        $resolver->method('resolve')->willReturn(new ColumnType(ColumnTypeFamily::STRING, 'TEXT'));
+
+        $columns = MysqliResultColumnExtractor::extract($result, $resolver);
+
+        self::assertSame(['id', 'name'], array_column($columns, 'name'));
+    }
 }

--- a/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoTest.php
+++ b/packages/ztd-query-pdo-adapter/tests/Unit/ZtdPdoTest.php
@@ -13,9 +13,11 @@ use RuntimeException;
 use ZtdQuery\Adapter\Pdo\PdoConnection;
 use ZtdQuery\Adapter\Pdo\PdoStatement;
 use ZtdQuery\Adapter\Pdo\ZtdPdo;
+use ZtdQuery\Adapter\Pdo\ZtdPdoException;
 use ZtdQuery\Config\ZtdConfig;
 use ZtdQuery\Connection\ConnectionInterface;
 use ZtdQuery\Platform\SessionFactory;
+use ZtdQuery\Platform\CopySupport;
 use ZtdQuery\Platform\ResultColumnTypeResolver;
 use ZtdQuery\ResultSelectRunner;
 use ZtdQuery\Rewrite\QueryKind;
@@ -30,6 +32,7 @@ use ZtdQuery\Shadow\ShadowStore;
 #[CoversClass(ZtdPdo::class)]
 #[UsesClass(PdoConnection::class)]
 #[UsesClass(PdoStatement::class)]
+#[UsesClass(ZtdPdoException::class)]
 final class ZtdPdoTest extends TestCase
 {
     /**
@@ -308,6 +311,32 @@ final class ZtdPdoTest extends TestCase
         self::assertSame(1, $ztdPdo->exec('first; second'));
         self::assertSame([['id' => 1], ['id' => 2]], $store->get('first_items'));
         self::assertSame([['id' => 3]], $store->get('second_items'));
+    }
+
+    public function testExecRejectsRawPostgreSqlCopy(): void
+    {
+        $rewriter = static::createStub(SqlRewriter::class);
+        $copySupport = static::createStub(CopySupport::class);
+        $copySupport->method('isCopyStatement')->willReturn(true);
+        $factory = static::createStub(SessionFactory::class);
+        $factory->method('create')
+            ->willReturnCallback(static fn (ConnectionInterface $connection, ZtdConfig $config): Session => new Session(
+                $rewriter,
+                new ShadowStore(),
+                new ResultSelectRunner(),
+                $config,
+                $connection,
+                copySupport: $copySupport,
+            ));
+        $ztdPdo = ZtdPdo::fromPdo(new PDO('sqlite::memory:'), null, $factory);
+
+        $this->expectException(ZtdPdoException::class);
+        $this->expectExceptionMessage(
+            'ZTD Write Protection: Raw PostgreSQL COPY cannot preserve shadow isolation; '
+            . 'use the pgsqlCopyToArray(), pgsqlCopyFromArray(), pgsqlCopyToFile(), or pgsqlCopyFromFile() methods.',
+        );
+
+        $ztdPdo->exec('COPY users TO STDOUT');
     }
 
     public function testExecStopsBatchWhenFirstStatementFails(): void

--- a/packages/ztd-query-postgres/src/PgSqlLexerProfile.php
+++ b/packages/ztd-query-postgres/src/PgSqlLexerProfile.php
@@ -27,6 +27,8 @@ final class PgSqlLexerProfile
             identifierPartPattern: '/^[_A-Za-z0-9$\x80-\xFF]$/',
             bracketPair: ['[', ']'],
             nestingPair: ['(', ')'],
+            statementDelimiter: ';',
+            listDelimiter: ',',
             nestedBlockComments: true,
             backslashEscapedStrings: false,
         );

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlCteShadowComposerTest.php
@@ -147,6 +147,16 @@ final class PgSqlCteShadowComposerTest extends TestCase
             $declared,
             $composer->compose($declared, ['Users' => 'Users AS (SELECT 2 AS id)']),
         );
+        self::assertStringContainsString(
+            'orders AS (SELECT 2 AS id)',
+            $composer->compose(
+                'WITH users AS (SELECT 1 AS id) SELECT * FROM users JOIN orders ON TRUE',
+                [
+                    'orders' => 'orders AS (SELECT 2 AS id)',
+                    'Users' => 'Users AS (SELECT 3 AS id)',
+                ],
+            ),
+        );
     }
 
     public function testHandlesAWithTokenWithoutFollowingHeaderTokens(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlPartitionParserTest.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
 use ZtdQuery\Schema\TablePartitionKey;
 use ZtdQuery\Schema\TablePartitionStrategy;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(PgSqlPartitionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlLexerProfile::class)]
@@ -260,5 +263,14 @@ final class PgSqlPartitionParserTest extends TestCase
             'Logs',
             $parser->parentTable('CREATE TABLE child PARTITION OF public."Logs" DEFAULT'),
         );
+    }
+
+    public function testQualifiedIdentifierRejectsMismatchedTokenStream(): void
+    {
+        $method = new \ReflectionMethod(PgSqlPartitionParser::class, 'qualifiedIdentifierAt');
+        $stream = SqlTokenStream::tokenize('users', \ZtdQuery\Platform\Postgres\PgSqlLexerProfile::create());
+        $tokens = [new SqlToken(SqlTokenKind::String, 'users', 0, 0, 0)];
+
+        self::assertNull($method->invoke(new PgSqlPartitionParser(), $stream, $tokens, 0));
     }
 }

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlSchemaParserTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use ZtdQuery\Platform\Postgres\PgSqlPartitionParser;
 use ZtdQuery\Schema\TablePartitionStrategy;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
+use ZtdQuery\Sql\SqlTokenStream;
 
 #[CoversClass(PgSqlSchemaParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlColumnTypeMapper::class)]
@@ -21,6 +24,15 @@ use ZtdQuery\Schema\TablePartitionStrategy;
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlLexerProfile::class)]
 final class PgSqlSchemaParserTest extends SchemaParserContractTest
 {
+    public function testQualifiedIdentifierRejectsMismatchedTokenStream(): void
+    {
+        $method = new \ReflectionMethod(PgSqlSchemaParser::class, 'qualifiedIdentifierAt');
+        $stream = SqlTokenStream::tokenize('users', \ZtdQuery\Platform\Postgres\PgSqlLexerProfile::create());
+        $tokens = [new SqlToken(SqlTokenKind::String, 'users', 0, 0, 0)];
+
+        self::assertNull($method->invoke(new PgSqlSchemaParser(), $stream, $tokens, 0));
+    }
+
     public function testParsesSchemaQualifiedQuotedDomainTypeWithoutChangingItsCase(): void
     {
         $definition = (new PgSqlSchemaParser())->parse(

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlTransformerTest.php
@@ -19,6 +19,7 @@ use ZtdQuery\Platform\Postgres\Transformer\SelectTransformer;
 use ZtdQuery\Platform\Postgres\Transformer\UpdateTransformer;
 use ZtdQuery\Schema\ColumnType;
 use ZtdQuery\Schema\ColumnTypeFamily;
+use ZtdQuery\Schema\IdentityGenerationStrategy;
 
 #[CoversClass(PgSqlTransformer::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlSelectRelationParser::class)]
@@ -124,6 +125,32 @@ final class PgSqlTransformerTest extends TestCase
 
         self::assertStringContainsString('WHERE NOT (EXISTS', $result);
         $transformer->commitRewriteState();
+    }
+
+    public function testCommitRewriteStateCommitsGeneratedIdentityValues(): void
+    {
+        $parser = new PgSqlParser();
+        $selectTransformer = new SelectTransformer();
+        $transformer = new PgSqlTransformer(
+            $parser,
+            $selectTransformer,
+            new InsertTransformer($parser, $selectTransformer),
+            new UpdateTransformer($parser, $selectTransformer),
+            new DeleteTransformer($parser, $selectTransformer),
+        );
+        $tables = ['users' => [
+            'rows' => [],
+            'columns' => ['id', 'name'],
+            'columnTypes' => [],
+            'identityStrategies' => ['id' => IdentityGenerationStrategy::Sequence],
+        ]];
+
+        $first = $transformer->transform("INSERT INTO users (name) VALUES ('first')", $tables);
+        $transformer->commitRewriteState();
+        $second = $transformer->transform("INSERT INTO users (name) VALUES ('second')", $tables);
+
+        self::assertStringContainsString('1 AS "id"', $first);
+        self::assertStringContainsString('2 AS "id"', $second);
     }
 
     public function testTransformUnsupportedStatementThrows(): void

--- a/packages/ztd-query-postgres/tests/Unit/PgSqlUpsertExpressionParserTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/PgSqlUpsertExpressionParserTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Exception\UnsupportedSqlException;
 use ZtdQuery\Platform\Postgres\PgSqlUpsertExpressionParser;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
 
 #[CoversClass(PgSqlUpsertExpressionParser::class)]
 #[UsesClass(\ZtdQuery\Platform\Postgres\PgSqlLexerProfile::class)]
@@ -98,6 +100,14 @@ final class PgSqlUpsertExpressionParserTest extends TestCase
         $this->expectException(UnsupportedSqlException::class);
 
         (new PgSqlUpsertExpressionParser())->parse('EXCLUDED.`quantity`', 'items');
+    }
+
+    public function testIdentifierRejectsNonPostgresQuotedToken(): void
+    {
+        $method = new \ReflectionMethod(PgSqlUpsertExpressionParser::class, 'isIdentifier');
+        $token = new SqlToken(SqlTokenKind::QuotedIdentifier, '`quantity`', 0, 0, 0);
+
+        self::assertFalse($method->invoke(new PgSqlUpsertExpressionParser(), $token));
     }
 
     #[DataProvider('providerInvalidPostgresExpression')]

--- a/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-postgres/tests/Unit/Transformer/InsertTransformerTest.php
@@ -499,6 +499,7 @@ final class InsertTransformerTest extends TestCase
         ]];
 
         $transformer->transform("INSERT INTO users (id, name) VALUES (42, 'explicit')", $tables);
+        $transformer->commitRewriteState();
         $generated = $transformer->transform("INSERT INTO users (name) VALUES ('generated')", $tables);
 
         self::assertStringContainsString('1 AS "id"', $generated);

--- a/packages/ztd-query-sqlite/src/SqliteLexerProfile.php
+++ b/packages/ztd-query-sqlite/src/SqliteLexerProfile.php
@@ -27,6 +27,8 @@ final class SqliteLexerProfile
             identifierPartPattern: '/^[_A-Za-z0-9$\x80-\xFF]$/',
             bracketPair: ['[', ']'],
             nestingPair: ['(', ')'],
+            statementDelimiter: ';',
+            listDelimiter: ',',
             nestedBlockComments: false,
             backslashEscapedStrings: false,
         );

--- a/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
+++ b/packages/ztd-query-sqlite/src/SqliteSchemaParser.php
@@ -206,7 +206,7 @@ final class SqliteSchemaParser implements SchemaParser
         if ($opening === null) {
             return null;
         }
-        $closing = $stream->matchingClosingParenthesis($opening);
+        $closing = $stream->matchingClosingNestingToken($opening);
         if ($closing === null) {
             return null;
         }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteCteShadowComposerTest.php
@@ -147,6 +147,16 @@ final class SqliteCteShadowComposerTest extends TestCase
             $declared,
             $composer->compose($declared, ['Users' => 'Users AS (SELECT 2 AS id)']),
         );
+        self::assertStringContainsString(
+            'orders AS (SELECT 2 AS id)',
+            $composer->compose(
+                'WITH users AS (SELECT 1 AS id) SELECT * FROM users JOIN orders ON TRUE',
+                [
+                    'orders' => 'orders AS (SELECT 2 AS id)',
+                    'Users' => 'Users AS (SELECT 3 AS id)',
+                ],
+            ),
+        );
     }
 
     public function testHandlesAWithTokenWithoutFollowingHeaderTokens(): void

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteInMemoryAttachStatementTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteInMemoryAttachStatementTest.php
@@ -47,6 +47,7 @@ final class SqliteInMemoryAttachStatementTest extends TestCase
         yield 'database missing alias' => ["ATTACH DATABASE ':memory:' AS"];
         yield 'missing as' => ["ATTACH ':memory:' db2"];
         yield 'extra token' => ["ATTACH ':memory:' AS db2 extra"];
+        yield 'trailing closing parenthesis' => ["ATTACH ':memory:' AS db2 )"];
         yield 'string alias' => ["ATTACH ':memory:' AS 'db2'"];
         yield 'empty bracket alias' => ["ATTACH ':memory:' AS []"];
         yield 'unterminated bracket alias' => ["ATTACH ':memory:' AS [db2"];

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteIndexHintStripperTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteIndexHintStripperTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteIndexHintStripper;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
 
 #[CoversClass(SqliteIndexHintStripper::class)]
 #[UsesClass(\ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser::class)]
@@ -111,5 +113,16 @@ final class SqliteIndexHintStripperTest extends TestCase
                 ['products'],
             ),
         );
+    }
+
+    public function testIdentifierEndAcceptsBracketSymbolTokens(): void
+    {
+        $method = new \ReflectionMethod(SqliteIndexHintStripper::class, 'identifierEndIndex');
+        $tokens = [
+            new SqlToken(SqlTokenKind::Symbol, '[', 0, 0, 0),
+            new SqlToken(SqlTokenKind::Symbol, ']', 1, 0, 0),
+        ];
+
+        self::assertSame(2, $method->invoke(null, $tokens, 0));
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/SqliteSelectRelationParserTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/SqliteSelectRelationParserTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use ZtdQuery\Platform\Sqlite\SqliteLexerProfile;
 use ZtdQuery\Platform\Sqlite\SqliteSelectRelationParser;
+use ZtdQuery\Sql\SqlToken;
+use ZtdQuery\Sql\SqlTokenKind;
 
 #[CoversClass(SqliteSelectRelationParser::class)]
 #[UsesClass(SqliteLexerProfile::class)]
@@ -218,5 +220,13 @@ final class SqliteSelectRelationParserTest extends TestCase
         self::assertSame([], $parser->tableNames('SELECT * FROM [unterminated'));
         self::assertSame([], $parser->tableNames('SELECT * FROM + leaked ]'));
         self::assertSame([], $parser->tableNames("SELECT * FROM 'literal' leaked ]"));
+    }
+
+    public function testIdentifierComponentRejectsMismatchedTokenKind(): void
+    {
+        $method = new \ReflectionMethod(SqliteSelectRelationParser::class, 'identifierComponentAt');
+        $token = new SqlToken(SqlTokenKind::String, '"users"', 0, 0, 0);
+
+        self::assertNull($method->invoke(new SqliteSelectRelationParser(), [$token], 0));
     }
 }

--- a/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
+++ b/packages/ztd-query-sqlite/tests/Unit/Transformer/InsertTransformerTest.php
@@ -510,6 +510,7 @@ final class InsertTransformerTest extends TestCase
         ]];
 
         $transformer->transform("INSERT INTO users (id, name) VALUES (42, 'explicit')", $tables);
+        $transformer->commitRewriteState();
         $generated = $transformer->transform("INSERT INTO users (name) VALUES ('generated')", $tables);
 
         self::assertStringContainsString('1 AS "id"', $generated);


### PR DESCRIPTION
## What

Move punctuation into dialect profiles, generalize closing-token matching, and test nonstandard nesting and delimiters.

## Why

Core token helpers still hardcoded nesting, statement, and list delimiters.

## Verification

- Core full unit suite, affected MySQL and SQLite tests, all dialect lints, and Claude Code CLI final audit: CLEAN.
- Final stack: 7,188 unit tests and 16,469 assertions passed.

Stack: agent/issue-zero-66-mysql-session-sql-mode -> agent/issue-zero-67-profile-sql-punctuation